### PR TITLE
feat: post CI failure summaries as PR comments and auto-tag @claude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
       - name: Run tests with coverage
         run: pytest tests/ --cov=app
 
+      - name: Post failure comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Backend Lint & Test failed\n\n[View full logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n@claude please investigate the backend CI failure and push a fix.`
+            })
+
   frontend-ci:
     name: Frontend Lint & Build
     runs-on: ubuntu-latest
@@ -84,6 +96,18 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Post failure comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Frontend Lint & Build failed\n\n[View full logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n@claude please investigate the frontend CI failure and push a fix.`
+            })
 
   # E2E (Playwright) tests are NOT run in CI automatically — they require a live
   # docker-compose stack. To run locally:
@@ -120,3 +144,15 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+      - name: Post failure comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Bot Lint & Test failed\n\n[View full logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n@claude please investigate the bot CI failure and push a fix.`
+            })


### PR DESCRIPTION
## Summary

Closes #13 — CI failures are now self-reporting. No more manual log sharing.

Each CI job (`Backend Lint & Test`, `Frontend Lint & Build`, `Bot Lint & Test`) has a new final step that:
1. Only runs `if: failure() && github.event_name == 'pull_request'`
2. Posts a comment on the PR with a direct link to the failing run
3. Tags `@claude` so the Claude Code bot picks it up and pushes a fix automatically

### Example comment posted on failure:
> ❌ **Backend Lint & Test failed**
>
> [View full logs](https://github.com/...)
>
> @claude please investigate the backend CI failure and push a fix.

## Behaviour

| Scenario | Comment posted? |
|---|---|
| CI fails on a PR | ✅ One comment per failing job |
| CI passes | ❌ No comment |
| CI fails on `workflow_dispatch` or `workflow_call` | ❌ No comment (no PR to comment on) |

## Test Plan
- [ ] Introduce a deliberate lint error on a branch, open a PR, verify a failure comment appears
- [ ] Verify `@claude` picks up the comment and pushes a fix
- [ ] Verify no spurious comments on passing runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)