### PR TITLE
chore(ci): migrate Claude workflows from shared actions v1 to v2

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fix:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/ci-failure.yaml@v2
+    uses: cbeaulieu-gt/github-actions/.github/workflows/ci-failure.yaml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v2
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v2
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary
- Bumps all three Claude CI caller workflows from `@v1` to `@v2` of `cbeaulieu-gt/github-actions`
- Replaces deprecated `gh_pat` with GitHub App tokens (`app_id` + `app_private_key`)
- Adds `statuses: write` permission to PR review workflow (required by v2's review checkpoint)
- Fixes `startup_failure` that broke automated PR reviews since April 6

## Test plan
- [ ] Verify this PR itself triggers a successful "Claude PR Review" run (no more `startup_failure`)
- [ ] Verify `@claude` tag respond works on this PR
- [ ] Verify CI failure diagnosis triggers on a future failed CI run

closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)