### PR TITLE
fix: use isolated session in _send_dms finally block (#60)

### DIFF
--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -92,18 +92,21 @@ async def _send_dms(batch_id: int, members_data: list[dict]) -> None:
                     result.sent_at = sent_at
 
         finally:
-            # Always mark the batch completed, even if an exception occurs mid-loop.
-            # BackgroundTasks swallow exceptions silently, so try/except alone cannot
-            # guarantee completion — the except block itself may throw and leave the
-            # batch stuck in "pending". try/finally is unconditional and runs whether
-            # the try block succeeded or raised.
-            batch_row = await session.execute(
-                select(NotificationBatch).where(NotificationBatch.id == batch_id)
-            )
-            batch = batch_row.scalar_one_or_none()
-            if batch is not None:
-                batch.status = NotificationBatchStatus.completed
-            await session.commit()
+            # Always mark the batch completed via a FRESH, INDEPENDENT session.
+            # If the try block raised a SQLAlchemy-level error (e.g. a DB connection
+            # blip during session.execute), the original `session` enters a "needs
+            # rollback" state. Any subsequent operation on that same session raises
+            # PendingRollbackError, which BackgroundTasks swallows silently — leaving
+            # the batch stuck at "pending" forever. Opening a new AsyncSessionLocal()
+            # here is fully isolated from that error state and always succeeds.
+            async with AsyncSessionLocal() as status_session:
+                batch_row = await status_session.execute(
+                    select(NotificationBatch).where(NotificationBatch.id == batch_id)
+                )
+                batch = batch_row.scalar_one_or_none()
+                if batch is not None:
+                    batch.status = NotificationBatchStatus.completed
+                await status_session.commit()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The previous try/finally fix (#60) still left batches stuck at `pending` because it reused the **same `AsyncSession`** in the `finally` block
- If a SQLAlchemy-level error occurred in the `try` block (e.g. a DB connection blip), the session enters a "needs rollback" state — any subsequent `session.execute()` in `finally` raises `PendingRollbackError`, which `BackgroundTasks` swallows silently
- Fix: open a **fresh `AsyncSessionLocal()` context** (`status_session`) inside the `finally` block, fully isolated from any error state in the `try` block's session

## Test plan

- [ ] Trigger a notification batch normally — batch status should transition to `completed` and member rows should resolve to ✓ or ✗
- [ ] Simulate a DB error mid-loop (or kill the bot sidecar to force an error) — batch should still transition to `completed`, not stay at `pending`
- [ ] Verify polling stops once `status === 'completed'` is returned

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)