### PR TITLE
fix: add pull-requests: write permission to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,19 @@ on:
 # Emergency workflow_dispatch promotions each get a unique group (run_id) so
 # they are never cancelled by each other.
 
+# ── Permissions ────────────────────────────────────────────────────────────────
+#
+# pull-requests: write is required because the reusable ci.yml workflow
+# declares that permission (for its on-failure PR comment steps). GitHub
+# constrains a called workflow's permissions to the caller's grant, so
+# deploy.yml must include it even though the deploy pipeline itself never
+# writes to pull requests (the comment steps in ci.yml are gated on
+# github.event_name == 'pull_request' and will never fire here).
+
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: deploy-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.image_tag != '' && github.run_id || 'pipeline' }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Adds a `permissions` block to `deploy.yml` with `pull-requests: write`
- Fixes the workflow validation error: *"The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'"*

## Root cause
`deploy.yml` calls `ci.yml` via `workflow_call`. GitHub constrains the called workflow's permissions to whatever the caller grants. `ci.yml` declares `pull-requests: write` (for its on-failure @claude comment steps), but `deploy.yml` had no permissions block — so GitHub defaulted to `pull-requests: none` and rejected the workflow at load time.

The failure comment steps in `ci.yml` are gated on `github.event_name == 'pull_request'` and will never execute from the deploy pipeline, but GitHub validates the permission statically regardless.

## Test plan
- [x] Merge this PR
- [ ] Confirm the deploy workflow loads without the validation error on the next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)