### PR TITLE
fix: promote Rule 13 to error for all siege members missing attack day (#53)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,10 @@
   - [x] Create SVG favicon with siege/shield motif
   - [x] Place favicon in `frontend/public/`
   - [x] Add `<link>` tags in `frontend/index.html` (svg + png fallback sizes)
+- [x] Fix #53: missing attack day is a validation error for all siege members
+  - [x] Promote Rule 13 from warning → error in `validation.py`
+  - [x] Expand scope from assigned members → all siege members
+  - [x] Update/add tests in `test_validation.py`
 - [x] Author Bicep IaC for production environment
   - [x] New `infra/modules/app-insights.bicep` (workspace-based Application Insights)
   - [x] Updated `infra/modules/log-analytics.bicep` (retentionInDays param + resourceId output)

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -277,17 +277,15 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                     )
                 )
 
-    # Rule 13: Assigned members with no attack day set
-    assigned_member_ids = set(assignments_by_member.keys())
-    for member_id in assigned_member_ids:
-        sm = sm_by_member.get(member_id)
-        name = sm.member.name if sm and sm.member else "Unknown"
-        if sm is None or sm.attack_day is None:
-            warnings.append(
+    # Rule 13: Any siege member with no attack day set
+    for sm in siege.siege_members:
+        if sm.attack_day is None:
+            name = sm.member.name if sm.member else "Unknown"
+            errors.append(
                 ValidationIssue(
                     rule=13,
-                    message=f"Member '{name}' is assigned to positions but has no attack_day set",
-                    context={"member_id": member_id},
+                    message=f"Member '{name}' has no attack day assigned",
+                    context={"member_id": sm.member_id},
                 )
             )
 
@@ -303,6 +301,7 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
         )
 
     # Rule 15: Assigned members with has_reserve_set = NULL
+    assigned_member_ids = set(assignments_by_member.keys())
     for member_id in assigned_member_ids:
         sm = sm_by_member.get(member_id)
         name = sm.member.name if sm and sm.member else "Unknown"

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -632,8 +632,8 @@ async def test_rule11_no_warning_when_no_preferences():
 
 
 @pytest.mark.asyncio
-async def test_rule13_missing_attack_day():
-    """Rule 13: assigned member with no attack_day → warning."""
+async def test_rule13_missing_attack_day_assigned_member():
+    """Rule 13: assigned member with no attack_day → error."""
     member = _make_member(id=1, is_active=True)
     pos = _make_position(id=1, member_id=1, member=member)
     group = _make_group(id=1)
@@ -647,13 +647,29 @@ async def test_rule13_missing_attack_day():
 
     session = _session_with_siege_and_configs(siege)
     result = await svc_validate(session, 1)
-    rule13_warnings = [w for w in result.warnings if w.rule == 13]
-    assert len(rule13_warnings) >= 1
+    rule13_errors = [e for e in result.errors if e.rule == 13]
+    assert len(rule13_errors) >= 1
+
+
+@pytest.mark.asyncio
+async def test_rule13_missing_attack_day_unassigned_member():
+    """Rule 13: siege member not assigned to any position but has no attack_day → error."""
+    member = _make_member(id=1, is_active=True)
+    # No positions reference this member — they are on the roster but unassigned
+    siege = _make_siege(defense_scroll_count=5)
+    siege.buildings = []
+    sm = _make_siege_member(member_id=1, attack_day=None, has_reserve_set=True, member=member)
+    siege.siege_members = [sm]
+
+    session = _session_with_siege_and_configs(siege)
+    result = await svc_validate(session, 1)
+    rule13_errors = [e for e in result.errors if e.rule == 13]
+    assert len(rule13_errors) >= 1
 
 
 @pytest.mark.asyncio
 async def test_rule13_attack_day_set():
-    """Rule 13 pass: assigned member has attack_day set."""
+    """Rule 13 pass: all siege members have attack_day set → no rule 13 error."""
     member = _make_member(id=1, is_active=True)
     pos = _make_position(id=1, member_id=1, member=member)
     group = _make_group(id=1)
@@ -667,8 +683,8 @@ async def test_rule13_attack_day_set():
 
     session = _session_with_siege_and_configs(siege)
     result = await svc_validate(session, 1)
-    rule13_warnings = [w for w in result.warnings if w.rule == 13]
-    assert len(rule13_warnings) == 0
+    rule13_errors = [e for e in result.errors if e.rule == 13]
+    assert len(rule13_errors) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Rule 13 previously appended to `warnings` and only iterated assigned member IDs — roster members never placed in a position were silently skipped
- Now iterates all `siege.siege_members` and appends to `errors`, blocking the siege from proceeding with incomplete data
- Attack day is required by the attack-day split algorithm, image generation (reserves grouped by day), and planned Discord notifications

## Test plan
- [x] `pytest backend/tests/test_validation.py` — all 34 tests pass
- [ ] Assigned member with no attack_day → Rule 13 appears in `errors` (not `warnings`)
- [x] Unassigned roster member with no attack_day → Rule 13 error still fires
- [x] All members have attack_day set → no Rule 13 entry in errors

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)