### PR TITLE
fix: add pre-flight variable validation to deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,21 @@ jobs:
             context: ./bot
 
     steps:
+      - name: Validate required variables
+        run: |
+          missing=()
+          [[ -z "${{ vars.ACR_NAME }}" ]]          && missing+=("ACR_NAME")
+          [[ -z "${{ vars.ACR_LOGIN_SERVER }}" ]]  && missing+=("ACR_LOGIN_SERVER")
+          [[ -z "${{ vars.RESOURCE_GROUP }}" ]]    && missing+=("RESOURCE_GROUP")
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "❌ Missing required GitHub Actions environment variables:"
+            printf '   - %s\n' "${missing[@]}"
+            echo ""
+            echo "Set these under: GitHub → Settings → Environments → dev → Variables"
+            exit 1
+          fi
+          echo "✅ All required variables present"
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Refs #15 — adds a validation step at the top of `build-and-push` that checks all required GitHub Actions environment variables are set before any Azure CLI commands run.

**Before:** `az acr login --name` fails with a cryptic `expected one argument` error.

**After:**
```
❌ Missing required GitHub Actions environment variables:
   - ACR_NAME
   - ACR_LOGIN_SERVER

Set these under: GitHub → Settings → Environments → dev → Variables
```

## Variables checked

| Variable | Where used |
|---|---|
| `ACR_NAME` | `az acr login --name` |
| `ACR_LOGIN_SERVER` | Image tag prefix for all three services |
| `RESOURCE_GROUP` | All Azure Container Apps deploy steps |

## ⚠️ You still need to set the variables

This PR improves the error message but doesn't set the variables for you. Go to:

**GitHub → repo Settings → Environments → `dev` → Variables** and add:
- `ACR_NAME` — your ACR registry name (e.g. `siegewebacr`)
- `ACR_LOGIN_SERVER` — full login server (e.g. `siegewebacr.azurecr.io`)
- `RESOURCE_GROUP` — `siege-rg-dev`

Repeat for the **`prod`** environment with prod values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)