### PR TITLE
chore: split .env.deploy into per-environment files

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,6 +1,10 @@
-# Copy to .env.deploy and fill in real values.
-# .env.deploy is gitignored — never commit real secrets.
+# Copy to .env.deploy.dev and .env.deploy.prod and fill in the values for each environment.
+# Both files are gitignored — never commit real secrets.
 # Used by bootstrap-images.ps1 to supply Bicep deploy parameters.
+#
+# Usage:
+#   .\bootstrap-images.ps1 -Env dev -EnvFile .env.deploy.dev
+#   .\bootstrap-images.ps1 -Env prod -EnvFile .env.deploy.prod
 
 PG_ADMIN_PASSWORD=
 DISCORD_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ coverage.xml
 
 # Azure
 .azure/
-.env.deploy
+.env.deploy.*
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ cd backend && black . && ruff check .
 cd frontend && npm run lint
 ```
 
+## Deploy Environments
+
+Secrets for Azure deployments are stored in per-environment files (both gitignored):
+
+| File | Purpose |
+|---|---|
+| `.env.deploy.dev` | Secrets for the dev Azure instance (`siege-web-dev` resource group) |
+| `.env.deploy.prod` | Secrets for the prod Azure instance (`siege-rg` resource group) |
+
+Copy `.env.deploy.example` to both files and fill in the values. At minimum, `DISCORD_GUILD_ID` must differ between environments.
+
+```powershell
+# Build and deploy to dev
+.\bootstrap-images.ps1 -Env dev -EnvFile .env.deploy.dev
+
+# Build and deploy to prod (default EnvFile, so -EnvFile is optional)
+.\bootstrap-images.ps1 -Env prod -EnvFile .env.deploy.prod
+.\bootstrap-images.ps1 -Env prod
+```
+
 ## Environment Variables
 
 Copy `.env.example` to `.env`. All variables are required for Docker Compose. For dev mode, the backend reads from `backend/.env`.

--- a/bootstrap-images.ps1
+++ b/bootstrap-images.ps1
@@ -1,25 +1,28 @@
 # Usage:
-#   .\bootstrap-images.ps1 -Env dev
-#   .\bootstrap-images.ps1 -Env prod
+#   .\bootstrap-images.ps1 -Env dev  [-EnvFile .env.deploy.dev]
+#   .\bootstrap-images.ps1 -Env prod [-EnvFile .env.deploy.prod]
 
 param(
     [Parameter(Mandatory = $true)]
-    [string]$Env
+    [string]$Env,
+
+    [Parameter(Mandatory = $false)]
+    [string]$EnvFile = '.env.deploy.prod'
 )
 
 $ErrorActionPreference = 'Stop'
 
 $SecretsLoaded = $false
-$EnvDeployPath = Join-Path $PSScriptRoot '.env.deploy'
+$EnvDeployPath = Join-Path $PSScriptRoot $EnvFile
 if (Test-Path $EnvDeployPath) {
     Get-Content $EnvDeployPath | Where-Object { $_ -notmatch '^\s*#' -and $_ -match '=' } | ForEach-Object {
         $parts = $_ -split '=', 2
         [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim())
     }
     $SecretsLoaded = $true
-    Write-Host '==> Loaded secrets from .env.deploy'
+    Write-Host "==> Loaded secrets from $EnvFile"
 } else {
-    Write-Host '    (no .env.deploy found — secrets must be set in the environment)' -ForegroundColor Yellow
+    Write-Host "    (no $EnvFile found - secrets must be set in the environment)" -ForegroundColor Yellow
 }
 
 $ImageTag = git -C $PSScriptRoot rev-parse --short HEAD
@@ -76,7 +79,7 @@ Write-Host ""
 Write-Host "==> All images pushed successfully."
 Write-Host ""
 if ($SecretsLoaded) {
-    Write-Host '==> Secrets loaded from .env.deploy' -ForegroundColor Green
+    Write-Host "==> Secrets loaded from $EnvFile" -ForegroundColor Green
 } else {
     Write-Host "    WARNING: Before running the deploy command below, set these environment variables" -ForegroundColor Yellow
     Write-Host "    or the deployment will proceed with blank secrets:" -ForegroundColor Yellow

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -57,3 +57,13 @@
 - [x] Frontend: change "Notification failed" label to "Status unknown" for `batchComplete && success === null` case (result recording failed, DM status is ambiguous)
 - [x] Frontend test: update existing test to expect "Status unknown" instead of "Notification failed"
 - [x] Backend (root cause): `sent_at = datetime.now(UTC)` stores timezone-aware datetime into a `TIMESTAMP WITHOUT TIME ZONE` column — asyncpg raises DataError on flush, silently aborting the commit. Fix: `.replace(tzinfo=None)` (matches pattern in autofill.py and attack_day.py)
+
+## Issue #88 — Split .env.deploy into per-environment files
+- [x] Rename `.env.deploy` → `.env.deploy.prod`
+- [x] Copy to `.env.deploy.dev` with header comment listing values to change
+- [x] Update `.gitignore`: `.env.deploy` → `.env.deploy.*`
+- [x] Update `.env.deploy.example` to reflect new naming convention
+- [x] Update `bootstrap-images.ps1`: add `-EnvFile` parameter, default `.env.deploy.prod`
+- [x] Update `README.md`: add Deploy environments section
+- [x] Verify both new files are gitignored
+- [x] Commit tracked changes and open PR


### PR DESCRIPTION
## Summary

Closes #88.

- Replaces the single `.env.deploy` secret file with `.env.deploy.dev` and `.env.deploy.prod` so dev and prod Azure deployments carry separate credentials (at minimum `DISCORD_GUILD_ID` differs between environments)
- `bootstrap-images.ps1` gains an `-EnvFile` parameter (default: `.env.deploy.prod`) — existing `.\bootstrap-images.ps1 -Env prod` invocations continue to work unchanged
- `.gitignore` updated from `.env.deploy` to `.env.deploy.*` to cover both new files
- `.env.deploy.example` updated with new naming convention and usage examples
- `README.md` gains a **Deploy Environments** section documenting the two-file convention

## Test plan

- [ ] Confirm `git check-ignore .env.deploy.dev` and `git check-ignore .env.deploy.prod` both return a match (neither file is ever committed)
- [ ] Run `.\bootstrap-images.ps1 -Env prod` — should load from `.env.deploy.prod` by default
- [ ] Run `.\bootstrap-images.ps1 -Env dev -EnvFile .env.deploy.dev` — should load from `.env.deploy.dev`
- [ ] Confirm `.env.deploy.example` is still tracked (not gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)