### PR TITLE
fix: use GH_PAT for CI failure comments to trigger claude.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,6 +108,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -155,6 +157,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Adds `github-token: ${{ secrets.GH_PAT }}` to all three `actions/github-script` failure comment steps (backend, frontend, bot)
- `GITHUB_TOKEN` suppresses downstream workflow events by design; comments posted by it do not trigger `claude.yml`
- Using `GH_PAT` (a personal access token) closes the self-healing loop: CI failure → @claude comment on PR → `claude.yml` fires and investigates

Fixes #25

## Test plan
- [ ] Merge this PR
- [ ] Open a PR that causes a CI failure
- [ ] Confirm the failure comment appears on the PR
- [ ] Confirm `claude.yml` triggers in response to the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)