### PR TITLE
feat: add infra deployment pipeline with approval gates

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -26,6 +26,10 @@ name: Infra CI
 #             Always runs (even on success) so reviewers can see the impact
 #             before merging.
 #
+# This workflow also supports workflow_call so it can be invoked directly from
+# deploy.yml on pushes to main, running the full gate sequence in parallel with
+# the application test suite before any image build or deployment proceeds.
+#
 # ──────────────────────────────────────────────────────────────────────────────
 
 on:
@@ -36,6 +40,7 @@ on:
       - 'infra/**'
       - '.github/workflows/infra-ci.yml'
   workflow_dispatch:
+  workflow_call:
 
 # Cancel any in-progress infra-ci run for the same branch when a new commit is
 # pushed. group uses head_ref (PR source branch) for pull_request events so each


### PR DESCRIPTION
## Summary

- Restores missing `workflow_call` trigger on `infra-ci.yml` (lost in a merge conflict from main)
- Adds `infra-deploy.yml` — a dedicated, manual infra deployment pipeline
- Removes the redundant `run-infra-ci` job from `deploy.yml`

## New workflow: `infra-deploy.yml`

Triggered manually via `workflow_dispatch` — infra changes are intentional, never automatic.

**Flow:**
```
workflow_dispatch (choose: dev | prod)
    → Infra CI Gates (lint → build → ARM validate → what-if)
    → [GitHub Environment approval]
    → az deployment group create
```

- All 4 infra CI gates must pass before deployment starts
- Each environment requires a GitHub Environment approval (configure Required Reviewers in Settings → Environments → dev/prod)
- `cancel-in-progress: false` — never interrupts a deployment mid-flight

## New secrets required (add to both `dev` and `prod` environments)

| Secret | Description |
|---|---|
| `POSTGRES_ADMIN_PASSWORD` | DB admin password |
| `DISCORD_TOKEN` | Discord bot token |
| `BOT_API_KEY` | Shared backend↔bot API key (used for both `discordBotApiKey` and `botApiKey` params) |

| Variable | Description |
|---|---|
| `DISCORD_GUILD_ID` | Discord server ID |

## Test plan

- [ ] Add secrets/variables to `dev` and `prod` environments in GitHub
- [ ] Merge this PR
- [ ] Go to **Actions → Infra Deploy → Run workflow** → select `dev` → approve → confirm `az deployment group create` succeeds
- [ ] Confirm `deploy.yml` no longer has a `run-infra-ci` job on next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)