### PR TITLE
fix: standardize Azure credential secret name in infra-ci.yml

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS_DEV }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Validate deployment (dev)
         run: |
@@ -201,7 +201,7 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS_DEV }}
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Run what-if (dev)
         run: |


### PR DESCRIPTION
## Summary
- `infra-ci.yml` referenced `AZURE_CREDENTIALS_DEV` while `infra-deploy.yml` uses `AZURE_CREDENTIALS`
- Both workflows use the same service principal — the split name caused login failures when only `AZURE_CREDENTIALS` was configured
- Changed both occurrences (lines 152, 204) to `AZURE_CREDENTIALS`

closes #136

## Test plan
- [ ] Re-run infra-deploy to prod — login step should succeed
- [ ] Verify infra-ci gates (validate + what-if) still pass on PR

> Generated with [Claude Code](https://claude.com/claude-code)