### PR TITLE
fix: use GH_PAT in Claude Code checkout so bot commits trigger CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ secrets.GH_PAT }}
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
## Summary

Closes #7 — when the Claude Code action pushed commits using `GITHUB_TOKEN`, GitHub suppressed the downstream `pull_request` event, so CI never triggered on those commits.

**The fix:** pass `token: ${{ secrets.GH_PAT }}` to the `actions/checkout` step. Commits pushed via a PAT are treated as user-initiated and correctly fire the CI workflow.

**One line changed in `claude.yml`:**
```yaml
- uses: actions/checkout@v6
  with:
    fetch-depth: 1
    token: ${{ secrets.GH_PAT }}   # ← added
```

## Prerequisites ⚠️

Before merging, add a **`GH_PAT` secret** to the repo:

1. GitHub → your profile → Settings → Developer settings → Personal access tokens → Generate new token
2. Scopes needed: `repo` (full)
3. GitHub → this repo → Settings → Secrets and variables → Actions → New repository secret
4. Name: `GH_PAT`, value: the token you just generated

Without this secret the Claude Code action will fail on checkout.

## Test Plan
- [ ] Add `GH_PAT` secret to the repo
- [ ] Trigger the Claude Code action on a PR (comment `@claude` with a small task)
- [ ] Verify CI runs automatically on the commit it pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)