### PR TITLE
fix: add pull-requests write permission to ci.yml for failure comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ concurrency:
   group: ci-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# Least-privilege permissions. pull-requests: write is required for the
+# on-failure comment steps that tag @claude on failing PRs.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   backend-ci:
     name: Backend Lint & Test


### PR DESCRIPTION
## Summary

Closes #22 — the `actions/github-script` step that posts failure comments was rejected with `403 Resource not accessible by integration` because `ci.yml` had no `permissions` block, leaving `GITHUB_TOKEN` read-only.

**One file changed** (`ci.yml`), **one change** — added a workflow-level `permissions` block:

```yaml
permissions:
  contents: read        # explicit least-privilege
  pull-requests: write  # required to post PR comments
```

## Test Plan
- [ ] Introduce a deliberate lint error on a branch, open a PR, verify failure comment posts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)