### PR TITLE
fix: remove Member Role column from reserves image (#35)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,11 @@
 - [x] Fix 22 failing Playwright E2E tests (Date.now() uniqueness, strict-mode selector violations, member bucket selector, row-count race)
 - [x] Fix three Azure Container Apps health check failures (KV role assignments, nginx envsubst variable bleed, ACR name mismatch)
 - [x] Write Vitest component tests: BoardPage (position cell states, context menu actions, member bucket) and notification polling (SiegeSettingsPage)
+- [x] Fix issue #37: capture Discord CDN URLs and post image links to clan-siege-assignments (PR #41)
+- [ ] Fix issue #35: remove Member Role column from reserves image
+  - [ ] Remove `<th>Role</th>` header and role `<td>` cell from `_build_reserves_html`
+  - [ ] Remove unused `_ROLE_ABBREV` dict
+  - [ ] Update tests in `test_image_gen.py`
 - [x] Author Bicep IaC for production environment
   - [x] New `infra/modules/app-insights.bicep` (workspace-based Application Insights)
   - [x] Updated `infra/modules/log-analytics.bicep` (retentionInDays param + resourceId output)

--- a/backend/app/services/image_gen.py
+++ b/backend/app/services/image_gen.py
@@ -30,13 +30,6 @@ _BUILDING_COLORS: dict[BuildingType, str] = {
     BuildingType.post: "#dc2626",
 }
 
-_ROLE_ABBREV: dict[MemberRole, str] = {
-    MemberRole.heavy_hitter: "HH",
-    MemberRole.advanced: "ADV",
-    MemberRole.medium: "MED",
-    MemberRole.novice: "NOV",
-}
-
 _BUILDING_LABELS: dict[BuildingType, str] = {
     BuildingType.stronghold: "Stronghold",
     BuildingType.mana_shrine: "Mana Shrine",
@@ -152,12 +145,10 @@ def _build_reserves_html(members: list[SiegeMemberWithName], siege_date: str) ->
         reserve_label = (
             "Yes" if m.has_reserve_set else ("No" if m.has_reserve_set is False else "—")
         )
-        role_abbrev = _ROLE_ABBREV.get(m.role, str(m.role))
 
         rows_html += f"""
         <tr>
             <td style="padding:4px 8px;border:1px solid #374151;">{m.name}</td>
-            <td style="padding:4px 8px;border:1px solid #374151;color:#9ca3af;">{role_abbrev}</td>
             <td style="padding:4px 8px;border:1px solid #374151;{day_style}">{day_label}</td>
             <td style="padding:4px 8px;border:1px solid #374151;color:#9ca3af;">{reserve_label}</td>
         </tr>"""
@@ -207,7 +198,6 @@ def _build_reserves_html(members: list[SiegeMemberWithName], siege_date: str) ->
     <thead>
       <tr>
         <th>Name</th>
-        <th>Role</th>
         <th>Attack Day</th>
         <th>Has Reserve Set</th>
       </tr>

--- a/backend/tests/test_image_gen.py
+++ b/backend/tests/test_image_gen.py
@@ -154,7 +154,6 @@ def test_build_reserves_html_contains_member():
     members = [_make_member(name="Bob", attack_day=1)]
     html = _build_reserves_html(members, "2026-03-20")
     assert "Bob" in html
-    assert "ADV" in html
 
 
 def test_build_reserves_html_day1_color():
@@ -169,20 +168,18 @@ def test_build_reserves_html_day2_color():
     assert "#fb923c" in html  # orange for day 2
 
 
-def test_build_reserves_html_role_abbreviations():
-    from app.models.enums import MemberRole
-
+def test_build_reserves_html_no_role_column():
+    """Role column must not appear in the rendered HTML."""
     members = [
-        _make_member(name="HH", role=MemberRole.heavy_hitter),
-        _make_member(name="ADV", role=MemberRole.advanced),
-        _make_member(name="MED", role=MemberRole.medium),
-        _make_member(name="NOV", role=MemberRole.novice),
+        _make_member(name="Alice", role=MemberRole.heavy_hitter),
+        _make_member(name="Bob", role=MemberRole.advanced),
     ]
     html = _build_reserves_html(members, "2026-03-20")
-    assert "HH" in html
-    assert "ADV" in html
-    assert "MED" in html
-    assert "NOV" in html
+    assert "Role" not in html
+    assert "HH" not in html
+    assert "ADV" not in html
+    assert "MED" not in html
+    assert "NOV" not in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed the **Role** column (`<th>Role</th>` header + `<td>` cell per row) from `_build_reserves_html`
- Removed the now-dead `_ROLE_ABBREV` dict
- Reserves image table is now 3 columns: **Name**, **Attack Day**, **Has Reserve Set**

## Test plan
- [x] `test_build_reserves_html_no_role_column` asserts `"Role"`, `"HH"`, `"ADV"`, `"MED"`, `"NOV"` are absent from the HTML
- [x] `test_build_reserves_html_contains_member` updated to no longer assert role abbreviation is present
- [x] All 118 backend tests pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)