### PR TITLE
fix: commit batch status atomically with result rows (#80)

### DIFF
--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -63,6 +63,7 @@ class NotificationBatchResponse(BaseModel):
 
 async def _send_dms(batch_id: int, members_data: list[dict]) -> None:
     """Send DMs for each member and record results in a fresh DB session."""
+    batch_marked_complete = False
     async with AsyncSessionLocal() as session:
         try:
             for item in members_data:
@@ -96,24 +97,35 @@ async def _send_dms(batch_id: int, members_data: list[dict]) -> None:
                     result.error = error_text
                     result.sent_at = sent_at
 
+            # Mark the batch complete in the same transaction as the result rows.
+            # This ensures "completed" status only appears in the DB when result
+            # rows are also persisted — preventing a false "Status unknown" on the
+            # frontend when the commit itself was the failure point.
+            batch_row = await session.execute(
+                select(NotificationBatch).where(NotificationBatch.id == batch_id)
+            )
+            batch = batch_row.scalar_one_or_none()
+            if batch is not None:
+                batch.status = NotificationBatchStatus.completed
+
             await session.commit()
+            batch_marked_complete = True
 
         finally:
-            # Always mark the batch completed via a FRESH, INDEPENDENT session.
-            # If the try block raised a SQLAlchemy-level error (e.g. a DB connection
-            # blip during session.execute), the original `session` enters a "needs
-            # rollback" state. Any subsequent operation on that same session raises
-            # PendingRollbackError, which BackgroundTasks swallows silently — leaving
-            # the batch stuck at "pending" forever. Opening a new AsyncSessionLocal()
-            # here is fully isolated from that error state and always succeeds.
-            async with AsyncSessionLocal() as status_session:
-                batch_row = await status_session.execute(
-                    select(NotificationBatch).where(NotificationBatch.id == batch_id)
-                )
-                batch = batch_row.scalar_one_or_none()
-                if batch is not None:
-                    batch.status = NotificationBatchStatus.completed
-                await status_session.commit()
+            if not batch_marked_complete:
+                # The try block raised before commit completed — result rows may be
+                # null/partial. Use a fresh isolated session to mark the batch
+                # completed so the frontend doesn't get stuck on "pending" forever.
+                # The frontend will show "Status unknown" for null-success rows in
+                # this case, which is accurate: the DM may or may not have been sent.
+                async with AsyncSessionLocal() as status_session:
+                    batch_row = await status_session.execute(
+                        select(NotificationBatch).where(NotificationBatch.id == batch_id)
+                    )
+                    batch = batch_row.scalar_one_or_none()
+                    if batch is not None:
+                        batch.status = NotificationBatchStatus.completed
+                    await status_session.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/SiegeSettingsPage.tsx
+++ b/frontend/src/pages/SiegeSettingsPage.tsx
@@ -469,7 +469,7 @@ export default function SiegeSettingsPage() {
                         ? ` — ${item.error}`
                         : null}
                       {item.discord_username !== null && item.success === null && batchComplete
-                        ? ' — Notification failed'
+                        ? ' — Status unknown'
                         : null}
                     </span>
                   </li>

--- a/frontend/src/test/pages/SiegeSettingsPage.test.tsx
+++ b/frontend/src/test/pages/SiegeSettingsPage.test.tsx
@@ -446,11 +446,11 @@ describe('SiegeSettingsPage — notification batch panel', () => {
     const dialog = screen.getByRole('dialog');
     await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
 
-    await waitFor(() => expect(screen.getByText(/notification failed/i)).toBeInTheDocument(), {
+    await waitFor(() => expect(screen.getByText(/status unknown/i)).toBeInTheDocument(), {
       timeout: 5000,
     });
 
-    const memberRow = screen.getByText(/notification failed/i).closest('li')!;
+    const memberRow = screen.getByText(/status unknown/i).closest('li')!;
 
     // Must NOT show a spinning loader
     expect(memberRow.querySelector('.animate-spin')).toBeNull();


### PR DESCRIPTION
## Summary

- **Root cause**: `_send_dms` always ran `batch.status = completed` in the `finally` block unconditionally, even when `session.commit()` failed. This left result rows with `success = null` in the DB while the batch appeared completed. The frontend (post-PR #79) interpreted `batchComplete && success === null` as a failure and displayed "Notification failed" — even when DMs were actually sent.
- **Backend fix**: Move `batch.status = completed` into the `try` block so it commits atomically with the result rows in the same `session.commit()` call. The `finally` block is now guarded by a `batch_marked_complete` boolean flag and only runs as a safety net when the try block raises — using a fresh isolated session to prevent the batch getting stuck at `pending` forever.
- **Frontend fix**: Rename the label from `'Notification failed'` to `'Status unknown'` — when the commit fails, it is genuinely ambiguous whether DMs were sent, so "failed" was misleading.
- **Test fix**: Update the corresponding test assertion from `/notification failed/i` to `/status unknown/i`.

## Test plan

- [x] 183 backend tests pass (`pytest tests/` excluding health, which needs a live DB)
- [x] Frontend builds cleanly (`npm run build`)
- [x] Verify in staging: trigger a notification batch, confirm results appear correctly when commit succeeds (green checks / red X)
- [x] Verify in staging: simulate a commit failure and confirm batch shows "Status unknown" rather than "Notification failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)