### PR TITLE
fix: eager validation on page load and surface notify 400 errors (#65)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,16 @@
   - [x] Add a group label row before each group's positions in `_build_assignments_html`
   - [x] Visual distinction for group headers (background color, label text)
   - [x] Update/add tests in `test_image_gen.py`
+- [x] Fix #65: notify button UX — eager validation gate and 400 error display
+  - [x] Auto-run validation on page load so button is gated correctly
+  - [x] Display 400 error detail from notifyMutation in the UI
+- [x] Fix #63: member name color uses Member Role, not Discord role color
+  - [x] Add _MEMBER_ROLE_COLORS constant to image_gen.py
+  - [x] Replace role_colors dict param with member_id_to_role in assignments image
+  - [x] Use m.role directly in reserves image
+  - [x] Remove bot.get_members() color fetch from images.py and notifications.py
+  - [x] Remove top_role_color from bot get_members()
+  - [x] Update tests
 - [x] Fix #59: block notifications when siege has validation errors
   - [x] Add validate_siege guard in notify_siege_members endpoint
   - [x] Disable notify button on frontend when errors present

--- a/frontend/src/pages/SiegeSettingsPage.tsx
+++ b/frontend/src/pages/SiegeSettingsPage.tsx
@@ -72,6 +72,7 @@ export default function SiegeSettingsPage() {
   const [notifyBatch, setNotifyBatch] = useState<NotifyResponse | null>(null);
   const [postChannelResult, setPostChannelResult] = useState<string | null>(null);
   const [postChannelError, setPostChannelError] = useState<string | null>(null);
+  const [notifyError, setNotifyError] = useState<string | null>(null);
   const [generatedImages, setGeneratedImages] = useState<{
     assignments_image: string;
     reserves_image: string;
@@ -112,6 +113,11 @@ export default function SiegeSettingsPage() {
       setDate(siege.date ?? '');
     }
   }, [siege]);
+
+  // Eagerly run validation on mount so the Notify button is correctly gated
+  // even if the user hasn't manually clicked "Validate" in this session.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { validateMutation.mutate(); }, [siegeId]);
 
   const updateMutation = useMutation({
     mutationFn: () =>
@@ -204,6 +210,13 @@ export default function SiegeSettingsPage() {
     mutationFn: () => notifySiegeMembers(siegeId),
     onSuccess: (data) => {
       setNotifyBatch(data);
+      setNotifyConfirmOpen(false);
+      setNotifyError(null);
+    },
+    onError: (err) => {
+      setNotifyError(
+        isAxiosError(err) ? (err.response?.data?.detail ?? 'Failed to send notifications.') : 'Failed to send notifications.',
+      );
       setNotifyConfirmOpen(false);
     },
   });
@@ -391,6 +404,13 @@ export default function SiegeSettingsPage() {
 
         {/* Results / status areas */}
         <div className="space-y-4">
+          {/* Notify error (e.g. 400 from validation guard) */}
+          {notifyError && (
+            <p className="flex items-center gap-1 text-sm text-red-600">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {notifyError}
+            </p>
+          )}
           {/* Notify Members batch results */}
           {notifyBatch && (
             <div className="rounded-md border border-slate-200 bg-slate-50 p-3">


### PR DESCRIPTION
## Summary
- **Eager validation gate**: adds a `useEffect` that calls `validateMutation.mutate()` on mount (keyed to `siegeId`), so the Notify Members button is correctly disabled based on validation state even before the user manually clicks Validate
- **Graceful 400 handling**: adds `onError` to `notifyMutation` — extracts `err.response?.data?.detail` and renders it inline with an `AlertCircle` icon above the batch results panel, matching the existing `postChannelError` display pattern

## Test plan
- [x] Navigate to a siege settings page with errors — Notify button should be disabled immediately without clicking Validate
- [x] Forcibly trigger the notify endpoint while errors exist → inline error message appears instead of silent failure
- [x] Navigate to a valid siege — Notify button enabled, works normally
- [x] On success, `notifyError` is cleared and batch panel appears as before

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)