### PR TITLE
fix: use python -m to run bot so app package resolves correctly

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 EXPOSE 8001
 
-CMD ["python", "app/main.py"]
+CMD ["python", "-m", "app.main"]


### PR DESCRIPTION
## Summary
- Changes `CMD ["python", "app/main.py"]` → `CMD ["python", "-m", "app.main"]` in `bot/Dockerfile`
- Fixes bot crashing immediately on startup with `No module named 'app'`

## Root cause
`python app/main.py` inserts the **script's directory** (`/app/app`) into `sys.path[0]`. When `app/main.py` then runs `from app.config import settings`, Python looks for an `app` package inside `/app/app/` — which doesn't exist, causing the crash.

`python -m app.main` inserts the **current working directory** (`/app`, set by `WORKDIR`) into `sys.path[0]`, so all `from app.X import ...` statements correctly resolve against `/app/app/`.

## Confirmed via logs
```
No module named 'app'
File "/app/app/main.py", line 9, in <module>
    from app.config import settings
```
The bot container was crash-looping, making it unreachable, which caused the backend's `_fetch_bot_version()` to time out and return `null` — displayed as "unavailable" on the System page.

## Version
Bot: patch bump `1.0.0` → `1.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)