### PR TITLE
fix: correct building-type color mapping (#43)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,10 @@
   - [x] Add a group label row before each group's positions in `_build_assignments_html`
   - [x] Visual distinction for group headers (background color, label text)
   - [x] Update/add tests in `test_image_gen.py`
+- [x] Fix building-type color mapping (#43)
+  - [x] Update `BUILDING_COLORS` in `BoardPage.tsx` to match spec (SH=red, MT=blue, DT=green, MS=gold, Post=white)
+  - [x] Update `_BUILDING_COLORS` in `image_gen.py` to match
+  - [x] Update `test_build_assignments_html_all_building_types_colored` with new hex values
 - [x] Add favicon for browser tab (#38)
   - [x] Create SVG favicon with siege/shield motif
   - [x] Place favicon in `frontend/public/`

--- a/backend/app/services/image_gen.py
+++ b/backend/app/services/image_gen.py
@@ -23,11 +23,11 @@ class SiegeMemberWithName:
 # ---------------------------------------------------------------------------
 
 _BUILDING_COLORS: dict[BuildingType, str] = {
-    BuildingType.stronghold: "#7c3aed",
-    BuildingType.mana_shrine: "#2563eb",
-    BuildingType.magic_tower: "#d97706",
+    BuildingType.stronghold: "#dc2626",
+    BuildingType.mana_shrine: "#d97706",
+    BuildingType.magic_tower: "#2563eb",
     BuildingType.defense_tower: "#16a34a",
-    BuildingType.post: "#dc2626",
+    BuildingType.post: "#64748b",
 }
 
 _BUILDING_LABELS: dict[BuildingType, str] = {

--- a/backend/tests/test_image_gen.py
+++ b/backend/tests/test_image_gen.py
@@ -132,11 +132,11 @@ def test_build_assignments_html_all_building_types_colored():
     board = BoardResponse.model_validate({"siege_id": 1, "buildings": buildings})
     html = _build_assignments_html(board, "2026-03-20")
     # All color codes should appear
-    assert "#7c3aed" in html  # stronghold
-    assert "#2563eb" in html  # mana_shrine
-    assert "#d97706" in html  # magic_tower
+    assert "#dc2626" in html  # stronghold
+    assert "#d97706" in html  # mana_shrine
+    assert "#2563eb" in html  # magic_tower
     assert "#16a34a" in html  # defense_tower
-    assert "#dc2626" in html  # post
+    assert "#64748b" in html  # post
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -58,25 +58,25 @@ type BuildingColorClass = {
 
 const BUILDING_COLORS: Record<BuildingType, BuildingColorClass> = {
   stronghold: {
-    header: 'bg-violet-600',
-    headerText: 'text-violet-700',
-    border: 'border-violet-200',
-    bg: 'bg-violet-50',
-    sectionHeader: 'bg-violet-50 border-violet-200 text-violet-800',
+    header: 'bg-red-600',
+    headerText: 'text-red-700',
+    border: 'border-red-200',
+    bg: 'bg-red-50',
+    sectionHeader: 'bg-red-50 border-red-200 text-red-800',
   },
   mana_shrine: {
+    header: 'bg-amber-500',
+    headerText: 'text-amber-700',
+    border: 'border-amber-200',
+    bg: 'bg-amber-50',
+    sectionHeader: 'bg-amber-50 border-amber-200 text-amber-800',
+  },
+  magic_tower: {
     header: 'bg-blue-600',
     headerText: 'text-blue-700',
     border: 'border-blue-200',
     bg: 'bg-blue-50',
     sectionHeader: 'bg-blue-50 border-blue-200 text-blue-800',
-  },
-  magic_tower: {
-    header: 'bg-orange-600',
-    headerText: 'text-orange-700',
-    border: 'border-orange-200',
-    bg: 'bg-orange-50',
-    sectionHeader: 'bg-orange-50 border-orange-200 text-orange-800',
   },
   defense_tower: {
     header: 'bg-green-600',
@@ -86,11 +86,11 @@ const BUILDING_COLORS: Record<BuildingType, BuildingColorClass> = {
     sectionHeader: 'bg-green-50 border-green-200 text-green-800',
   },
   post: {
-    header: 'bg-red-600',
-    headerText: 'text-red-700',
-    border: 'border-red-200',
-    bg: 'bg-red-50',
-    sectionHeader: 'bg-red-50 border-red-200 text-red-800',
+    header: 'bg-slate-500',
+    headerText: 'text-slate-700',
+    border: 'border-slate-200',
+    bg: 'bg-slate-50',
+    sectionHeader: 'bg-slate-50 border-slate-200 text-slate-800',
   },
 };
 


### PR DESCRIPTION
## Summary

- Fixes the color-to-building-type mapping so each building type gets its canonical color throughout the UI and generated Discord image
- `BUILDING_COLORS` in `BoardPage.tsx` and `_BUILDING_COLORS` in `image_gen.py` now both follow the same scheme:

| Building Type | Color |
|---|---|
| Stronghold | Red |
| Magic Tower | Blue |
| Defense Tower | Green |
| Mana Shrine | Amber / Gold |
| Post | Slate (neutral — white-on-white is invisible in the image) |

- Updated `test_build_assignments_html_all_building_types_colored` hex assertions to match

## Test plan

- [x] All 15 `test_image_gen.py` tests pass
- [x] Board UI visually shows correct colors per building type

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)