### PR TITLE
fix: Warning 15 only fires for HH/Advanced Role members without reserve set

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 from app.models.building import Building
 from app.models.building_group import BuildingGroup
 from app.models.building_type_config import BuildingTypeConfig
-from app.models.enums import BuildingType
+from app.models.enums import BuildingType, MemberRole
 from app.models.member import Member
 from app.models.position import Position
 from app.models.post import Post
@@ -337,10 +337,13 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
             )
         )
 
-    # Rule 15: Assigned members with has_reserve_set = NULL
+    # Rule 15: HH/Advanced Role members without a reserve flag configured.
+    # Only Heavy Hitter and Advanced Role members are required to have the reserve
+    # toggle set; other roles are not subject to this requirement.
     # Uses all_assigned_member_ids (includes broken buildings) because reserve-set
     # configuration is not scroll-related — a member assigned only to broken buildings
     # must still have has_reserve_set configured.
+    _HH_ADVANCED_ROLES = {MemberRole.heavy_hitter, MemberRole.advanced}
     all_assigned_member_ids: set[int] = {
         pos.member_id
         for pos, group, building in all_positions
@@ -348,12 +351,20 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
     }
     for member_id in all_assigned_member_ids:
         sm = sm_by_member.get(member_id)
-        name = sm.member.name if sm and sm.member else "Unknown"
-        if sm is None or sm.has_reserve_set is None:
+        if sm is None:
+            continue
+        member_role = sm.member.role if sm.member else None
+        if member_role not in _HH_ADVANCED_ROLES:
+            continue
+        if not sm.has_reserve_set:
+            name = sm.member.name if sm.member else "Unknown"
             warnings.append(
                 ValidationIssue(
                     rule=15,
-                    message=f"Member '{name}' is assigned but has_reserve_set is not configured",
+                    message=(
+                        f"Member '{name}' is a Heavy Hitter/Advanced Role "
+                        f"but has no reserve configured"
+                    ),
                     context={"member_id": member_id},
                 )
             )

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -829,9 +829,9 @@ async def test_rule14_ten_or_more_day2():
 
 
 @pytest.mark.asyncio
-async def test_rule15_has_reserve_set_null():
-    """Rule 15: assigned member with has_reserve_set=None → warning."""
-    member = _make_member(id=1, is_active=True)
+async def test_rule15_hh_no_reserve():
+    """Rule 15: HH member with has_reserve_set=None → warning."""
+    member = _make_member(id=1, is_active=True, role=MemberRole.heavy_hitter)
     pos = _make_position(id=1, member_id=1, member=member)
     group = _make_group(id=1)
     group.positions = [pos]
@@ -849,9 +849,29 @@ async def test_rule15_has_reserve_set_null():
 
 
 @pytest.mark.asyncio
-async def test_rule15_has_reserve_set_configured():
-    """Rule 15 pass: has_reserve_set is True."""
-    member = _make_member(id=1, is_active=True)
+async def test_rule15_advanced_no_reserve():
+    """Rule 15: Advanced Role member with has_reserve_set=None → warning."""
+    member = _make_member(id=1, is_active=True, role=MemberRole.advanced)
+    pos = _make_position(id=1, member_id=1, member=member)
+    group = _make_group(id=1)
+    group.positions = [pos]
+    building = _make_building(id=1)
+    building.groups = [group]
+    siege = _make_siege(defense_scroll_count=5)
+    siege.buildings = [building]
+    sm = _make_siege_member(member_id=1, attack_day=1, has_reserve_set=None, member=member)
+    siege.siege_members = [sm]
+
+    session = _session_with_siege_and_configs(siege)
+    result = await svc_validate(session, 1)
+    rule15_warnings = [w for w in result.warnings if w.rule == 15]
+    assert len(rule15_warnings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_rule15_hh_reserve_configured():
+    """Rule 15 pass: HH member with has_reserve_set=True → no warning."""
+    member = _make_member(id=1, is_active=True, role=MemberRole.heavy_hitter)
     pos = _make_position(id=1, member_id=1, member=member)
     group = _make_group(id=1)
     group.positions = [pos]
@@ -860,6 +880,26 @@ async def test_rule15_has_reserve_set_configured():
     siege = _make_siege(defense_scroll_count=5)
     siege.buildings = [building]
     sm = _make_siege_member(member_id=1, attack_day=1, has_reserve_set=True, member=member)
+    siege.siege_members = [sm]
+
+    session = _session_with_siege_and_configs(siege)
+    result = await svc_validate(session, 1)
+    rule15_warnings = [w for w in result.warnings if w.rule == 15]
+    assert len(rule15_warnings) == 0
+
+
+@pytest.mark.asyncio
+async def test_rule15_non_hh_no_reserve_no_warning():
+    """Rule 15 pass: medium/novice member with has_reserve_set=None → no warning."""
+    member = _make_member(id=1, is_active=True, role=MemberRole.medium)
+    pos = _make_position(id=1, member_id=1, member=member)
+    group = _make_group(id=1)
+    group.positions = [pos]
+    building = _make_building(id=1)
+    building.groups = [group]
+    siege = _make_siege(defense_scroll_count=5)
+    siege.buildings = [building]
+    sm = _make_siege_member(member_id=1, attack_day=1, has_reserve_set=None, member=member)
     siege.siege_members = [sm]
 
     session = _session_with_siege_and_configs(siege)


### PR DESCRIPTION
## Summary

- Rule 15 previously fired for **any** assigned member with `has_reserve_set = None`, regardless of role
- Fixed to only trigger when the member is **Heavy Hitter or Advanced Role** AND has no reserve flag set
- Updated warning message to reflect the real reason
- Replaced 2 old tests with 4 targeted cases covering all four table rows from the issue spec

## Test plan

- [x] `test_rule15_hh_no_reserve` — HH + no reserve → warning ✅
- [x] `test_rule15_advanced_no_reserve` — Advanced + no reserve → warning ✅
- [x] `test_rule15_hh_reserve_configured` — HH + reserve=True → no warning ✅
- [x] `test_rule15_non_hh_no_reserve_no_warning` — non-HH + no reserve → no warning ✅ (regression guard for old broken behavior)
- [x] All 39 validation tests pass

Closes #111

> Generated with [Claude Code](https://claude.com/claude-code)