### PR TITLE
feat: consistent building colors on Building Settings page (closes #101)

### DIFF
--- a/frontend/src/lib/buildingColors.ts
+++ b/frontend/src/lib/buildingColors.ts
@@ -1,0 +1,61 @@
+import type { BuildingType } from '../api/types';
+
+/** Per-slot color tokens for a building type, used on both the Board and Settings pages. */
+export type BuildingColorClass = {
+  /** Solid colored header bar (e.g. the left sidebar on a building card). */
+  header: string;
+  /** Text color matching the header hue, used on light backgrounds. */
+  headerText: string;
+  /** Border color for the card outline and internal dividers. */
+  border: string;
+  /** Light tinted background for group cells. */
+  bg: string;
+  /** Section header row (collapsible building-type heading). */
+  sectionHeader: string;
+};
+
+export const BUILDING_COLORS: Record<BuildingType, BuildingColorClass> = {
+  stronghold: {
+    header: 'bg-red-600',
+    headerText: 'text-red-700',
+    border: 'border-red-200',
+    bg: 'bg-red-50',
+    sectionHeader: 'bg-red-50 border-red-200 text-red-800',
+  },
+  mana_shrine: {
+    header: 'bg-amber-500',
+    headerText: 'text-amber-700',
+    border: 'border-amber-200',
+    bg: 'bg-amber-50',
+    sectionHeader: 'bg-amber-50 border-amber-200 text-amber-800',
+  },
+  magic_tower: {
+    header: 'bg-blue-600',
+    headerText: 'text-blue-700',
+    border: 'border-blue-200',
+    bg: 'bg-blue-50',
+    sectionHeader: 'bg-blue-50 border-blue-200 text-blue-800',
+  },
+  defense_tower: {
+    header: 'bg-green-600',
+    headerText: 'text-green-700',
+    border: 'border-green-200',
+    bg: 'bg-green-50',
+    sectionHeader: 'bg-green-50 border-green-200 text-green-800',
+  },
+  post: {
+    header: 'bg-slate-500',
+    headerText: 'text-slate-700',
+    border: 'border-slate-200',
+    bg: 'bg-slate-50',
+    sectionHeader: 'bg-slate-50 border-slate-200 text-slate-800',
+  },
+};
+
+export const BUILDING_LABELS: Record<BuildingType, string> = {
+  stronghold: 'Stronghold',
+  mana_shrine: 'Mana Shrine',
+  magic_tower: 'Magic Tower',
+  defense_tower: 'Defense Tower',
+  post: 'Post',
+};

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -45,62 +45,9 @@ import {
   MessageSquare,
   Search,
 } from 'lucide-react';
+import { BUILDING_COLORS, BUILDING_LABELS } from '../lib/buildingColors';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-type BuildingColorClass = {
-  header: string;
-  headerText: string;
-  border: string;
-  bg: string;
-  sectionHeader: string;
-};
-
-const BUILDING_COLORS: Record<BuildingType, BuildingColorClass> = {
-  stronghold: {
-    header: 'bg-red-600',
-    headerText: 'text-red-700',
-    border: 'border-red-200',
-    bg: 'bg-red-50',
-    sectionHeader: 'bg-red-50 border-red-200 text-red-800',
-  },
-  mana_shrine: {
-    header: 'bg-amber-500',
-    headerText: 'text-amber-700',
-    border: 'border-amber-200',
-    bg: 'bg-amber-50',
-    sectionHeader: 'bg-amber-50 border-amber-200 text-amber-800',
-  },
-  magic_tower: {
-    header: 'bg-blue-600',
-    headerText: 'text-blue-700',
-    border: 'border-blue-200',
-    bg: 'bg-blue-50',
-    sectionHeader: 'bg-blue-50 border-blue-200 text-blue-800',
-  },
-  defense_tower: {
-    header: 'bg-green-600',
-    headerText: 'text-green-700',
-    border: 'border-green-200',
-    bg: 'bg-green-50',
-    sectionHeader: 'bg-green-50 border-green-200 text-green-800',
-  },
-  post: {
-    header: 'bg-slate-500',
-    headerText: 'text-slate-700',
-    border: 'border-slate-200',
-    bg: 'bg-slate-50',
-    sectionHeader: 'bg-slate-50 border-slate-200 text-slate-800',
-  },
-};
-
-const BUILDING_LABELS: Record<BuildingType, string> = {
-  stronghold: 'Stronghold',
-  mana_shrine: 'Mana Shrine',
-  magic_tower: 'Magic Tower',
-  defense_tower: 'Defense Tower',
-  post: 'Post',
-};
 
 const ROLE_LABELS: Record<string, string> = {
   heavy_hitter: 'HH',

--- a/frontend/src/pages/SiegeSettingsPage.tsx
+++ b/frontend/src/pages/SiegeSettingsPage.tsx
@@ -52,6 +52,7 @@ import {
 } from 'lucide-react';
 import { isAxiosError } from 'axios';
 import { cn } from '../lib/utils';
+import { BUILDING_COLORS, BUILDING_LABELS } from '../lib/buildingColors';
 
 export default function SiegeSettingsPage() {
   const { id } = useParams<{ id: string }>();
@@ -596,56 +597,83 @@ export default function SiegeSettingsPage() {
         <h2 className="mb-4 text-base font-semibold text-slate-900">Buildings</h2>
         {buildings && buildings.length > 0 && (
           <div className="mb-4 space-y-2">
-            {buildings.filter((b) => b.building_type !== 'post').map((b) => (
-              <div
-                key={b.id}
-                className="flex items-center gap-3 rounded-md border border-slate-100 bg-slate-50 px-3 py-2"
-              >
-                <span className="w-32 text-sm font-medium capitalize">
-                  {b.building_type.replace(/_/g, ' ')} {b.building_number}
-                </span>
-                <div className="flex items-center gap-1">
-                  <span className="text-xs text-slate-500 mr-1">Lvl</span>
-                  {[1, 2, 3, 4, 5, 6].map((lvl) => (
-                    <button
-                      key={lvl}
-                      className={`h-7 w-7 rounded text-xs font-medium transition-colors ${
-                        b.level === lvl
-                          ? 'bg-violet-600 text-white'
-                          : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                      } disabled:cursor-not-allowed disabled:opacity-50`}
-                      disabled={siege?.status === 'complete'}
-                      onClick={() => {
-                        if (lvl !== b.level) {
-                          updateBuildingMutation.mutate({
-                            buildingId: b.id,
-                            data: { level: lvl },
-                          });
+            {buildings.filter((b) => b.building_type !== 'post').map((b) => {
+              const colors = BUILDING_COLORS[b.building_type];
+              return (
+                <div
+                  key={b.id}
+                  className={cn(
+                    'flex overflow-hidden rounded-md border',
+                    colors.border,
+                    b.is_broken && 'opacity-60',
+                  )}
+                >
+                  {/* Colored label bar — mirrors the Board page building header */}
+                  <div
+                    className={cn(
+                      colors.header,
+                      'flex w-36 shrink-0 flex-col justify-center px-2 py-2 text-white',
+                    )}
+                  >
+                    <p className="text-xs font-semibold leading-tight">
+                      {BUILDING_LABELS[b.building_type]} {b.building_number}
+                    </p>
+                    <p className="mt-0.5 text-xs opacity-75">
+                      Lv {b.level}
+                      {b.is_broken ? ' · Broken' : ''}
+                    </p>
+                  </div>
+
+                  {/* Controls area */}
+                  <div className={cn('flex flex-1 items-center gap-4 px-3 py-2', colors.bg)}>
+                    <div className="flex items-center gap-1">
+                      <span className="mr-1 text-xs text-slate-500">Lvl</span>
+                      {[1, 2, 3, 4, 5, 6].map((lvl) => (
+                        <button
+                          key={lvl}
+                          className={cn(
+                            'h-7 w-7 rounded text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+                            b.level === lvl
+                              ? cn(colors.header, 'text-white')
+                              : 'bg-white text-slate-600 hover:bg-slate-100',
+                          )}
+                          disabled={siege?.status === 'complete'}
+                          onClick={() => {
+                            if (lvl !== b.level) {
+                              updateBuildingMutation.mutate({
+                                buildingId: b.id,
+                                data: { level: lvl },
+                              });
+                            }
+                          }}
+                        >
+                          {lvl}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <Checkbox
+                        id={`broken-${b.id}`}
+                        checked={b.is_broken}
+                        disabled={siege?.status === 'complete'}
+                        onCheckedChange={
+                          siege?.status === 'complete'
+                            ? undefined
+                            : (v) =>
+                                updateBuildingMutation.mutate({
+                                  buildingId: b.id,
+                                  data: { is_broken: Boolean(v) },
+                                })
                         }
-                      }}
-                    >
-                      {lvl}
-                    </button>
-                  ))}
+                      />
+                      <Label htmlFor={`broken-${b.id}`} className="text-xs text-slate-500">
+                        Broken
+                      </Label>
+                    </div>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1.5">
-                  <Checkbox
-                    id={`broken-${b.id}`}
-                    checked={b.is_broken}
-                    disabled={siege?.status === 'complete'}
-                    onCheckedChange={siege?.status === 'complete' ? undefined : (v) =>
-                      updateBuildingMutation.mutate({
-                        buildingId: b.id,
-                        data: { is_broken: Boolean(v) },
-                      })
-                    }
-                  />
-                  <Label htmlFor={`broken-${b.id}`} className="text-xs text-slate-500">
-                    Broken
-                  </Label>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </section>


### PR DESCRIPTION
## Summary

- Extracts `BUILDING_COLORS` and `BUILDING_LABELS` from `BoardPage.tsx` into a new shared module `frontend/src/lib/buildingColors.ts`
- Updates `BoardPage.tsx` to import from the shared module (no behavior change)
- Applies the Board page color scheme to the Building Settings page (`SiegeSettingsPage.tsx`): each building row now shows the same type-colored left bar, tinted background, colored level button, and broken-state opacity treatment as on the Board

## What changed visually

Before: building rows in Settings were flat slate (`border-slate-100 bg-slate-50`) with a generic label and a violet active-level button.

After: each building row mirrors the Board — colored left sidebar (red for Stronghold, amber for Mana Shrine, blue for Magic Tower, green for Defense Tower), type-tinted row background, active level button uses the building's own color, and broken buildings are dimmed at 60% opacity with `· Broken` shown in the header.

## Test plan

- [ ] Open Building Settings for a siege with multiple building types — verify each row shows its Board-style color bar
- [ ] Toggle a building's level — verify the active button turns the correct building-type color (not violet)
- [ ] Check the Broken checkbox on a building — verify the row dims to 60% opacity and the header shows `· Broken`
- [ ] Verify the Board page is visually unchanged

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)