### PR TITLE
fix: allow HTTP on internal ingress and install Playwright browsers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Install Playwright browser binaries.
+# pip install only brings in the Python package; the actual Chromium binary and
+# its system-level dependencies (fonts, shared libs) must be fetched separately.
+# --with-deps handles apt packages required on Debian slim images.
+RUN playwright install --with-deps chromium
+
 # Copy application code
 COPY . .
 

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -96,6 +96,7 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: false
         targetPort: 8000
         transport: 'http'
+        allowInsecure: true // Nginx proxies plain HTTP internally; without this Azure redirects to HTTPS (301), causing browsers to downgrade POST → GET → 405
       }
       registries: [
         {
@@ -247,6 +248,7 @@ resource botApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: false
         targetPort: 8001
         transport: 'http'
+        allowInsecure: true // Same as API: internal HTTP calls from siege-api must not be redirected to HTTPS
       }
       registries: [
         {


### PR DESCRIPTION
## Summary
- Sets `allowInsecure: true` on the API and bot Container Apps ingress (Bicep)
- Adds `RUN playwright install --with-deps chromium` to the backend Dockerfile

## Root causes

### 405 Method Not Allowed on "Post to Discord"
`allowInsecure: false` (the Azure default) causes Container Apps to redirect HTTP → HTTPS even on internal apps. When Nginx proxied `POST http://siege-web-api-dev/api/...`, Azure returned a `301` redirect. Nginx passed it to the browser; browsers convert POST → GET when following 301s. The backend received GET on a POST-only route → 405.

Confirmed from API logs:
```
GET /api/sieges/37/post-to-channel 405 0ms
```

Fix: `allowInsecure: true` disables the HTTP→HTTPS redirect for internal service-to-service calls. The frontend app is unchanged — it's external and should keep enforcing HTTPS.

### Image generation would also fail (Playwright)
The backend Dockerfile installs the `playwright` Python package but never runs `playwright install`. Without the browser binaries, any call to render HTML→PNG would fail with "Executable doesn't exist". The `--with-deps` flag also installs the OS-level libraries Chromium needs on Debian slim images.

Confirmed from API logs:
```
Playwright was just installed or updated.
Please run the following command to download new browsers:
playwright install
```

## Test plan
- [ ] Merge and let the deploy pipeline rebuild + redeploy dev
- [ ] Click "Post to Discord" on an active siege — should succeed (no 405)
- [ ] Click "Generate Images" — should return PNG previews (no Playwright error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)