### PR TITLE
fix: block notifications on validation errors and fix batch stuck pending (#59 #60)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,14 @@
   - [x] Add a group label row before each group's positions in `_build_assignments_html`
   - [x] Visual distinction for group headers (background color, label text)
   - [x] Update/add tests in `test_image_gen.py`
+- [x] Fix #59: block notifications when siege has validation errors
+  - [x] Add validate_siege guard in notify_siege_members endpoint
+  - [x] Disable notify button on frontend when errors present
+  - [x] Add/update tests in test_notifications.py
+- [x] Fix #60: notification batch status stuck at pending
+  - [x] Wrap _send_dms in try/finally to guarantee status update
+  - [x] Fix batchDone vacuous-truth bug for empty results arrays
+  - [x] Add/update tests in test_notifications.py
 - [x] Fix building-type color mapping (#43)
   - [x] Update `BUILDING_COLORS` in `BoardPage.tsx` to match spec (SH=red, MT=blue, DT=green, MS=gold, Post=white)
   - [x] Update `_BUILDING_COLORS` in `image_gen.py` to match

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -19,6 +19,7 @@ from app.services import image_gen
 from app.services.bot_client import bot_client
 from app.services.image_gen import SiegeMemberWithName
 from app.services.sieges import get_siege
+from app.services.validation import validate_siege
 
 router = APIRouter(tags=["notifications"])
 
@@ -58,45 +59,58 @@ class NotificationBatchResponse(BaseModel):
 async def _send_dms(batch_id: int, members_data: list[dict]) -> None:
     """Send DMs for each member and record results in a fresh DB session."""
     async with AsyncSessionLocal() as session:
-        for item in members_data:
-            member_id = item["member_id"]
-            discord_username = item["discord_username"]
-            message = item["message"]
+        try:
+            for item in members_data:
+                member_id = item["member_id"]
+                discord_username = item["discord_username"]
+                message = item["message"]
 
-            success = False
-            error_text: str | None = None
-            sent_at: datetime | None = None
+                success = False
+                error_text: str | None = None
+                sent_at: datetime | None = None
 
-            if discord_username:
-                ok = await bot_client.notify(discord_username, message)
-                success = ok
-                if not ok:
-                    error_text = "Bot failed to deliver message"
+                if discord_username:
+                    ok = await bot_client.notify(discord_username, message)
+                    success = ok
+                    if not ok:
+                        error_text = "Bot failed to deliver message"
+                    else:
+                        sent_at = datetime.now(UTC)
                 else:
-                    sent_at = datetime.now(UTC)
-            else:
-                error_text = "No discord_username set for member"
+                    error_text = "No discord_username set for member"
 
-            result_row = await session.execute(
-                select(NotificationBatchResult).where(
-                    NotificationBatchResult.batch_id == batch_id,
-                    NotificationBatchResult.member_id == member_id,
+                result_row = await session.execute(
+                    select(NotificationBatchResult).where(
+                        NotificationBatchResult.batch_id == batch_id,
+                        NotificationBatchResult.member_id == member_id,
+                    )
                 )
+                result = result_row.scalar_one_or_none()
+                if result is not None:
+                    result.success = success
+                    result.error = error_text
+                    result.sent_at = sent_at
+
+            batch_row = await session.execute(
+                select(NotificationBatch).where(NotificationBatch.id == batch_id)
             )
-            result = result_row.scalar_one_or_none()
-            if result is not None:
-                result.success = success
-                result.error = error_text
-                result.sent_at = sent_at
+            batch = batch_row.scalar_one_or_none()
+            if batch is not None:
+                batch.status = NotificationBatchStatus.completed
 
-        batch_row = await session.execute(
-            select(NotificationBatch).where(NotificationBatch.id == batch_id)
-        )
-        batch = batch_row.scalar_one_or_none()
-        if batch is not None:
-            batch.status = NotificationBatchStatus.completed
-
-        await session.commit()
+            await session.commit()
+        except Exception:
+            # Guarantee the batch is marked completed even if a mid-loop exception
+            # occurs. BackgroundTasks swallow exceptions silently, so without this
+            # the batch would remain "pending" forever.
+            batch_row = await session.execute(
+                select(NotificationBatch).where(NotificationBatch.id == batch_id)
+            )
+            batch = batch_row.scalar_one_or_none()
+            if batch is not None and batch.status == NotificationBatchStatus.pending:
+                batch.status = NotificationBatchStatus.completed
+            await session.commit()
+            raise
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +128,16 @@ async def notify_siege_members(
     siege = await get_siege(db, siege_id)
     if siege.status == SiegeStatus.complete:
         raise HTTPException(status_code=400, detail="Cannot notify for a completed siege")
+
+    validation = await validate_siege(db, siege_id)
+    if validation.errors:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot notify: siege has {len(validation.errors)} validation error(s). "
+                "Resolve all errors before sending notifications."
+            ),
+        )
 
     # Load siege members with member data
     result = await db.execute(

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -176,23 +176,30 @@ async def test_notify_returns_batch_id(client):
 
     app.dependency_overrides[get_db] = fake_get_db
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            return_value=[{"username": "alice#0001"}],
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                instance = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                instance.status = NotificationBatchStatus.pending
-                instance.id = 10
-                MockBatch.return_value = instance
-                with patch("app.api.notifications.NotificationBatchResult"):
-                    with patch("app.api.notifications._send_dms"):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                return_value=[{"username": "alice#0001"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    instance = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    instance.status = NotificationBatchStatus.pending
+                    instance.id = 10
+                    MockBatch.return_value = instance
+                    with patch("app.api.notifications.NotificationBatchResult"):
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -571,20 +578,27 @@ async def test_notify_skips_member_with_no_discord_username(client):
 
     app.dependency_overrides[get_db] = fake_get_db
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            return_value=[{"username": "someoneelse"}],
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                MockBatch.return_value = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                with patch("app.api.notifications.NotificationBatchResult") as MockResult:
-                    with patch("app.api.notifications._send_dms"):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                return_value=[{"username": "someoneelse"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult") as MockResult:
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -623,21 +637,28 @@ async def test_notify_skips_member_not_in_guild(client):
 
     app.dependency_overrides[get_db] = fake_get_db
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            # Guild has alice but NOT bob
-            return_value=[{"username": "alice#0001"}],
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                MockBatch.return_value = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                with patch("app.api.notifications.NotificationBatchResult") as MockResult:
-                    with patch("app.api.notifications._send_dms"):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                # Guild has alice but NOT bob
+                return_value=[{"username": "alice#0001"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult") as MockResult:
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -680,20 +701,27 @@ async def test_notify_eligible_member_gets_result_row_and_dm(client):
     async def fake_send_dms(batch_id, members_data):
         captured_members_data.extend(members_data)
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            return_value=[{"username": "alice#0001"}],
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                MockBatch.return_value = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                with patch("app.api.notifications.NotificationBatchResult") as MockResult:
-                    with patch("app.api.notifications._send_dms", side_effect=fake_send_dms):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                return_value=[{"username": "alice#0001"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult") as MockResult:
+                        with patch("app.api.notifications._send_dms", side_effect=fake_send_dms):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -740,21 +768,28 @@ async def test_notify_skipped_count_reflects_all_skipped_members(client):
 
     app.dependency_overrides[get_db] = fake_get_db
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            # Only alice is in the guild
-            return_value=[{"username": "alice#0001"}],
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                MockBatch.return_value = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                with patch("app.api.notifications.NotificationBatchResult"):
-                    with patch("app.api.notifications._send_dms"):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                # Only alice is in the guild
+                return_value=[{"username": "alice#0001"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult"):
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -764,7 +799,109 @@ async def test_notify_skipped_count_reflects_all_skipped_members(client):
 
 
 # ---------------------------------------------------------------------------
-# 13. notify — bot unreachable (get_members returns []) falls back to
+# 13. notify — 400 when siege has validation errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_blocked_when_siege_has_validation_errors(client):
+    """POST /notify must return 400 when validate_siege returns errors."""
+    from app.schemas.validation import ValidationIssue, ValidationResult
+
+    siege = _make_siege()
+
+    from app.db.session import get_db
+
+    async def fake_get_db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_db] = fake_get_db
+
+    validation_with_errors = ValidationResult(
+        errors=[
+            ValidationIssue(
+                rule=13,
+                message="Member 'Alice' has no attack day assigned",
+                context={"member_id": 1},
+            )
+        ],
+        warnings=[],
+    )
+
+    with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
+        with patch(
+            "app.api.notifications.validate_siege",
+            new_callable=AsyncMock,
+            return_value=validation_with_errors,
+        ):
+            async with client as c:
+                response = await c.post("/api/sieges/1/notify")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "validation error" in detail.lower()
+    assert "1" in detail
+
+
+# ---------------------------------------------------------------------------
+# 14. notify — passes validation guard when siege has no errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_passes_validation_guard_when_no_errors(client):
+    """POST /notify must not be blocked when validate_siege returns no errors."""
+    from app.schemas.validation import ValidationResult
+
+    siege = _make_siege()
+    sm = _make_siege_member()
+
+    mock_session = MagicMock()
+    sm_result = MagicMock()
+    sm_result.scalars.return_value.all.return_value = [sm]
+    mock_session.execute = AsyncMock(return_value=sm_result)
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def fake_get_db():
+        yield mock_session
+
+    from app.db.session import get_db
+
+    app.dependency_overrides[get_db] = fake_get_db
+
+    clean_validation = ValidationResult(errors=[], warnings=[])
+
+    with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
+        with patch(
+            "app.api.notifications.validate_siege",
+            new_callable=AsyncMock,
+            return_value=clean_validation,
+        ):
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                return_value=[{"username": "alice#0001"}],
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult"):
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 200
+    data = response.json()
+    assert "batch_id" in data
+
+
+# ---------------------------------------------------------------------------
+# 15. notify — bot unreachable (get_members returns []) falls back to
 #     discord_username filter only
 # ---------------------------------------------------------------------------
 
@@ -799,20 +936,27 @@ async def test_notify_bot_unreachable_falls_back_to_username_filter(client):
 
     app.dependency_overrides[get_db] = fake_get_db
 
+    from app.schemas.validation import ValidationResult
+
     with patch("app.api.notifications.get_siege", new_callable=AsyncMock, return_value=siege):
         with patch(
-            "app.api.notifications.bot_client.get_members",
+            "app.api.notifications.validate_siege",
             new_callable=AsyncMock,
-            return_value=[],  # bot unreachable
+            return_value=ValidationResult(errors=[], warnings=[]),
         ):
-            with patch("app.api.notifications.NotificationBatch") as MockBatch:
-                MockBatch.return_value = SimpleNamespace(
-                    id=10, siege_id=1, status=NotificationBatchStatus.pending
-                )
-                with patch("app.api.notifications.NotificationBatchResult") as MockResult:
-                    with patch("app.api.notifications._send_dms"):
-                        async with client as c:
-                            response = await c.post("/api/sieges/1/notify")
+            with patch(
+                "app.api.notifications.bot_client.get_members",
+                new_callable=AsyncMock,
+                return_value=[],  # bot unreachable
+            ):
+                with patch("app.api.notifications.NotificationBatch") as MockBatch:
+                    MockBatch.return_value = SimpleNamespace(
+                        id=10, siege_id=1, status=NotificationBatchStatus.pending
+                    )
+                    with patch("app.api.notifications.NotificationBatchResult") as MockResult:
+                        with patch("app.api.notifications._send_dms"):
+                            async with client as c:
+                                response = await c.post("/api/sieges/1/notify")
 
     app.dependency_overrides.clear()
     assert response.status_code == 200
@@ -822,3 +966,65 @@ async def test_notify_bot_unreachable_falls_back_to_username_filter(client):
     assert data["member_count"] == 1
     # member with no username is still skipped
     assert data["skipped_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 16. _send_dms — batch status is set to completed even when bot raises mid-loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_dms_sets_completed_status_even_when_bot_raises():
+    """_send_dms must guarantee batch.status = completed in its finally block.
+
+    Scenario: two members; bot raises on the first notify call. The batch
+    must still be committed as completed so the frontend polling terminates.
+    """
+    from app.api.notifications import _send_dms
+
+    batch = _make_batch(id=42, siege_id=1, status=NotificationBatchStatus.pending)
+    result_row = _make_batch_result(batch_id=42, member_id=1)
+
+    # Build a session that tracks mutations on the batch object.
+    call_count = 0
+    mock_session = MagicMock()
+
+    async def tracked_execute(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        stmt_str = str(stmt)
+        if "notification_batch_result" in stmt_str.lower():
+            result.scalar_one_or_none.return_value = result_row
+        else:
+            # notification_batch lookup (both in try and in except finally)
+            result.scalar_one_or_none.return_value = batch
+        return result
+
+    mock_session.execute = tracked_execute
+    mock_session.commit = AsyncMock()
+
+    # AsyncSessionLocal is used as an async context manager; patch it so it
+    # yields our controlled session instead of opening a real DB connection.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_session_local():
+        yield mock_session
+
+    members_data = [
+        {"member_id": 1, "discord_username": "alice#0001", "message": "test"},
+    ]
+
+    with patch("app.api.notifications.AsyncSessionLocal", fake_session_local):
+        with patch(
+            "app.api.notifications.bot_client.notify",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("bot exploded"),
+        ):
+            with pytest.raises(RuntimeError, match="bot exploded"):
+                await _send_dms(42, members_data)
+
+    # The except block must have committed the session with completed status.
+    assert mock_session.commit.called
+    assert batch.status == NotificationBatchStatus.completed

--- a/frontend/src/pages/SiegeSettingsPage.tsx
+++ b/frontend/src/pages/SiegeSettingsPage.tsx
@@ -94,7 +94,7 @@ export default function SiegeSettingsPage() {
 
   // Notification batch polling — runs until all results have success !== null or status === "completed"
   const batchDone = (results: NotificationResultItem[], status: string) =>
-    status === 'completed' || results.every((r) => r.success !== null);
+    status === 'completed' || (results.length > 0 && results.every((r) => r.success !== null));
 
   const { data: batchData } = useQuery({
     queryKey: ['notificationBatch', siegeId, notifyBatch?.batch_id],
@@ -346,7 +346,11 @@ export default function SiegeSettingsPage() {
             variant="outline"
             size="sm"
             onClick={() => setNotifyConfirmOpen(true)}
-            disabled={notifyMutation.isPending || siege?.status === 'complete'}
+            disabled={
+              notifyMutation.isPending ||
+              siege?.status === 'complete' ||
+              (validation !== null && validation.errors.length > 0)
+            }
           >
             {notifyMutation.isPending
               ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
@@ -376,6 +380,14 @@ export default function SiegeSettingsPage() {
             Generate Images
           </Button>
         </div>
+
+        {validation !== null && validation.errors.length > 0 && (
+          <p className="flex items-center gap-1.5 text-sm text-red-600">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            Notifications blocked: resolve {validation.errors.length} validation error
+            {validation.errors.length !== 1 ? 's' : ''} before notifying members.
+          </p>
+        )}
 
         {/* Results / status areas */}
         <div className="space-y-4">


### PR DESCRIPTION
## Summary

### #59 — Block notifications when siege has validation errors
- Added `validate_siege` call in `notify_siege_members` endpoint; returns 400 with a clear message if any hard errors are present (warnings don't block)
- Frontend: disables the Notify Members button and shows an explanation when the siege has validation errors

### #60 — Notification batch status stuck at pending
- Wrapped `_send_dms` body in `try/finally` so `batch.status` is always set to `completed` and committed, even if an exception occurs mid-send
- Fixed `batchDone` vacuous-truth bug: `[].every(...)` returned `true` immediately, stopping polling before the background task ran — now guards with `results.length > 0`

## Test plan
- [ ] `pytest backend/tests/test_notifications.py` — 16 tests pass (2 new for #59 guard, 1 new for #60 finally)
- [ ] Siege with errors → POST `/notify` returns 400
- [ ] Siege without errors → proceeds normally
- [ ] `_send_dms` with mid-loop bot exception → batch still transitions to `completed`
- [ ] Frontend: Notify button disabled when validation errors shown

Closes #59
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)