### PR TITLE
fix: explicitly override DISCORD_BOT_API_URL in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,10 @@ services:
     build: ./backend
     env_file: .env
     environment:
+      # Override .env values with Docker-network hostnames.
+      # These must always point to sibling service names, not localhost.
       DATABASE_URL: postgresql+asyncpg://postgres:password@postgres:5432/siege
+      DISCORD_BOT_API_URL: http://bot:8001
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- Adds `DISCORD_BOT_API_URL: http://bot:8001` to the `backend` service's `environment` block in `docker-compose.yml`
- Mirrors the existing `DATABASE_URL` override pattern — .env values work for running outside Docker, but inside Docker containers need to use sibling service hostnames
- Without this, if `.env` contains `localhost:8001`, the backend resolves it to itself rather than the bot container, causing the bot API to show as "unavailable" on the System page

## Root cause
Inside Docker, `localhost` resolves to the container itself. The backend was reading `DISCORD_BOT_API_URL` from `.env` with no override, so any `.env` pointing to `localhost` would silently fail to reach the bot. The `/api/version` endpoint catches the exception and returns `bot_version: null`, which the System page renders as "unavailable".

## Note
If the bot shows unavailable in the **Azure** deployment, run `az containerapp logs show --name siege-web-bot-dev --resource-group siege-rg-dev --tail 50` to check for startup errors (missing Key Vault secrets, invalid Discord token, etc.) — the URL configuration in Bicep (`http://siege-web-bot-dev`) is correct for Container Apps internal DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)