### PR TITLE
feat: Discord OAuth2 authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ DISCORD_REDIRECT_URI=http://localhost:8000/api/auth/callback
 SESSION_SECRET=changeme-use-a-long-random-string-in-production
 
 # Service auth (for bot→backend calls)
-BOT_SERVICE_TOKEN=
+BOT_SERVICE_TOKEN=changeme-use-a-long-random-string-in-production
 
 # Dev auth bypass — backend WILL NOT START if this is set outside development environment
 # AUTH_DISABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage.xml
 *.swo
 .DS_Store
 .claude/worktrees/
+.worktrees/
 
 # Docker
 .dockerignore

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,7 +2,7 @@
 
 import logging
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode
 
 import httpx
@@ -129,9 +129,7 @@ async def callback(
     try:
         guild_check = await _check_guild_membership(discord_id)
     except httpx.HTTPError:
-        logger.error(
-            "auth_guild_check_failed", extra={"discord_id": discord_id}, exc_info=True
-        )
+        logger.error("auth_guild_check_failed", extra={"discord_id": discord_id}, exc_info=True)
         return _error_redirect("service_unavailable")
 
     if not guild_check.get("is_member"):
@@ -146,7 +144,7 @@ async def callback(
         return _error_redirect("unauthorized")
 
     # 6. Issue JWT — 24-hour expiry
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     token_payload = {
         "sub": str(member.id),
         "name": member.name,

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,202 @@
+"""Discord OAuth2 authentication endpoints."""
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.session import get_db
+from app.dependencies.auth import AuthenticatedUser, get_current_user
+from app.models.member import Member
+from app.services.bot_client import bot_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+DISCORD_OAUTH_AUTHORIZE = "https://discord.com/oauth2/authorize"
+DISCORD_OAUTH_TOKEN = f"{DISCORD_API_BASE}/oauth2/token"
+
+
+async def _exchange_code_for_token(code: str) -> str:
+    """Exchange an authorization code for a Discord access token."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            DISCORD_OAUTH_TOKEN,
+            data={
+                "client_id": settings.discord_client_id,
+                "client_secret": settings.discord_client_secret,
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": settings.discord_redirect_uri,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
+
+async def _get_discord_user(access_token: str) -> dict:
+    """Fetch the authenticated Discord user's profile (identify scope)."""
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{DISCORD_API_BASE}/users/@me",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def _check_guild_membership(discord_id: str) -> dict:
+    """Check guild membership via the bot sidecar. Raises on connection failure."""
+    return await bot_client.get_member(discord_id)
+
+
+@router.get("/login")
+async def login(response: Response) -> dict:
+    """Initiate Discord OAuth2 flow.
+
+    Generates a CSRF state token, stores it in a short-lived cookie, and
+    returns the Discord authorization URL for the frontend to redirect to.
+    """
+    state = secrets.token_hex(32)
+    params = urlencode(
+        {
+            "client_id": settings.discord_client_id,
+            "redirect_uri": settings.discord_redirect_uri,
+            "response_type": "code",
+            "scope": "identify",
+            "state": state,
+        }
+    )
+    url = f"{DISCORD_OAUTH_AUTHORIZE}?{params}"
+    response.set_cookie(
+        key="oauth_state",
+        value=state,
+        httponly=True,
+        max_age=300,
+        samesite="lax",
+        secure=settings.environment != "development",
+    )
+    return {"url": url}
+
+
+@router.get("/callback")
+async def callback(
+    code: str,
+    state: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Handle Discord OAuth2 callback.
+
+    Validates CSRF state, exchanges the authorization code for an access token,
+    fetches the Discord user profile, verifies guild membership via the bot
+    sidecar, matches to a Member record, and issues a signed JWT session cookie.
+    """
+    # 1. Validate state (CSRF)
+    stored_state = request.cookies.get("oauth_state", "")
+    if not stored_state or not secrets.compare_digest(stored_state, state):
+        logger.warning("auth_invalid_state")
+        return _error_redirect("invalid_state")
+
+    # 2. Exchange code for access token
+    try:
+        access_token = await _exchange_code_for_token(code)
+    except httpx.HTTPError:
+        logger.error("auth_token_exchange_failed", exc_info=True)
+        return _error_redirect("service_unavailable")
+
+    # 3. Get Discord user profile
+    try:
+        discord_user = await _get_discord_user(access_token)
+    except httpx.HTTPError:
+        logger.error("auth_discord_user_fetch_failed", exc_info=True)
+        return _error_redirect("service_unavailable")
+
+    discord_id = discord_user["id"]
+
+    # 4. Verify guild membership via bot sidecar
+    try:
+        guild_check = await _check_guild_membership(discord_id)
+    except httpx.HTTPError:
+        logger.error(
+            "auth_guild_check_failed", extra={"discord_id": discord_id}, exc_info=True
+        )
+        return _error_redirect("service_unavailable")
+
+    if not guild_check.get("is_member"):
+        logger.warning("auth_guild_check_rejected", extra={"discord_id": discord_id})
+        return _error_redirect("unauthorized")
+
+    # 5. Match member by discord_id only — no username fallback
+    result = await db.execute(select(Member).where(Member.discord_id == discord_id))
+    member = result.scalar_one_or_none()
+    if not member:
+        logger.warning("auth_member_not_found", extra={"discord_id": discord_id})
+        return _error_redirect("unauthorized")
+
+    # 6. Issue JWT — 24-hour expiry
+    now = datetime.now(timezone.utc)
+    token_payload = {
+        "sub": str(member.id),
+        "name": member.name,
+        "iat": now,
+        "exp": now + timedelta(hours=24),
+    }
+    token = jwt.encode(token_payload, settings.session_secret, algorithm="HS256")
+
+    # 7. Set session cookie and redirect to app root
+    redirect = RedirectResponse(url="/", status_code=307)
+    redirect.set_cookie(
+        key="session",
+        value=token,
+        httponly=True,
+        max_age=86400,
+        samesite="lax",
+        secure=settings.environment != "development",
+    )
+    redirect.delete_cookie(key="oauth_state")
+    return redirect
+
+
+@router.post("/logout")
+async def logout(response: Response) -> dict:
+    """Clear the session cookie, ending the user's session."""
+    response.delete_cookie(key="session")
+    return {"status": "logged_out"}
+
+
+@router.get("/me")
+async def me(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Return identity information for the currently authenticated caller."""
+    role = None
+    discord_id = None
+    if current_user.member_id:
+        member = await db.get(Member, current_user.member_id)
+        if member:
+            role = member.role.value if member.role else None
+            discord_id = member.discord_id
+    return {
+        "member_id": current_user.member_id,
+        "name": current_user.name,
+        "role": role,
+        "discord_id": discord_id,
+    }
+
+
+def _error_redirect(error: str) -> RedirectResponse:
+    """Return a redirect to the login page with an error query parameter."""
+    return RedirectResponse(url=f"/login?error={error}", status_code=307)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -22,6 +22,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+
+class AuthError:
+    """Error codes returned in login redirect query parameters."""
+
+    INVALID_STATE = "invalid_state"
+    SERVICE_UNAVAILABLE = "service_unavailable"
+    UNAUTHORIZED = "unauthorized"
+
+
 DISCORD_API_BASE = "https://discord.com/api/v10"
 DISCORD_OAUTH_AUTHORIZE = "https://discord.com/oauth2/authorize"
 DISCORD_OAUTH_TOKEN = f"{DISCORD_API_BASE}/oauth2/token"
@@ -107,21 +116,21 @@ async def callback(
     stored_state = request.cookies.get("oauth_state", "")
     if not stored_state or not secrets.compare_digest(stored_state, state):
         logger.warning("auth_invalid_state")
-        return _error_redirect("invalid_state")
+        return _error_redirect(AuthError.INVALID_STATE)
 
     # 2. Exchange code for access token
     try:
         access_token = await _exchange_code_for_token(code)
     except httpx.HTTPError:
         logger.error("auth_token_exchange_failed", exc_info=True)
-        return _error_redirect("service_unavailable")
+        return _error_redirect(AuthError.SERVICE_UNAVAILABLE)
 
     # 3. Get Discord user profile
     try:
         discord_user = await _get_discord_user(access_token)
     except httpx.HTTPError:
         logger.error("auth_discord_user_fetch_failed", exc_info=True)
-        return _error_redirect("service_unavailable")
+        return _error_redirect(AuthError.SERVICE_UNAVAILABLE)
 
     discord_id = discord_user["id"]
 
@@ -130,18 +139,18 @@ async def callback(
         guild_check = await _check_guild_membership(discord_id)
     except httpx.HTTPError:
         logger.error("auth_guild_check_failed", extra={"discord_id": discord_id}, exc_info=True)
-        return _error_redirect("service_unavailable")
+        return _error_redirect(AuthError.SERVICE_UNAVAILABLE)
 
     if not guild_check.get("is_member"):
         logger.warning("auth_guild_check_rejected", extra={"discord_id": discord_id})
-        return _error_redirect("unauthorized")
+        return _error_redirect(AuthError.UNAUTHORIZED)
 
     # 5. Match member by discord_id only — no username fallback
     result = await db.execute(select(Member).where(Member.discord_id == discord_id))
     member = result.scalar_one_or_none()
     if not member:
         logger.warning("auth_member_not_found", extra={"discord_id": discord_id})
-        return _error_redirect("unauthorized")
+        return _error_redirect(AuthError.UNAUTHORIZED)
 
     # 6. Issue JWT — 24-hour expiry
     now = datetime.now(UTC)
@@ -159,7 +168,7 @@ async def callback(
         key="session",
         value=token,
         httponly=True,
-        max_age=86400,
+        max_age=82800,  # 23h — safety margin so cookie expires before JWT
         samesite="lax",
         secure=settings.environment != "development",
     )
@@ -177,21 +186,13 @@ async def logout(response: Response) -> dict:
 @router.get("/me")
 async def me(
     current_user: AuthenticatedUser = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Return identity information for the currently authenticated caller."""
-    role = None
-    discord_id = None
-    if current_user.member_id:
-        member = await db.get(Member, current_user.member_id)
-        if member:
-            role = member.role.value if member.role else None
-            discord_id = member.discord_id
     return {
         "member_id": current_user.member_id,
         "name": current_user.name,
-        "role": role,
-        "discord_id": discord_id,
+        "role": current_user.role,
+        "discord_id": current_user.discord_id,
     }
 
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -12,7 +12,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.config import JWT_ALGORITHM, settings
 from app.db.session import get_db
 from app.dependencies.auth import AuthenticatedUser, get_current_user
 from app.models.member import Member
@@ -151,10 +151,10 @@ async def callback(
         "iat": now,
         "exp": now + timedelta(hours=24),
     }
-    token = jwt.encode(token_payload, settings.session_secret, algorithm="HS256")
+    token = jwt.encode(token_payload, settings.session_secret, algorithm=JWT_ALGORITHM)
 
     # 7. Set session cookie and redirect to app root
-    redirect = RedirectResponse(url="/", status_code=307)
+    redirect = RedirectResponse(url="/", status_code=302)
     redirect.set_cookie(
         key="session",
         value=token,
@@ -197,4 +197,4 @@ async def me(
 
 def _error_redirect(error: str) -> RedirectResponse:
     """Return a redirect to the login page with an error query parameter."""
-    return RedirectResponse(url=f"/login?error={error}", status_code=307)
+    return RedirectResponse(url=f"/login?error={error}", status_code=302)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,3 +30,5 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+JWT_ALGORITHM = "HS256"

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -14,7 +14,7 @@ import jwt
 from fastapi import Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.config import JWT_ALGORITHM, settings
 from app.db.session import get_db
 from app.models.member import Member
 
@@ -53,7 +53,7 @@ async def get_current_user(
     session_token = request.cookies.get("session")
     if session_token:
         try:
-            payload = jwt.decode(session_token, settings.session_secret, algorithms=["HS256"])
+            payload = jwt.decode(session_token, settings.session_secret, algorithms=[JWT_ALGORITHM])
             member = await db.get(Member, int(payload["sub"]))
             if member:
                 return AuthenticatedUser(member_id=member.id, name=member.name, is_service=False)

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -53,14 +53,10 @@ async def get_current_user(
     session_token = request.cookies.get("session")
     if session_token:
         try:
-            payload = jwt.decode(
-                session_token, settings.session_secret, algorithms=["HS256"]
-            )
+            payload = jwt.decode(session_token, settings.session_secret, algorithms=["HS256"])
             member = await db.get(Member, int(payload["sub"]))
             if member:
-                return AuthenticatedUser(
-                    member_id=member.id, name=member.name, is_service=False
-                )
+                return AuthenticatedUser(member_id=member.id, name=member.name, is_service=False)
         except (jwt.ExpiredSignatureError, jwt.InvalidTokenError, KeyError, ValueError):
             pass
 

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,0 +1,67 @@
+"""FastAPI dependency for request authentication.
+
+Checks three paths in order:
+1. AUTH_DISABLED=true (development only) → stub user
+2. Authorization: Bearer <token> → service principal
+3. Cookie: session=<jwt> → authenticated user
+4. Otherwise → HTTP 401
+"""
+
+import secrets
+from dataclasses import dataclass
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.session import get_db
+from app.models.member import Member
+
+
+@dataclass
+class AuthenticatedUser:
+    """Represents the currently authenticated user or service principal."""
+
+    member_id: int | None
+    name: str
+    is_service: bool
+
+
+async def get_current_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> AuthenticatedUser:
+    """Resolve the caller's identity from the incoming request.
+
+    Tries three mechanisms in priority order: dev bypass flag, Bearer token
+    for service-to-service calls, and a signed JWT session cookie for
+    browser-based users.
+    """
+    # 1. Dev bypass — only permitted when ENVIRONMENT=development (startup guard enforces this)
+    if settings.auth_disabled:
+        return AuthenticatedUser(member_id=None, name="dev-user", is_service=False)
+
+    # 2. Service token (Bearer) — timing-safe comparison prevents timing attacks
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer ") and settings.bot_service_token:
+        provided = auth_header.removeprefix("Bearer ")
+        if secrets.compare_digest(provided, settings.bot_service_token):
+            return AuthenticatedUser(member_id=None, name="bot-service", is_service=True)
+
+    # 3. User session cookie — decode JWT and look up the member record
+    session_token = request.cookies.get("session")
+    if session_token:
+        try:
+            payload = jwt.decode(
+                session_token, settings.session_secret, algorithms=["HS256"]
+            )
+            member = await db.get(Member, int(payload["sub"]))
+            if member:
+                return AuthenticatedUser(
+                    member_id=member.id, name=member.name, is_service=False
+                )
+        except (jwt.ExpiredSignatureError, jwt.InvalidTokenError, KeyError, ValueError):
+            pass
+
+    raise HTTPException(status_code=401, detail="Not authenticated")

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -26,6 +26,8 @@ class AuthenticatedUser:
     member_id: int | None
     name: str
     is_service: bool
+    role: str | None = None
+    discord_id: str | None = None
 
 
 async def get_current_user(
@@ -56,7 +58,13 @@ async def get_current_user(
             payload = jwt.decode(session_token, settings.session_secret, algorithms=[JWT_ALGORITHM])
             member = await db.get(Member, int(payload["sub"]))
             if member:
-                return AuthenticatedUser(member_id=member.id, name=member.name, is_service=False)
+                return AuthenticatedUser(
+                    member_id=member.id,
+                    name=member.name,
+                    is_service=False,
+                    role=member.role.value if member.role else None,
+                    discord_id=member.discord_id,
+                )
         except (jwt.ExpiredSignatureError, jwt.InvalidTokenError, KeyError, ValueError):
             pass
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,17 @@ async def lifespan(app: FastAPI):
             "AUTH_DISABLED=true is not permitted outside development. "
             f"Current environment: {settings.environment}"
         )
+    if not settings.auth_disabled:
+        if not settings.session_secret:
+            raise RuntimeError(
+                "SESSION_SECRET must be set when auth is enabled. "
+                f"Current environment: {settings.environment}"
+            )
+        if settings.environment != "development" and not settings.bot_service_token:
+            raise RuntimeError(
+                "BOT_SERVICE_TOKEN must be set in non-development environments. "
+                f"Current environment: {settings.environment}"
+            )
     yield
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,11 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.attack_day import router as attack_day_router
+from app.api.auth import router as auth_router
 from app.api.autofill import router as autofill_router
 from app.api.board import router as board_router
 from app.api.buildings import router as buildings_router
@@ -23,6 +24,7 @@ from app.api.sieges import router as sieges_router
 from app.api.validation import router as validation_router
 from app.api.version import router as version_router
 from app.config import settings
+from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
 
 logging.basicConfig(
@@ -59,21 +61,26 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Public routes — no auth required
 app.include_router(health_router, prefix="/api")
-app.include_router(reference_router, prefix="/api")
-app.include_router(discord_sync_router, prefix="/api")
-app.include_router(members_router, prefix="/api")
-app.include_router(sieges_router, prefix="/api")
-app.include_router(buildings_router, prefix="/api")
-app.include_router(siege_members_router, prefix="/api")
-app.include_router(board_router, prefix="/api")
-app.include_router(lifecycle_router, prefix="/api")
-app.include_router(posts_router, prefix="/api")
-app.include_router(validation_router, prefix="/api")
-app.include_router(autofill_router, prefix="/api")
-app.include_router(comparison_router, prefix="/api")
-app.include_router(attack_day_router, prefix="/api")
-app.include_router(images_router, prefix="/api")
-app.include_router(notifications_router, prefix="/api")
-app.include_router(post_priority_config_router, prefix="/api")
 app.include_router(version_router, prefix="/api")
+app.include_router(auth_router, prefix="/api")
+
+# Protected routes — require authentication
+_auth_deps = [Depends(get_current_user)]
+app.include_router(reference_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(discord_sync_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(members_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(sieges_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(buildings_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(siege_members_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(board_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(lifecycle_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(posts_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(validation_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(autofill_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(comparison_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(attack_day_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(images_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(notifications_router, prefix="/api", dependencies=_auth_deps)
+app.include_router(post_priority_config_router, prefix="/api", dependencies=_auth_deps)

--- a/backend/app/services/bot_client.py
+++ b/backend/app/services/bot_client.py
@@ -68,5 +68,17 @@ class BotClient:
         except httpx.HTTPError:
             return []
 
+    async def get_member(self, discord_user_id: str) -> dict:
+        """
+        Check guild membership via bot sidecar.
+        Returns the member dict (including ``is_member`` boolean).
+        Raises ``httpx.HTTPError`` if the sidecar is unreachable or returns
+        a non-2xx status.
+        """
+        async with self._make_client() as client:
+            response = await client.get(f"/api/members/{discord_user_id}")
+            response.raise_for_status()
+            return response.json()
+
 
 bot_client = BotClient()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,8 @@ a sensible default or is already present in the developer's .env file.
 
 import os
 
+import pytest
+
 # Ensure ENVIRONMENT is always set — Settings has no default for this field so
 # that production deployments fail fast if it is missing.  Tests run as "test".
 os.environ.setdefault("ENVIRONMENT", "test")
@@ -22,3 +24,15 @@ os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/
 os.environ.setdefault("DISCORD_BOT_API_URL", "http://localhost:8001")
 os.environ.setdefault("DISCORD_BOT_API_KEY", "test-key")
 os.environ.setdefault("DISCORD_GUILD_ID", "123456789")
+
+
+@pytest.fixture(autouse=True)
+def disable_auth_for_tests(monkeypatch):
+    """Bypass auth middleware for all tests by default.
+
+    Individual tests that exercise auth behaviour override this by calling
+    ``monkeypatch.setattr("app.config.settings.auth_disabled", False)``
+    explicitly, which takes precedence because monkeypatch patches are applied
+    in order within the same test.
+    """
+    monkeypatch.setattr("app.config.settings.auth_disabled", True)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -215,6 +215,29 @@ async def test_expired_jwt_returns_401(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_jwt_with_wrong_secret_returns_401(monkeypatch):
+    """A JWT signed with a different secret is rejected with 401."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    # Sign with a completely different secret
+    wrong_secret_token = _make_jwt(member_id=1, secret="wrong-secret-entirely")
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            client.cookies.set("session", wrong_secret_token)
+            response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_jwt_with_deleted_member_returns_401(monkeypatch):
     """A valid JWT whose member no longer exists in the DB returns 401."""
     monkeypatch.setattr("app.config.settings.auth_disabled", False)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,578 @@
+"""Tests for Discord OAuth2 auth middleware and endpoints."""
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import jwt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.db.session import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models.enums import MemberRole
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
+
+TEST_SESSION_SECRET = "test-session-secret"
+
+
+def _make_jwt(
+    member_id: int,
+    secret: str = TEST_SESSION_SECRET,
+    exp_hours: int = 24,
+) -> str:
+    payload = {
+        "sub": str(member_id),
+        "name": "TestUser",
+        "iat": datetime.now(timezone.utc),
+        "exp": datetime.now(timezone.utc) + timedelta(hours=exp_hours),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _make_expired_jwt(member_id: int, secret: str = TEST_SESSION_SECRET) -> str:
+    payload = {
+        "sub": str(member_id),
+        "name": "TestUser",
+        "iat": datetime.now(timezone.utc) - timedelta(hours=48),
+        "exp": datetime.now(timezone.utc) - timedelta(hours=24),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+# ---------------------------------------------------------------------------
+# DB + member fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_member(
+    id: int = 1,
+    name: str = "TestUser",
+    discord_id: str = "discord-999",
+    role: MemberRole = MemberRole.advanced,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        discord_id=discord_id,
+        discord_username=None,
+        role=role,
+        power_level=None,
+        is_active=True,
+    )
+
+
+def _make_mock_db(member=None):
+    """Return an AsyncMock session whose db.get() returns `member`."""
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=member)
+    session.execute = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# A protected endpoint to probe middleware behaviour
+# The /api/members endpoint requires auth — use it as the probe.
+# ---------------------------------------------------------------------------
+
+PROTECTED_URL = "/api/members"
+
+
+# ===========================================================================
+# Middleware tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_allows_access(monkeypatch):
+    """AUTH_DISABLED=true + ENVIRONMENT=development bypasses auth entirely."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", True)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    mock_db = _make_mock_db()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch("app.api.members.members_service.list_members", new_callable=AsyncMock) as m:
+            m.return_value = []
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_valid_service_token_allows_access(monkeypatch):
+    """A correct Bearer token grants access as the bot-service principal."""
+    token = "super-secret-service-token"
+    monkeypatch.setattr("app.config.settings.bot_service_token", token)
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+
+    mock_db = _make_mock_db()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch("app.api.members.members_service.list_members", new_callable=AsyncMock) as m:
+            m.return_value = []
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    PROTECTED_URL, headers={"Authorization": f"Bearer {token}"}
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_invalid_service_token_returns_401(monkeypatch):
+    """A wrong Bearer token is rejected with 401."""
+    monkeypatch.setattr("app.config.settings.bot_service_token", "correct-token")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get(
+                PROTECTED_URL, headers={"Authorization": "Bearer wrong-token"}
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_jwt_cookie_allows_access(monkeypatch):
+    """A valid JWT session cookie with an existing member grants access."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    member = _make_member(id=42)
+    mock_db = _make_mock_db(member=member)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    token = _make_jwt(member_id=42)
+    try:
+        with patch("app.api.members.members_service.list_members", new_callable=AsyncMock) as m:
+            m.return_value = []
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                client.cookies.set("session", token)
+                response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_expired_jwt_returns_401(monkeypatch):
+    """An expired JWT cookie is rejected with 401."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    expired_token = _make_expired_jwt(member_id=1)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            client.cookies.set("session", expired_token)
+            response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_jwt_with_deleted_member_returns_401(monkeypatch):
+    """A valid JWT whose member no longer exists in the DB returns 401."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    # db.get returns None — member was deleted
+    mock_db = _make_mock_db(member=None)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    token = _make_jwt(member_id=99)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            client.cookies.set("session", token)
+            response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_no_auth_returns_401(monkeypatch):
+    """No credentials at all → 401."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get(PROTECTED_URL)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_no_auth_required(monkeypatch):
+    """/api/health is accessible without any credentials."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/health")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_version_no_auth_required(monkeypatch):
+    """/api/version is accessible without any credentials."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+
+    with patch("app.api.version._fetch_bot_version", new=AsyncMock(return_value=None)):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/version")
+
+    assert response.status_code == 200
+
+
+# ===========================================================================
+# Auth endpoint tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_login_returns_discord_url_and_state_cookie(monkeypatch):
+    """GET /api/auth/login returns a Discord authorization URL and sets a state cookie."""
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-client-id")
+    monkeypatch.setattr(
+        "app.config.settings.discord_redirect_uri", "http://localhost:8000/api/auth/callback"
+    )
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/auth/login")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "url" in data
+    assert "discord.com/oauth2/authorize" in data["url"]
+    assert "test-client-id" in data["url"]
+    assert "oauth_state" in response.cookies
+
+
+@pytest.mark.asyncio
+async def test_callback_invalid_state_redirects(monkeypatch):
+    """Mismatched OAuth state redirects to /login?error=invalid_state."""
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", follow_redirects=False
+    ) as client:
+        # Send a state cookie that doesn't match the query-param state
+        client.cookies.set("oauth_state", "correct-state")
+        response = await client.get(
+            "/api/auth/callback", params={"code": "auth-code", "state": "wrong-state"}
+        )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login?error=invalid_state"
+
+
+@pytest.mark.asyncio
+async def test_callback_happy_path(monkeypatch):
+    """Full valid callback flow issues a session cookie and redirects to /."""
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    member = _make_member(id=7, discord_id="discord-777")
+    mock_db = _make_mock_db(member=member)
+    # scalar_one_or_none is a sync method on the SQLAlchemy result object
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none = MagicMock(return_value=member)
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def override_get_db():
+        yield mock_db
+
+    state = secrets.token_hex(32)
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.auth._exchange_code_for_token",
+            new=AsyncMock(return_value="discord-access-token"),
+        ):
+            with patch(
+                "app.api.auth._get_discord_user",
+                new=AsyncMock(return_value={"id": "discord-777"}),
+            ):
+                with patch(
+                    "app.api.auth._check_guild_membership",
+                    new=AsyncMock(return_value={"is_member": True}),
+                ):
+                    async with AsyncClient(
+                        transport=ASGITransport(app=app),
+                        base_url="http://test",
+                        follow_redirects=False,
+                    ) as client:
+                        client.cookies.set("oauth_state", state)
+                        response = await client.get(
+                            "/api/auth/callback",
+                            params={"code": "auth-code", "state": state},
+                        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/"
+    assert "session" in response.cookies
+
+
+@pytest.mark.asyncio
+async def test_callback_not_in_guild_redirects(monkeypatch):
+    """User not in the guild redirects to /login?error=unauthorized."""
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    state = secrets.token_hex(32)
+    with patch(
+        "app.api.auth._exchange_code_for_token",
+        new=AsyncMock(return_value="discord-access-token"),
+    ):
+        with patch(
+            "app.api.auth._get_discord_user",
+            new=AsyncMock(return_value={"id": "discord-outsider"}),
+        ):
+            with patch(
+                "app.api.auth._check_guild_membership",
+                new=AsyncMock(return_value={"is_member": False}),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app),
+                    base_url="http://test",
+                    follow_redirects=False,
+                ) as client:
+                    client.cookies.set("oauth_state", state)
+                    response = await client.get(
+                        "/api/auth/callback",
+                        params={"code": "auth-code", "state": state},
+                    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login?error=unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_callback_bot_unreachable_redirects_service_unavailable(monkeypatch):
+    """Bot sidecar connection error redirects to /login?error=service_unavailable."""
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    state = secrets.token_hex(32)
+    with patch(
+        "app.api.auth._exchange_code_for_token",
+        new=AsyncMock(return_value="discord-access-token"),
+    ):
+        with patch(
+            "app.api.auth._get_discord_user",
+            new=AsyncMock(return_value={"id": "discord-abc"}),
+        ):
+            with patch(
+                "app.api.auth._check_guild_membership",
+                side_effect=httpx.ConnectError("bot unreachable"),
+            ):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app),
+                    base_url="http://test",
+                    follow_redirects=False,
+                ) as client:
+                    client.cookies.set("oauth_state", state)
+                    response = await client.get(
+                        "/api/auth/callback",
+                        params={"code": "auth-code", "state": state},
+                    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login?error=service_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_callback_no_member_record_redirects(monkeypatch):
+    """Guild member whose discord_id isn't in the DB redirects to /login?error=unauthorized."""
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none = MagicMock(return_value=None)
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def override_get_db():
+        yield mock_db
+
+    state = secrets.token_hex(32)
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.auth._exchange_code_for_token",
+            new=AsyncMock(return_value="discord-access-token"),
+        ):
+            with patch(
+                "app.api.auth._get_discord_user",
+                new=AsyncMock(return_value={"id": "discord-unknown"}),
+            ):
+                with patch(
+                    "app.api.auth._check_guild_membership",
+                    new=AsyncMock(return_value={"is_member": True}),
+                ):
+                    async with AsyncClient(
+                        transport=ASGITransport(app=app),
+                        base_url="http://test",
+                        follow_redirects=False,
+                    ) as client:
+                        client.cookies.set("oauth_state", state)
+                        response = await client.get(
+                            "/api/auth/callback",
+                            params={"code": "auth-code", "state": state},
+                        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login?error=unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_session_cookie():
+    """POST /api/auth/logout clears the session cookie."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        client.cookies.set("session", "some-token")
+        response = await client.post("/api/auth/logout")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "logged_out"}
+    # Cookie is cleared (max-age=0 or expires in the past)
+    assert "session" in response.headers.get("set-cookie", "")
+
+
+@pytest.mark.asyncio
+async def test_me_with_valid_session(monkeypatch):
+    """GET /api/auth/me returns member info when authenticated via session cookie."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    member = _make_member(id=5, name="Alice", discord_id="discord-555", role=MemberRole.heavy_hitter)
+    mock_db = _make_mock_db(member=member)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    token = _make_jwt(member_id=5)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            client.cookies.set("session", token)
+            response = await client.get("/api/auth/me")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["member_id"] == 5
+    assert data["name"] == "Alice"
+    assert data["role"] == "heavy_hitter"
+    assert data["discord_id"] == "discord-555"
+
+
+@pytest.mark.asyncio
+async def test_me_without_auth_returns_401(monkeypatch):
+    """GET /api/auth/me without credentials returns 401."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", "")
+    monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
+
+    async def override_get_db():
+        yield _make_mock_db()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/api/auth/me")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 401

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,7 +1,7 @@
 """Tests for Discord OAuth2 auth middleware and endpoints."""
 
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,7 +11,6 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.db.session import get_db
-from app.dependencies.auth import get_current_user
 from app.main import app
 from app.models.enums import MemberRole
 
@@ -30,8 +29,8 @@ def _make_jwt(
     payload = {
         "sub": str(member_id),
         "name": "TestUser",
-        "iat": datetime.now(timezone.utc),
-        "exp": datetime.now(timezone.utc) + timedelta(hours=exp_hours),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(hours=exp_hours),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 
@@ -40,8 +39,8 @@ def _make_expired_jwt(member_id: int, secret: str = TEST_SESSION_SECRET) -> str:
     payload = {
         "sub": str(member_id),
         "name": "TestUser",
-        "iat": datetime.now(timezone.utc) - timedelta(hours=48),
-        "exp": datetime.now(timezone.utc) - timedelta(hours=24),
+        "iat": datetime.now(UTC) - timedelta(hours=48),
+        "exp": datetime.now(UTC) - timedelta(hours=24),
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 
@@ -154,9 +153,7 @@ async def test_invalid_service_token_returns_401(monkeypatch):
 
     app.dependency_overrides[get_db] = override_get_db
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(
                 PROTECTED_URL, headers={"Authorization": "Bearer wrong-token"}
             )
@@ -208,9 +205,7 @@ async def test_expired_jwt_returns_401(monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
     expired_token = _make_expired_jwt(member_id=1)
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             client.cookies.set("session", expired_token)
             response = await client.get(PROTECTED_URL)
     finally:
@@ -235,9 +230,7 @@ async def test_jwt_with_deleted_member_returns_401(monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
     token = _make_jwt(member_id=99)
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             client.cookies.set("session", token)
             response = await client.get(PROTECTED_URL)
     finally:
@@ -258,9 +251,7 @@ async def test_no_auth_returns_401(monkeypatch):
 
     app.dependency_overrides[get_db] = override_get_db
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get(PROTECTED_URL)
     finally:
         app.dependency_overrides.pop(get_db, None)
@@ -279,9 +270,7 @@ async def test_health_no_auth_required(monkeypatch):
 
     app.dependency_overrides[get_db] = override_get_db
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/api/health")
     finally:
         app.dependency_overrides.pop(get_db, None)
@@ -296,9 +285,7 @@ async def test_version_no_auth_required(monkeypatch):
     monkeypatch.setattr("app.config.settings.bot_service_token", "")
 
     with patch("app.api.version._fetch_bot_version", new=AsyncMock(return_value=None)):
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/api/version")
 
     assert response.status_code == 200
@@ -318,9 +305,7 @@ async def test_login_returns_discord_url_and_state_cookie(monkeypatch):
     )
     monkeypatch.setattr("app.config.settings.environment", "development")
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/api/auth/login")
 
     assert response.status_code == 200
@@ -512,9 +497,7 @@ async def test_callback_no_member_record_redirects(monkeypatch):
 @pytest.mark.asyncio
 async def test_logout_clears_session_cookie():
     """POST /api/auth/logout clears the session cookie."""
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         client.cookies.set("session", "some-token")
         response = await client.post("/api/auth/logout")
 
@@ -531,7 +514,9 @@ async def test_me_with_valid_session(monkeypatch):
     monkeypatch.setattr("app.config.settings.bot_service_token", "")
     monkeypatch.setattr("app.config.settings.session_secret", TEST_SESSION_SECRET)
 
-    member = _make_member(id=5, name="Alice", discord_id="discord-555", role=MemberRole.heavy_hitter)
+    member = _make_member(
+        id=5, name="Alice", discord_id="discord-555", role=MemberRole.heavy_hitter
+    )
     mock_db = _make_mock_db(member=member)
 
     async def override_get_db():
@@ -540,9 +525,7 @@ async def test_me_with_valid_session(monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
     token = _make_jwt(member_id=5)
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             client.cookies.set("session", token)
             response = await client.get("/api/auth/me")
     finally:
@@ -568,9 +551,7 @@ async def test_me_without_auth_returns_401(monkeypatch):
 
     app.dependency_overrides[get_db] = override_get_db
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             response = await client.get("/api/auth/me")
     finally:
         app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -330,7 +330,7 @@ async def test_callback_invalid_state_redirects(monkeypatch):
             "/api/auth/callback", params={"code": "auth-code", "state": "wrong-state"}
         )
 
-    assert response.status_code == 307
+    assert response.status_code == 302
     assert response.headers["location"] == "/login?error=invalid_state"
 
 
@@ -378,7 +378,7 @@ async def test_callback_happy_path(monkeypatch):
     finally:
         app.dependency_overrides.pop(get_db, None)
 
-    assert response.status_code == 307
+    assert response.status_code == 302
     assert response.headers["location"] == "/"
     assert "session" in response.cookies
 
@@ -412,7 +412,7 @@ async def test_callback_not_in_guild_redirects(monkeypatch):
                         params={"code": "auth-code", "state": state},
                     )
 
-    assert response.status_code == 307
+    assert response.status_code == 302
     assert response.headers["location"] == "/login?error=unauthorized"
 
 
@@ -445,7 +445,7 @@ async def test_callback_bot_unreachable_redirects_service_unavailable(monkeypatc
                         params={"code": "auth-code", "state": state},
                     )
 
-    assert response.status_code == 307
+    assert response.status_code == 302
     assert response.headers["location"] == "/login?error=service_unavailable"
 
 
@@ -490,7 +490,7 @@ async def test_callback_no_member_record_redirects(monkeypatch):
     finally:
         app.dependency_overrides.pop(get_db, None)
 
-    assert response.status_code == 307
+    assert response.status_code == 302
     assert response.headers["location"] == "/login?error=unauthorized"
 
 
@@ -557,3 +557,46 @@ async def test_me_without_auth_returns_401(monkeypatch):
         app.dependency_overrides.pop(get_db, None)
 
     assert response.status_code == 401
+
+
+# ===========================================================================
+# Startup validation tests
+# ===========================================================================
+
+
+class TestStartupValidation:
+
+    @pytest.mark.asyncio
+    async def test_startup_rejects_empty_session_secret(self, monkeypatch):
+        """Startup rejects empty SESSION_SECRET when auth is enabled."""
+        monkeypatch.setattr("app.config.settings.auth_disabled", False)
+        monkeypatch.setattr("app.config.settings.session_secret", "")
+        monkeypatch.setattr("app.config.settings.environment", "production")
+
+        with pytest.raises(RuntimeError, match="SESSION_SECRET must be set"):
+            async with app.router.lifespan_context(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_startup_rejects_missing_bot_service_token_in_production(self, monkeypatch):
+        """Startup rejects missing BOT_SERVICE_TOKEN in non-dev environments."""
+        monkeypatch.setattr("app.config.settings.auth_disabled", False)
+        monkeypatch.setattr("app.config.settings.session_secret", "valid-secret")
+        monkeypatch.setattr("app.config.settings.bot_service_token", "")
+        monkeypatch.setattr("app.config.settings.environment", "production")
+
+        with pytest.raises(RuntimeError, match="BOT_SERVICE_TOKEN must be set"):
+            async with app.router.lifespan_context(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_startup_allows_empty_bot_service_token_in_development(self, monkeypatch):
+        """Development environment allows empty BOT_SERVICE_TOKEN."""
+        monkeypatch.setattr("app.config.settings.auth_disabled", False)
+        monkeypatch.setattr("app.config.settings.session_secret", "valid-secret")
+        monkeypatch.setattr("app.config.settings.bot_service_token", "")
+        monkeypatch.setattr("app.config.settings.environment", "development")
+
+        # Should not raise
+        async with app.router.lifespan_context(app):
+            pass

--- a/backend/tests/test_bot_client.py
+++ b/backend/tests/test_bot_client.py
@@ -90,3 +90,57 @@ async def test_notify_returns_true_on_success():
     with patch.object(BotClient, "_make_client", return_value=client_mock):
         result = await BotClient().notify("alice", "siege activated")
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# get_member tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_member_returns_member_dict():
+    """get_member() returns the member dict when sidecar responds 200."""
+    member_data = {"discord_user_id": "123456789", "is_member": True, "username": "alice"}
+    response = _make_ok_response(status_code=200, json_data=member_data)
+    client_mock = _async_client_that_returns(response)
+    with patch.object(BotClient, "_make_client", return_value=client_mock):
+        result = await BotClient().get_member("123456789")
+    assert result == member_data
+
+
+@pytest.mark.asyncio
+async def test_get_member_returns_not_member():
+    """get_member() returns the dict as-is when sidecar responds with is_member=False."""
+    not_member_data = {"is_member": False}
+    response = _make_ok_response(status_code=200, json_data=not_member_data)
+    client_mock = _async_client_that_returns(response)
+    with patch.object(BotClient, "_make_client", return_value=client_mock):
+        result = await BotClient().get_member("999999999")
+    assert result == not_member_data
+
+
+@pytest.mark.asyncio
+async def test_get_member_raises_on_connection_error():
+    """get_member() raises httpx.HTTPError when the sidecar is unreachable."""
+    client_mock = _async_client_that_raises(httpx.ConnectError("unreachable"))
+    with patch.object(BotClient, "_make_client", return_value=client_mock):
+        with pytest.raises(httpx.HTTPError):
+            await BotClient().get_member("123456789")
+
+
+@pytest.mark.asyncio
+async def test_get_member_raises_on_503():
+    """get_member() raises httpx.HTTPStatusError when sidecar returns 503."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 503
+    response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=response,
+        )
+    )
+    client_mock = _async_client_that_returns(response)
+    with patch.object(BotClient, "_make_client", return_value=client_mock):
+        with pytest.raises(httpx.HTTPStatusError):
+            await BotClient().get_member("123456789")

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -26,9 +26,11 @@ that depend on the production environment being stood up.
 | 7 — Frontend Discord/Compare | Complete | Comparison view, DM notification panel, channel post action, image preview/download |
 | 8 — Excel Import | Complete | One-time CLI script using openpyxl; imports historical .xlsm siege files |
 | 9 — Hardening/Launch | In Progress | E2E tests, Bicep IaC, Vitest, RUNBOOK.md done; prod provisioning + CD pipeline + launch steps remaining |
+| 10 — Auth | Complete | Discord OAuth2 authentication: JWT session cookies, RequireAuth routing, `/api/auth/*` endpoints |
 
 ## What's Working
 
+- Discord OAuth2 authentication: login/callback/logout endpoints, JWT session cookies (24h expiry), guild membership enforcement, `RequireAuth` frontend wrapper, per-route auth bypass for `/api/auth/*`, `/api/health`, and `/api/version`
 - Full siege lifecycle: create → configure buildings → assign members → validate → activate → complete
 - Assignment board with per-position state (assigned / RESERVE / No Assignment / empty / disabled)
 - Auto-fill: Fisher-Yates shuffle respecting defense_scroll_count; preview → apply flow
@@ -40,6 +42,16 @@ that depend on the production environment being stood up.
 - Excel import: historical .xlsm files imported as completed siege records
 - 3500+ backend tests covering all routes, business logic, and constraint enforcement
 - CI pipeline: black, ruff, pytest (backend) + ESLint, build (frontend) on every PR
+
+## Phase 10 — Auth (Complete)
+
+Discord OAuth2 authentication is fully implemented:
+- Backend: `/api/auth/login`, `/api/auth/callback`, `/api/auth/logout`, `/api/auth/me` endpoints
+- JWT session cookies (HS256, 24-hour expiry) issued after successful OAuth2 callback
+- Guild membership enforced via bot's `get_member()` lookup — non-members redirected to `/login?error=unauthorized`
+- `get_current_user` dependency applied globally (excludes public routes); `auth_disabled` flag for local dev
+- Frontend: `AuthContext` + `useAuth` hook; `RequireAuth` wrapper on all protected routes; `LoginPage` with Discord button; 401 interceptor redirects to login
+- 19 backend auth tests; 6 frontend auth tests (LoginPage + AuthContext)
 
 ## Phase 9 — In Progress
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,31 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import Layout from './components/Layout';
-import SiegeLayout from './components/SiegeLayout';
-import MembersPage from './pages/MembersPage';
-import MemberDetailPage from './pages/MemberDetailPage';
-import SiegesPage from './pages/SiegesPage';
-import SiegeCreatePage from './pages/SiegeCreatePage';
-import SiegeSettingsPage from './pages/SiegeSettingsPage';
-import BoardPage from './pages/BoardPage';
-import PostsPage from './pages/PostsPage';
-import SiegeMembersPage from './pages/SiegeMembersPage';
-import ComparisonPage from './pages/ComparisonPage';
-import PostPrioritiesPage from './pages/PostPrioritiesPage';
-import SystemPage from './pages/SystemPage';
+import { Routes, Route, Navigate } from "react-router-dom";
+import Layout from "./components/Layout";
+import RequireAuth from "./components/RequireAuth";
+import SiegeLayout from "./components/SiegeLayout";
+import LoginPage from "./pages/LoginPage";
+import MembersPage from "./pages/MembersPage";
+import MemberDetailPage from "./pages/MemberDetailPage";
+import SiegesPage from "./pages/SiegesPage";
+import SiegeCreatePage from "./pages/SiegeCreatePage";
+import SiegeSettingsPage from "./pages/SiegeSettingsPage";
+import BoardPage from "./pages/BoardPage";
+import PostsPage from "./pages/PostsPage";
+import SiegeMembersPage from "./pages/SiegeMembersPage";
+import ComparisonPage from "./pages/ComparisonPage";
+import PostPrioritiesPage from "./pages/PostPrioritiesPage";
+import SystemPage from "./pages/SystemPage";
 
 function App() {
   return (
     <Routes>
-      <Route element={<Layout />}>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        element={
+          <RequireAuth>
+            <Layout />
+          </RequireAuth>
+        }
+      >
         <Route path="/" element={<Navigate to="/sieges" replace />} />
         <Route path="/members" element={<MembersPage />} />
         <Route path="/members/new" element={<MemberDetailPage />} />

--- a/frontend/src/api/board.ts
+++ b/frontend/src/api/board.ts
@@ -1,8 +1,10 @@
-import apiClient from './client';
-import type { BoardResponse, PositionResponse } from './types';
+import apiClient from "./client";
+import type { BoardResponse, PositionResponse } from "./types";
 
 export async function getBoard(siegeId: number): Promise<BoardResponse> {
-  const res = await apiClient.get<BoardResponse>(`/api/sieges/${siegeId}/board`);
+  const res = await apiClient.get<BoardResponse>(
+    `/api/sieges/${siegeId}/board`
+  );
   return res.data;
 }
 
@@ -14,11 +16,11 @@ export async function updatePosition(
     is_reserve?: boolean;
     has_no_assignment?: boolean;
     matched_condition_id?: number | null;
-  },
+  }
 ): Promise<PositionResponse> {
   const res = await apiClient.put<PositionResponse>(
     `/api/sieges/${siegeId}/positions/${positionId}`,
-    data,
+    data
   );
   return res.data;
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,4 +7,18 @@ const apiClient = axios.create({
   },
 });
 
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (
+      error.response?.status === 401 &&
+      !window.location.pathname.startsWith("/login") &&
+      !error.config?.url?.includes("/api/auth/me")
+    ) {
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default apiClient;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,7 +13,7 @@ apiClient.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !window.location.pathname.startsWith("/login") &&
-      !error.config?.url?.includes("/api/auth/me")
+      !error.config?.url?.includes("/api/auth/")
     ) {
       window.location.href = "/login";
     }

--- a/frontend/src/api/members.ts
+++ b/frontend/src/api/members.ts
@@ -1,8 +1,16 @@
-import apiClient from './client';
-import type { Member, PostCondition, MemberRoleInfo, SyncPreviewResponse, SyncApplyItem } from './types';
+import apiClient from "./client";
+import type {
+  Member,
+  PostCondition,
+  MemberRoleInfo,
+  SyncPreviewResponse,
+  SyncApplyItem,
+} from "./types";
 
-export async function getMembers(params?: { is_active?: boolean }): Promise<Member[]> {
-  const res = await apiClient.get<Member[]>('/api/members', { params });
+export async function getMembers(params?: {
+  is_active?: boolean;
+}): Promise<Member[]> {
+  const res = await apiClient.get<Member[]>("/api/members", { params });
   return res.data;
 }
 
@@ -17,7 +25,7 @@ export async function createMember(data: {
   role: string;
   power_level?: string | null;
 }): Promise<Member> {
-  const res = await apiClient.post<Member>('/api/members', data);
+  const res = await apiClient.post<Member>("/api/members", data);
   return res.data;
 }
 
@@ -29,7 +37,7 @@ export async function updateMember(
     role?: string;
     power_level?: string | null;
     is_active?: boolean;
-  },
+  }
 ): Promise<Member> {
   const res = await apiClient.put<Member>(`/api/members/${id}`, data);
   return res.data;
@@ -39,37 +47,51 @@ export async function deleteMember(id: number): Promise<void> {
   await apiClient.delete(`/api/members/${id}`);
 }
 
-export async function getMemberPreferences(id: number): Promise<PostCondition[]> {
-  const res = await apiClient.get<PostCondition[]>(`/api/members/${id}/preferences`);
+export async function getMemberPreferences(
+  id: number
+): Promise<PostCondition[]> {
+  const res = await apiClient.get<PostCondition[]>(
+    `/api/members/${id}/preferences`
+  );
   return res.data;
 }
 
 export async function updateMemberPreferences(
   id: number,
-  condition_ids: number[],
+  condition_ids: number[]
 ): Promise<PostCondition[]> {
-  const res = await apiClient.put<PostCondition[]>(`/api/members/${id}/preferences`, {
-    post_condition_ids: condition_ids,
-  });
+  const res = await apiClient.put<PostCondition[]>(
+    `/api/members/${id}/preferences`,
+    {
+      post_condition_ids: condition_ids,
+    }
+  );
   return res.data;
 }
 
 export async function getPostConditions(): Promise<PostCondition[]> {
-  const res = await apiClient.get<PostCondition[]>('/api/post-conditions');
+  const res = await apiClient.get<PostCondition[]>("/api/post-conditions");
   return res.data;
 }
 
 export async function getMemberRoles(): Promise<MemberRoleInfo[]> {
-  const res = await apiClient.get<MemberRoleInfo[]>('/api/members/roles');
+  const res = await apiClient.get<MemberRoleInfo[]>("/api/members/roles");
   return res.data;
 }
 
 export async function previewDiscordSync(): Promise<SyncPreviewResponse> {
-  const res = await apiClient.post<SyncPreviewResponse>('/api/members/discord-sync/preview');
+  const res = await apiClient.post<SyncPreviewResponse>(
+    "/api/members/discord-sync/preview"
+  );
   return res.data;
 }
 
-export async function applyDiscordSync(matches: SyncApplyItem[]): Promise<{ updated: number }> {
-  const res = await apiClient.post<{ updated: number }>('/api/members/discord-sync/apply', matches);
+export async function applyDiscordSync(
+  matches: SyncApplyItem[]
+): Promise<{ updated: number }> {
+  const res = await apiClient.post<{ updated: number }>(
+    "/api/members/discord-sync/apply",
+    matches
+  );
   return res.data;
 }

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,35 +1,41 @@
-import apiClient from './client';
+import apiClient from "./client";
 import type {
   NotifyResponse,
   NotificationBatchResponse,
   GenerateImagesResponse,
-} from './types';
+} from "./types";
 
-export async function notifySiegeMembers(siegeId: number): Promise<NotifyResponse> {
-  const res = await apiClient.post<NotifyResponse>(`/api/sieges/${siegeId}/notify`);
+export async function notifySiegeMembers(
+  siegeId: number
+): Promise<NotifyResponse> {
+  const res = await apiClient.post<NotifyResponse>(
+    `/api/sieges/${siegeId}/notify`
+  );
   return res.data;
 }
 
 export async function getNotificationBatch(
   siegeId: number,
-  batchId: number,
+  batchId: number
 ): Promise<NotificationBatchResponse> {
   const res = await apiClient.get<NotificationBatchResponse>(
-    `/api/sieges/${siegeId}/notify/${batchId}`,
+    `/api/sieges/${siegeId}/notify/${batchId}`
   );
   return res.data;
 }
 
 export async function postToChannel(
-  siegeId: number,
+  siegeId: number
 ): Promise<{ status: string; detail?: string }> {
   const res = await apiClient.post(`/api/sieges/${siegeId}/post-to-channel`);
   return res.data;
 }
 
-export async function generateImages(siegeId: number): Promise<GenerateImagesResponse> {
+export async function generateImages(
+  siegeId: number
+): Promise<GenerateImagesResponse> {
   const res = await apiClient.post<GenerateImagesResponse>(
-    `/api/sieges/${siegeId}/generate-images`,
+    `/api/sieges/${siegeId}/generate-images`
   );
   return res.data;
 }

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -1,5 +1,5 @@
-import apiClient from './client';
-import type { Post } from './types';
+import apiClient from "./client";
+import type { Post } from "./types";
 
 export interface PostPriorityConfig {
   id: number;
@@ -9,17 +9,17 @@ export interface PostPriorityConfig {
 }
 
 export async function getPostPriorities(): Promise<PostPriorityConfig[]> {
-  const res = await apiClient.get<PostPriorityConfig[]>('/api/post-priorities');
+  const res = await apiClient.get<PostPriorityConfig[]>("/api/post-priorities");
   return res.data;
 }
 
 export async function updatePostPriority(
   postNumber: number,
-  data: { priority?: number; description?: string | null },
+  data: { priority?: number; description?: string | null }
 ): Promise<PostPriorityConfig> {
   const res = await apiClient.put<PostPriorityConfig>(
     `/api/post-priorities/${postNumber}`,
-    data,
+    data
   );
   return res.data;
 }
@@ -32,20 +32,23 @@ export async function getPosts(siegeId: number): Promise<Post[]> {
 export async function updatePost(
   siegeId: number,
   postId: number,
-  data: { priority?: number; description?: string | null },
+  data: { priority?: number; description?: string | null }
 ): Promise<Post> {
-  const res = await apiClient.put<Post>(`/api/sieges/${siegeId}/posts/${postId}`, data);
+  const res = await apiClient.put<Post>(
+    `/api/sieges/${siegeId}/posts/${postId}`,
+    data
+  );
   return res.data;
 }
 
 export async function setPostConditions(
   siegeId: number,
   postId: number,
-  condition_ids: number[],
+  condition_ids: number[]
 ): Promise<Post> {
   const res = await apiClient.put<Post>(
     `/api/sieges/${siegeId}/posts/${postId}/conditions`,
-    { post_condition_ids: condition_ids },
+    { post_condition_ids: condition_ids }
   );
   return res.data;
 }

--- a/frontend/src/api/sieges.ts
+++ b/frontend/src/api/sieges.ts
@@ -1,4 +1,4 @@
-import apiClient from './client';
+import apiClient from "./client";
 import type {
   Siege,
   SiegeStatus,
@@ -13,10 +13,12 @@ import type {
   AttackDayPreviewResult,
   AttackDayApplyResult,
   ComparisonResult,
-} from './types';
+} from "./types";
 
-export async function getSieges(params?: { status?: SiegeStatus }): Promise<Siege[]> {
-  const res = await apiClient.get<Siege[]>('/api/sieges', { params });
+export async function getSieges(params?: {
+  status?: SiegeStatus;
+}): Promise<Siege[]> {
+  const res = await apiClient.get<Siege[]>("/api/sieges", { params });
   return res.data;
 }
 
@@ -25,16 +27,14 @@ export async function getSiege(id: number): Promise<Siege> {
   return res.data;
 }
 
-export async function createSiege(data: {
-  date?: string;
-}): Promise<Siege> {
-  const res = await apiClient.post<Siege>('/api/sieges', data);
+export async function createSiege(data: { date?: string }): Promise<Siege> {
+  const res = await apiClient.post<Siege>("/api/sieges", data);
   return res.data;
 }
 
 export async function updateSiege(
   id: number,
-  data: { date?: string | null },
+  data: { date?: string | null }
 ): Promise<Siege> {
   const res = await apiClient.put<Siege>(`/api/sieges/${id}`, data);
   return res.data;
@@ -65,65 +65,82 @@ export async function reopenSiege(id: number): Promise<Siege> {
 }
 
 export async function validateSiege(id: number): Promise<ValidationResult> {
-  const res = await apiClient.post<ValidationResult>(`/api/sieges/${id}/validate`);
+  const res = await apiClient.post<ValidationResult>(
+    `/api/sieges/${id}/validate`
+  );
   return res.data;
 }
 
 export async function getBuildings(siegeId: number): Promise<Building[]> {
-  const res = await apiClient.get<Building[]>(`/api/sieges/${siegeId}/buildings`);
+  const res = await apiClient.get<Building[]>(
+    `/api/sieges/${siegeId}/buildings`
+  );
   return res.data;
 }
 
 export async function createBuilding(
   siegeId: number,
-  data: { building_type: BuildingType; building_number: number },
+  data: { building_type: BuildingType; building_number: number }
 ): Promise<Building> {
-  const res = await apiClient.post<Building>(`/api/sieges/${siegeId}/buildings`, data);
+  const res = await apiClient.post<Building>(
+    `/api/sieges/${siegeId}/buildings`,
+    data
+  );
   return res.data;
 }
 
 export async function updateBuilding(
   siegeId: number,
   buildingId: number,
-  data: { level?: number; is_broken?: boolean },
+  data: { level?: number; is_broken?: boolean }
 ): Promise<Building> {
   const res = await apiClient.put<Building>(
     `/api/sieges/${siegeId}/buildings/${buildingId}`,
-    data,
+    data
   );
   return res.data;
 }
 
-export async function deleteBuilding(siegeId: number, buildingId: number): Promise<void> {
+export async function deleteBuilding(
+  siegeId: number,
+  buildingId: number
+): Promise<void> {
   await apiClient.delete(`/api/sieges/${siegeId}/buildings/${buildingId}`);
 }
 
 export async function getBuildingTypes(): Promise<BuildingTypeInfo[]> {
-  const res = await apiClient.get<BuildingTypeInfo[]>('/api/sieges/building-types');
+  const res = await apiClient.get<BuildingTypeInfo[]>(
+    "/api/sieges/building-types"
+  );
   return res.data;
 }
 
 export async function getSiegeMembers(siegeId: number): Promise<SiegeMember[]> {
-  const res = await apiClient.get<SiegeMember[]>(`/api/sieges/${siegeId}/members`);
+  const res = await apiClient.get<SiegeMember[]>(
+    `/api/sieges/${siegeId}/members`
+  );
   return res.data;
 }
 
 export async function getSiegeMemberPreferences(
-  siegeId: number,
+  siegeId: number
 ): Promise<MemberPreferenceSummary[]> {
   const res = await apiClient.get<MemberPreferenceSummary[]>(
-    `/api/sieges/${siegeId}/members/preferences`,
+    `/api/sieges/${siegeId}/members/preferences`
   );
   return res.data;
 }
 
 export async function addSiegeMember(
   siegeId: number,
-  memberId: number,
+  memberId: number
 ): Promise<SiegeMember> {
-  const res = await apiClient.post<SiegeMember>(`/api/sieges/${siegeId}/members`, {
-    member_id: memberId,
-  });
+  const res = await apiClient.post<SiegeMember>(
+    `/api/sieges/${siegeId}/members`,
+    {
+      member_id: memberId,
+    }
+  );
   return res.data;
 }
 
@@ -134,52 +151,66 @@ export async function updateSiegeMember(
     attack_day?: number | null;
     has_reserve_set?: boolean | null;
     attack_day_override?: boolean;
-  },
+  }
 ): Promise<SiegeMember> {
   const res = await apiClient.put<SiegeMember>(
     `/api/sieges/${siegeId}/members/${memberId}`,
-    data,
+    data
   );
   return res.data;
 }
 
-export async function previewAutofill(siegeId: number): Promise<AutofillPreviewResult> {
+export async function previewAutofill(
+  siegeId: number
+): Promise<AutofillPreviewResult> {
   const res = await apiClient.post<AutofillPreviewResult>(
-    `/api/sieges/${siegeId}/auto-fill`,
+    `/api/sieges/${siegeId}/auto-fill`
   );
   return res.data;
 }
 
-export async function applyAutofill(siegeId: number): Promise<AutofillApplyResult> {
+export async function applyAutofill(
+  siegeId: number
+): Promise<AutofillApplyResult> {
   const res = await apiClient.post<AutofillApplyResult>(
-    `/api/sieges/${siegeId}/auto-fill/apply`,
+    `/api/sieges/${siegeId}/auto-fill/apply`
   );
   return res.data;
 }
 
-export async function previewAttackDay(siegeId: number): Promise<AttackDayPreviewResult> {
+export async function previewAttackDay(
+  siegeId: number
+): Promise<AttackDayPreviewResult> {
   const res = await apiClient.post<AttackDayPreviewResult>(
-    `/api/sieges/${siegeId}/members/auto-assign-attack-day`,
+    `/api/sieges/${siegeId}/members/auto-assign-attack-day`
   );
   return res.data;
 }
 
-export async function applyAttackDay(siegeId: number): Promise<AttackDayApplyResult> {
+export async function applyAttackDay(
+  siegeId: number
+): Promise<AttackDayApplyResult> {
   const res = await apiClient.post<AttackDayApplyResult>(
-    `/api/sieges/${siegeId}/members/auto-assign-attack-day/apply`,
+    `/api/sieges/${siegeId}/members/auto-assign-attack-day/apply`
   );
   return res.data;
 }
 
-export async function compareSieges(siegeId: number): Promise<ComparisonResult> {
-  const res = await apiClient.get<ComparisonResult>(`/api/sieges/${siegeId}/compare`);
+export async function compareSieges(
+  siegeId: number
+): Promise<ComparisonResult> {
+  const res = await apiClient.get<ComparisonResult>(
+    `/api/sieges/${siegeId}/compare`
+  );
   return res.data;
 }
 
 export async function compareSiegesSpecific(
   siegeId: number,
-  otherId: number,
+  otherId: number
 ): Promise<ComparisonResult> {
-  const res = await apiClient.get<ComparisonResult>(`/api/sieges/${siegeId}/compare/${otherId}`);
+  const res = await apiClient.get<ComparisonResult>(
+    `/api/sieges/${siegeId}/compare/${otherId}`
+  );
   return res.data;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,12 +1,12 @@
 // Enums
-export type MemberRole = 'heavy_hitter' | 'advanced' | 'medium' | 'novice';
-export type SiegeStatus = 'planning' | 'active' | 'complete';
+export type MemberRole = "heavy_hitter" | "advanced" | "medium" | "novice";
+export type SiegeStatus = "planning" | "active" | "complete";
 export type BuildingType =
-  | 'stronghold'
-  | 'mana_shrine'
-  | 'magic_tower'
-  | 'defense_tower'
-  | 'post';
+  | "stronghold"
+  | "mana_shrine"
+  | "magic_tower"
+  | "defense_tower"
+  | "post";
 
 // Members
 export interface Member {
@@ -26,7 +26,7 @@ export interface SyncMatch {
   current_discord_username: string | null;
   proposed_discord_username: string;
   proposed_discord_id: string;
-  confidence: 'exact' | 'suggested' | 'ambiguous';
+  confidence: "exact" | "suggested" | "ambiguous";
 }
 
 export interface SyncPreviewResponse {
@@ -227,7 +227,7 @@ export interface NotifyResponse {
 // Images
 export interface GenerateImagesResponse {
   assignments_image: string; // base64
-  reserves_image: string;    // base64
+  reserves_image: string; // base64
 }
 
 // Version

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,15 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import apiClient from './client';
-import type { VersionInfo } from './types';
+import { useQuery } from "@tanstack/react-query";
+import apiClient from "./client";
+import type { VersionInfo } from "./types";
 
 async function getVersion(): Promise<VersionInfo> {
-  const res = await apiClient.get<VersionInfo>('/api/version');
+  const res = await apiClient.get<VersionInfo>("/api/version");
   return res.data;
 }
 
 export function useVersion() {
   return useQuery({
-    queryKey: ['version'],
+    queryKey: ["version"],
     queryFn: getVersion,
     // Version info is stable — refetch only on manual invalidation or mount.
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/components/DiscordSyncModal.tsx
+++ b/frontend/src/components/DiscordSyncModal.tsx
@@ -1,15 +1,15 @@
-import { useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
-import { RefreshCw } from 'lucide-react';
-import { previewDiscordSync, applyDiscordSync } from '../api/members';
-import type { SyncMatch, SyncApplyItem } from '../api/types';
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { RefreshCw } from "lucide-react";
+import { previewDiscordSync, applyDiscordSync } from "../api/members";
+import type { SyncMatch, SyncApplyItem } from "../api/types";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
-} from './ui/dialog';
+} from "./ui/dialog";
 import {
   Table,
   TableBody,
@@ -17,10 +17,10 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from './ui/table';
-import { Button } from './ui/button';
-import { Badge } from './ui/badge';
-import { Checkbox } from './ui/checkbox';
+} from "./ui/table";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Checkbox } from "./ui/checkbox";
 
 interface Props {
   open: boolean;
@@ -28,18 +28,18 @@ interface Props {
   onApplied: () => void;
 }
 
-type ConfidenceVariant = 'green' | 'yellow' | 'red';
+type ConfidenceVariant = "green" | "yellow" | "red";
 
-const CONFIDENCE_VARIANT: Record<SyncMatch['confidence'], ConfidenceVariant> = {
-  exact: 'green',
-  suggested: 'yellow',
-  ambiguous: 'red',
+const CONFIDENCE_VARIANT: Record<SyncMatch["confidence"], ConfidenceVariant> = {
+  exact: "green",
+  suggested: "yellow",
+  ambiguous: "red",
 };
 
-const CONFIDENCE_LABEL: Record<SyncMatch['confidence'], string> = {
-  exact: 'Exact',
-  suggested: 'Suggested',
-  ambiguous: 'Ambiguous',
+const CONFIDENCE_LABEL: Record<SyncMatch["confidence"], string> = {
+  exact: "Exact",
+  suggested: "Suggested",
+  ambiguous: "Ambiguous",
 };
 
 export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
@@ -65,24 +65,26 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
       // Default: check exact and suggested; leave ambiguous unchecked.
       const initial: Record<number, boolean> = {};
       for (const m of data.matches) {
-        initial[m.member_id] = m.confidence !== 'ambiguous';
+        initial[m.member_id] = m.confidence !== "ambiguous";
       }
       setChecked(initial);
     },
     onError: () => {
-      setErrorMessage('Failed to fetch sync preview. Is the bot reachable?');
+      setErrorMessage("Failed to fetch sync preview. Is the bot reachable?");
     },
   });
 
   const applyMutation = useMutation({
     mutationFn: (items: SyncApplyItem[]) => applyDiscordSync(items),
     onSuccess: (data) => {
-      setSuccessMessage(`Updated ${data.updated} member${data.updated !== 1 ? 's' : ''}.`);
+      setSuccessMessage(
+        `Updated ${data.updated} member${data.updated !== 1 ? "s" : ""}.`
+      );
       setErrorMessage(null);
       onApplied();
     },
     onError: () => {
-      setErrorMessage('Failed to apply sync changes.');
+      setErrorMessage("Failed to apply sync changes.");
     },
   });
 
@@ -113,7 +115,12 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
   const selectedCount = Object.values(checked).filter(Boolean).length;
 
   return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) handleClose(); }}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) handleClose();
+      }}
+    >
       <DialogContent className="max-w-3xl">
         <DialogHeader>
           <DialogTitle>Sync Discord Usernames</DialogTitle>
@@ -127,12 +134,15 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
               onClick={() => previewMutation.mutate()}
               disabled={previewMutation.isPending}
             >
-              <RefreshCw className={`h-4 w-4 ${previewMutation.isPending ? 'animate-spin' : ''}`} />
-              {previewMutation.isPending ? 'Loading...' : 'Fetch Preview'}
+              <RefreshCw
+                className={`h-4 w-4 ${previewMutation.isPending ? "animate-spin" : ""}`}
+              />
+              {previewMutation.isPending ? "Loading..." : "Fetch Preview"}
             </Button>
             {preview && (
               <span className="text-sm text-slate-500">
-                {preview.matches.length} match{preview.matches.length !== 1 ? 'es' : ''} found
+                {preview.matches.length} match
+                {preview.matches.length !== 1 ? "es" : ""} found
               </span>
             )}
           </div>
@@ -171,9 +181,13 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
                           onCheckedChange={() => toggleCheck(m.member_id)}
                         />
                       </TableCell>
-                      <TableCell className="font-medium">{m.member_name}</TableCell>
+                      <TableCell className="font-medium">
+                        {m.member_name}
+                      </TableCell>
                       <TableCell className="text-slate-500">
-                        {m.current_discord_username ?? <span className="italic text-slate-400">none</span>}
+                        {m.current_discord_username ?? (
+                          <span className="italic text-slate-400">none</span>
+                        )}
                       </TableCell>
                       <TableCell>{m.proposed_discord_username}</TableCell>
                       <TableCell>
@@ -193,20 +207,34 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
           )}
 
           {/* Unmatched counts */}
-          {preview && (preview.unmatched_guild_members.length > 0 || preview.unmatched_clan_members.length > 0) && (
-            <div className="rounded-md bg-slate-50 px-4 py-3 text-sm text-slate-600 space-y-1">
-              {preview.unmatched_guild_members.length > 0 && (
-                <div>
-                  <span className="font-medium">{preview.unmatched_guild_members.length}</span> guild member{preview.unmatched_guild_members.length !== 1 ? 's' : ''} not matched to any clan member
-                </div>
-              )}
-              {preview.unmatched_clan_members.length > 0 && (
-                <div>
-                  <span className="font-medium">{preview.unmatched_clan_members.length}</span> clan member{preview.unmatched_clan_members.length !== 1 ? 's' : ''} not matched to any guild member
-                </div>
-              )}
-            </div>
-          )}
+          {preview &&
+            (preview.unmatched_guild_members.length > 0 ||
+              preview.unmatched_clan_members.length > 0) && (
+              <div className="space-y-1 rounded-md bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                {preview.unmatched_guild_members.length > 0 && (
+                  <div>
+                    <span className="font-medium">
+                      {preview.unmatched_guild_members.length}
+                    </span>{" "}
+                    guild member
+                    {preview.unmatched_guild_members.length !== 1
+                      ? "s"
+                      : ""}{" "}
+                    not matched to any clan member
+                  </div>
+                )}
+                {preview.unmatched_clan_members.length > 0 && (
+                  <div>
+                    <span className="font-medium">
+                      {preview.unmatched_clan_members.length}
+                    </span>{" "}
+                    clan member
+                    {preview.unmatched_clan_members.length !== 1 ? "s" : ""} not
+                    matched to any guild member
+                  </div>
+                )}
+              </div>
+            )}
         </div>
 
         <DialogFooter>
@@ -218,7 +246,9 @@ export default function DiscordSyncModal({ open, onClose, onApplied }: Props) {
               onClick={handleApply}
               disabled={selectedCount === 0 || applyMutation.isPending}
             >
-              {applyMutation.isPending ? 'Applying...' : `Apply Selected (${selectedCount})`}
+              {applyMutation.isPending
+                ? "Applying..."
+                : `Apply Selected (${selectedCount})`}
             </Button>
           )}
         </DialogFooter>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,16 +1,18 @@
-import { NavLink, Outlet } from 'react-router-dom';
-import { cn } from '../lib/utils';
-import { Info, Shield } from 'lucide-react';
+import { NavLink, Outlet } from "react-router-dom";
+import { cn } from "../lib/utils";
+import { Info, LogOut, Shield } from "lucide-react";
+import { useAuth } from "../context/AuthContext";
 
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   cn(
-    'rounded-md px-3 py-2 text-sm font-medium transition-colors',
+    "rounded-md px-3 py-2 text-sm font-medium transition-colors",
     isActive
-      ? 'bg-slate-100 text-slate-900'
-      : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900',
+      ? "bg-slate-100 text-slate-900"
+      : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
   );
 
 export default function Layout() {
+  const { user, logout } = useAuth();
   return (
     <div className="min-h-screen bg-slate-50">
       <nav className="border-b border-slate-200 bg-white shadow-sm">
@@ -18,7 +20,7 @@ export default function Layout() {
           <div className="flex h-14 items-center gap-6">
             <div className="flex items-center gap-2 text-slate-900">
               <Shield className="h-5 w-5 text-violet-600" />
-              <span className="font-semibold text-sm">Siege Assignments</span>
+              <span className="text-sm font-semibold">Siege Assignments</span>
             </div>
             <div className="flex flex-1 items-center gap-1">
               <NavLink to="/sieges" className={navLinkClass}>
@@ -30,22 +32,34 @@ export default function Layout() {
               <NavLink to="/post-priorities" className={navLinkClass}>
                 Posts
               </NavLink>
-              {/* System link pushed to the far right */}
-              <div className="ml-auto">
+              {/* System link and user info pushed to the far right */}
+              <div className="ml-auto flex items-center gap-2">
                 <NavLink
                   to="/system"
                   className={({ isActive }) =>
                     cn(
-                      'flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                      "flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                       isActive
-                        ? 'bg-slate-100 text-slate-900'
-                        : 'text-slate-400 hover:bg-slate-50 hover:text-slate-600',
+                        ? "bg-slate-100 text-slate-900"
+                        : "text-slate-400 hover:bg-slate-50 hover:text-slate-600"
                     )
                   }
                 >
                   <Info className="h-3.5 w-3.5" />
                   System
                 </NavLink>
+                {user && (
+                  <>
+                    <span className="text-sm text-slate-500">{user.name}</span>
+                    <button
+                      onClick={logout}
+                      className="flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-slate-400 transition-colors hover:bg-slate-50 hover:text-slate-600"
+                      title="Sign out"
+                    >
+                      <LogOut className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -1,20 +1,31 @@
-import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ChevronDown, ChevronRight, AlertTriangle, Check, ExternalLink, BookmarkCheck } from 'lucide-react';
-import { getPosts } from '../api/posts';
-import { getSiegeMemberPreferences } from '../api/sieges';
-import { updatePosition } from '../api/board';
-import type { BuildingResponse, SiegeMember, PostConditionRef } from '../api/types';
-import { Button } from './ui/button';
+import { useState, useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  ChevronDown,
+  ChevronRight,
+  AlertTriangle,
+  Check,
+  ExternalLink,
+  BookmarkCheck,
+} from "lucide-react";
+import { getPosts } from "../api/posts";
+import { getSiegeMemberPreferences } from "../api/sieges";
+import { updatePosition } from "../api/board";
+import type {
+  BuildingResponse,
+  SiegeMember,
+  PostConditionRef,
+} from "../api/types";
+import { Button } from "./ui/button";
 
 // ─── Constants (duplicated from BoardPage to keep this file self-contained) ───
 
 const ROLE_LABELS: Record<string, string> = {
-  heavy_hitter: 'HH',
-  advanced: 'Adv',
-  medium: 'Med',
-  novice: 'Nov',
+  heavy_hitter: "HH",
+  advanced: "Adv",
+  medium: "Med",
+  novice: "Nov",
 };
 
 const ROLE_PRIORITY: Record<string, number> = {
@@ -25,32 +36,32 @@ const ROLE_PRIORITY: Record<string, number> = {
 };
 
 const ROLE_BADGE_COLORS: Record<string, string> = {
-  heavy_hitter: 'bg-red-100 text-red-700',
-  advanced: 'bg-amber-100 text-amber-700',
-  medium: 'bg-green-100 text-green-700',
-  novice: 'bg-blue-100 text-blue-700',
+  heavy_hitter: "bg-red-100 text-red-700",
+  advanced: "bg-amber-100 text-amber-700",
+  medium: "bg-green-100 text-green-700",
+  novice: "bg-blue-100 text-blue-700",
 };
 
 const POWER_LABELS: Record<string, string> = {
-  lt_10m: '<10M',
-  '10_15m': '10-15M',
-  '16_20m': '16-20M',
-  '21_25m': '21-25M',
-  gt_25m: '>25M',
+  lt_10m: "<10M",
+  "10_15m": "10-15M",
+  "16_20m": "16-20M",
+  "21_25m": "21-25M",
+  gt_25m: ">25M",
 };
 
 const PRIORITY_LABELS: Record<number, string> = {
-  0: 'Unset',
-  1: 'Low',
-  2: 'Medium',
-  3: 'High',
+  0: "Unset",
+  1: "Low",
+  2: "Medium",
+  3: "High",
 };
 
 const PRIORITY_BADGE_COLORS: Record<number, string> = {
-  0: 'bg-slate-100 text-slate-400',
-  1: 'bg-slate-100 text-slate-600',
-  2: 'bg-amber-100 text-amber-700',
-  3: 'bg-red-100 text-red-700',
+  0: "bg-slate-100 text-slate-400",
+  1: "bg-slate-100 text-slate-600",
+  2: "bg-amber-100 text-amber-700",
+  3: "bg-red-100 text-red-700",
 };
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -66,7 +77,9 @@ type DuplicateConditionMap = Map<string, number>;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function buildDuplicateConditionMap(postBuildings: BuildingResponse[]): DuplicateConditionMap {
+function buildDuplicateConditionMap(
+  postBuildings: BuildingResponse[]
+): DuplicateConditionMap {
   const map: DuplicateConditionMap = new Map();
   for (const building of postBuildings) {
     for (const group of building.groups) {
@@ -81,7 +94,9 @@ function buildDuplicateConditionMap(postBuildings: BuildingResponse[]): Duplicat
   return map;
 }
 
-function findPostPosition(building: BuildingResponse): { positionId: number } | null {
+function findPostPosition(
+  building: BuildingResponse
+): { positionId: number } | null {
   for (const group of building.groups) {
     for (const pos of group.positions) {
       if (!pos.is_disabled) {
@@ -118,12 +133,15 @@ function MemberAssignRow({
 
   // Which condition is selected for the match radio
   const [selectedConditionId, setSelectedConditionId] = useState<number | null>(
-    matchedConditions.length > 0 ? matchedConditions[0].id : null,
+    matchedConditions.length > 0 ? matchedConditions[0].id : null
   );
   const [confirmPending, setConfirmPending] = useState(false);
 
   const mutation = useMutation({
-    mutationFn: (data: { member_id: number; matched_condition_id: number | null }) =>
+    mutationFn: (data: {
+      member_id: number;
+      matched_condition_id: number | null;
+    }) =>
       updatePosition(siegeId, positionId, {
         member_id: data.member_id,
         is_reserve: false,
@@ -131,7 +149,7 @@ function MemberAssignRow({
         matched_condition_id: data.matched_condition_id,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['board', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
       setConfirmPending(false);
       onAssigned();
     },
@@ -157,7 +175,7 @@ function MemberAssignRow({
   }
 
   const role = member.member_role;
-  const badgeColor = ROLE_BADGE_COLORS[role] ?? 'bg-slate-100 text-slate-600';
+  const badgeColor = ROLE_BADGE_COLORS[role] ?? "bg-slate-100 text-slate-600";
   const powerLabel = member.member_power_level
     ? (POWER_LABELS[member.member_power_level] ?? member.member_power_level)
     : null;
@@ -180,15 +198,21 @@ function MemberAssignRow({
         {/* Member info */}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium text-slate-800">{member.member_name}</span>
-            <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${badgeColor}`}>
+            <span className="text-sm font-medium text-slate-800">
+              {member.member_name}
+            </span>
+            <span
+              className={`rounded px-1.5 py-0.5 text-xs font-medium ${badgeColor}`}
+            >
               {ROLE_LABELS[role] ?? role}
             </span>
             {powerLabel && (
               <span className="text-xs text-slate-500">{powerLabel}</span>
             )}
             {member.attack_day && (
-              <span className="text-xs text-slate-500">Day {member.attack_day}</span>
+              <span className="text-xs text-slate-500">
+                Day {member.attack_day}
+              </span>
             )}
           </div>
 
@@ -196,7 +220,10 @@ function MemberAssignRow({
           {hasConditions && matchedConditions.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-2">
               {matchedConditions.map((c) => (
-                <label key={c.id} className="flex cursor-pointer items-center gap-1.5">
+                <label
+                  key={c.id}
+                  className="flex cursor-pointer items-center gap-1.5"
+                >
                   <input
                     type="radio"
                     name={`condition-${member.member_id}-${postNumber}`}
@@ -222,7 +249,7 @@ function MemberAssignRow({
             <div className="mt-1.5 flex items-center gap-2 rounded bg-amber-50 px-2 py-1 text-xs text-amber-800">
               <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" />
               <span>
-                Already matched on "{selectedCondition.description}" at Post{' '}
+                Already matched on "{selectedCondition.description}" at Post{" "}
                 {duplicatePostNumber}
               </span>
             </div>
@@ -259,7 +286,7 @@ function MemberAssignRow({
                 onClick={handleAssignClick}
                 disabled={mutation.isPending}
               >
-                {mutation.isPending ? 'Assigning...' : 'Assign'}
+                {mutation.isPending ? "Assigning..." : "Assign"}
               </Button>
             )}
           </div>
@@ -311,9 +338,11 @@ function PostRow({
   const matchedCondition = useMemo(
     () =>
       !isReserve && assignedPosition?.matched_condition_id
-        ? (activeConditions.find((c) => c.id === assignedPosition.matched_condition_id) ?? null)
+        ? (activeConditions.find(
+            (c) => c.id === assignedPosition.matched_condition_id
+          ) ?? null)
         : null,
-    [isReserve, assignedPosition?.matched_condition_id, activeConditions],
+    [isReserve, assignedPosition?.matched_condition_id, activeConditions]
   );
 
   const reserveMutation = useMutation({
@@ -325,7 +354,7 @@ function PostRow({
         matched_condition_id: null,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['board', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
     },
   });
 
@@ -339,7 +368,9 @@ function PostRow({
     for (const member of siegeMembers) {
       const memberCondIds = preferenceMap.get(member.member_id) ?? [];
       if (hasConditions) {
-        const matchedConditions = activeConditions.filter((c) => memberCondIds.includes(c.id));
+        const matchedConditions = activeConditions.filter((c) =>
+          memberCondIds.includes(c.id)
+        );
         if (matchedConditions.length > 0) {
           matchedList.push({
             member,
@@ -378,7 +409,8 @@ function PostRow({
   }, [siegeMembers, preferenceMap, activeConditions, hasConditions]);
 
   const priorityLabel = PRIORITY_LABELS[priority] ?? String(priority);
-  const priorityBadgeColor = PRIORITY_BADGE_COLORS[priority] ?? 'bg-slate-100 text-slate-600';
+  const priorityBadgeColor =
+    PRIORITY_BADGE_COLORS[priority] ?? "bg-slate-100 text-slate-600";
 
   return (
     <div className="rounded border border-slate-200 bg-white">
@@ -401,7 +433,9 @@ function PostRow({
         </span>
 
         {/* Priority badge */}
-        <span className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${priorityBadgeColor}`}>
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${priorityBadgeColor}`}
+        >
           {priorityLabel}
         </span>
 
@@ -416,7 +450,8 @@ function PostRow({
         {/* Condition count */}
         {activeConditions.length > 0 ? (
           <span className="shrink-0 rounded bg-violet-100 px-1.5 py-0.5 text-xs font-medium text-violet-700">
-            {activeConditions.length} {activeConditions.length === 1 ? 'condition' : 'conditions'}
+            {activeConditions.length}{" "}
+            {activeConditions.length === 1 ? "condition" : "conditions"}
           </span>
         ) : (
           <span className="shrink-0 text-xs text-slate-400">No conditions</span>
@@ -439,10 +474,12 @@ function PostRow({
           <span className="ml-2 shrink-0">
             <span
               className={`text-sm ${
-                assignedMemberName ? 'font-medium text-slate-800' : 'text-slate-400'
+                assignedMemberName
+                  ? "font-medium text-slate-800"
+                  : "text-slate-400"
               }`}
             >
-              {assignedMemberName ?? 'Unassigned'}
+              {assignedMemberName ?? "Unassigned"}
             </span>
           </span>
         )}
@@ -481,7 +518,9 @@ function PostRow({
           </div>
 
           {positionId == null ? (
-            <p className="text-sm text-slate-400">No active position for this post.</p>
+            <p className="text-sm text-slate-400">
+              No active position for this post.
+            </p>
           ) : (
             <>
               {/* Mark RESERVE action */}
@@ -495,7 +534,11 @@ function PostRow({
                     disabled={reserveMutation.isPending || isReserve}
                   >
                     <BookmarkCheck className="h-3.5 w-3.5" />
-                    {isReserve ? 'Marked RESERVE' : reserveMutation.isPending ? 'Saving...' : 'Mark RESERVE'}
+                    {isReserve
+                      ? "Marked RESERVE"
+                      : reserveMutation.isPending
+                        ? "Saving..."
+                        : "Mark RESERVE"}
                   </Button>
                   {isReserve && (
                     <span className="text-xs text-slate-400">
@@ -555,7 +598,9 @@ function PostRow({
               )}
 
               {matched.length === 0 && unmatched.length === 0 && (
-                <p className="text-sm text-slate-400">No members in this siege.</p>
+                <p className="text-sm text-slate-400">
+                  No members in this siege.
+                </p>
               )}
             </>
           )}
@@ -580,12 +625,16 @@ export function PostsTab({
   memberRoleMap?: Record<number, string>; // accepted for API compatibility, used by callers
 }) {
   const { data: preferences, isLoading: prefLoading } = useQuery({
-    queryKey: ['memberPreferences', siegeId],
+    queryKey: ["memberPreferences", siegeId],
     queryFn: () => getSiegeMemberPreferences(siegeId),
   });
 
-  const { data: posts, isLoading: postsLoading, isError: postsError } = useQuery({
-    queryKey: ['posts', siegeId],
+  const {
+    data: posts,
+    isLoading: postsLoading,
+    isError: postsError,
+  } = useQuery({
+    queryKey: ["posts", siegeId],
     queryFn: () => getPosts(siegeId),
   });
 
@@ -595,7 +644,7 @@ export function PostsTab({
     for (const p of preferences ?? []) {
       map.set(
         p.member_id,
-        p.preferences.map((c) => c.id),
+        p.preferences.map((c) => c.id)
       );
     }
     return map;
@@ -603,13 +652,13 @@ export function PostsTab({
 
   // Build duplicate condition map from post buildings
   const postBuildings = useMemo(
-    () => buildings.filter((b) => b.building_type === 'post'),
-    [buildings],
+    () => buildings.filter((b) => b.building_type === "post"),
+    [buildings]
   );
 
   const duplicateMap = useMemo(
     () => buildDuplicateConditionMap(postBuildings),
-    [postBuildings],
+    [postBuildings]
   );
 
   // Build a map from building_number → Post (for priority/description/conditions)
@@ -624,12 +673,17 @@ export function PostsTab({
 
   // Sort post buildings by building_number
   const sortedPostBuildings = useMemo(
-    () => [...postBuildings].sort((a, b) => a.building_number - b.building_number),
-    [postBuildings],
+    () =>
+      [...postBuildings].sort((a, b) => a.building_number - b.building_number),
+    [postBuildings]
   );
 
   if (prefLoading || postsLoading) {
-    return <div className="py-12 text-center text-sm text-slate-500">Loading posts...</div>;
+    return (
+      <div className="py-12 text-center text-sm text-slate-500">
+        Loading posts...
+      </div>
+    );
   }
 
   if (postsError) {
@@ -643,10 +697,13 @@ export function PostsTab({
   if (sortedPostBuildings.length === 0) {
     return (
       <div className="py-12 text-center text-slate-500">
-        No posts configured.{' '}
-        <Link to={`/sieges/${siegeId}`} className="text-violet-600 hover:underline">
+        No posts configured.{" "}
+        <Link
+          to={`/sieges/${siegeId}`}
+          className="text-violet-600 hover:underline"
+        >
           Add buildings
-        </Link>{' '}
+        </Link>{" "}
         in siege settings.
       </div>
     );

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,24 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function RequireAuth({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-sm text-slate-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/SiegeLayout.tsx
+++ b/frontend/src/components/SiegeLayout.tsx
@@ -1,7 +1,14 @@
-import { useParams, Outlet, Link, useLocation } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { getSiege } from '../api/sieges';
-import { Lock, LayoutGrid, MessageSquare, Users, GitCompare, Settings } from 'lucide-react';
+import { useParams, Outlet, Link, useLocation } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getSiege } from "../api/sieges";
+import {
+  Lock,
+  LayoutGrid,
+  MessageSquare,
+  Users,
+  GitCompare,
+  Settings,
+} from "lucide-react";
 
 export default function SiegeLayout() {
   const { id } = useParams<{ id: string }>();
@@ -9,23 +16,46 @@ export default function SiegeLayout() {
   const location = useLocation();
 
   const { data: siege } = useQuery({
-    queryKey: ['siege', siegeId],
+    queryKey: ["siege", siegeId],
     queryFn: () => getSiege(siegeId),
     enabled: Boolean(siegeId),
   });
 
   const tabs = [
-    { label: 'Board', icon: <LayoutGrid className="h-4 w-4" />, to: `/sieges/${siegeId}/board` },
-    { label: 'Posts', icon: <MessageSquare className="h-4 w-4" />, to: `/sieges/${siegeId}/posts` },
-    { label: 'Members', icon: <Users className="h-4 w-4" />, to: `/sieges/${siegeId}/members` },
-    { label: 'Compare', icon: <GitCompare className="h-4 w-4" />, to: `/sieges/${siegeId}/compare` },
-    { label: 'Settings', icon: <Settings className="h-4 w-4" />, to: `/sieges/${siegeId}` },
+    {
+      label: "Board",
+      icon: <LayoutGrid className="h-4 w-4" />,
+      to: `/sieges/${siegeId}/board`,
+    },
+    {
+      label: "Posts",
+      icon: <MessageSquare className="h-4 w-4" />,
+      to: `/sieges/${siegeId}/posts`,
+    },
+    {
+      label: "Members",
+      icon: <Users className="h-4 w-4" />,
+      to: `/sieges/${siegeId}/members`,
+    },
+    {
+      label: "Compare",
+      icon: <GitCompare className="h-4 w-4" />,
+      to: `/sieges/${siegeId}/compare`,
+    },
+    {
+      label: "Settings",
+      icon: <Settings className="h-4 w-4" />,
+      to: `/sieges/${siegeId}`,
+    },
   ];
 
   // Determine active tab: Settings matches exactly; others match by path prefix.
   function isActive(to: string): boolean {
     if (to === `/sieges/${siegeId}`) {
-      return location.pathname === `/sieges/${siegeId}` || location.pathname === `/sieges/${siegeId}/`;
+      return (
+        location.pathname === `/sieges/${siegeId}` ||
+        location.pathname === `/sieges/${siegeId}/`
+      );
     }
     return location.pathname.startsWith(to);
   }
@@ -34,7 +64,7 @@ export default function SiegeLayout() {
     <>
       {/* ── Tab navigation ── */}
       <div className="-mx-4 mb-4 border-b border-slate-200 bg-slate-50 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
-        {siege?.status === 'complete' && (
+        {siege?.status === "complete" && (
           <div className="flex items-center gap-2 py-2 text-sm font-medium text-red-700">
             <Lock className="h-4 w-4 shrink-0" />
             This siege is locked — no changes allowed
@@ -47,8 +77,8 @@ export default function SiegeLayout() {
               to={tab.to}
               className={`flex items-center gap-1.5 border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
                 isActive(tab.to)
-                  ? 'border-violet-600 text-violet-700'
-                  : 'border-transparent text-slate-500 hover:text-slate-700'
+                  ? "border-violet-600 text-violet-700"
+                  : "border-transparent text-slate-500 hover:text-slate-700"
               }`}
             >
               {tab.icon}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,37 +1,40 @@
-import * as React from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2',
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-slate-900 text-white',
-        secondary: 'border-transparent bg-slate-100 text-slate-900',
-        destructive: 'border-transparent bg-red-600 text-white',
-        outline: 'text-slate-900 border-slate-300',
-        red: 'border-transparent bg-red-100 text-red-800',
-        orange: 'border-transparent bg-orange-100 text-orange-800',
-        blue: 'border-transparent bg-blue-100 text-blue-800',
-        green: 'border-transparent bg-green-100 text-green-800',
-        gray: 'border-transparent bg-slate-100 text-slate-600',
-        yellow: 'border-transparent bg-yellow-100 text-yellow-800',
-        purple: 'border-transparent bg-purple-100 text-purple-800',
+        default: "border-transparent bg-slate-900 text-white",
+        secondary: "border-transparent bg-slate-100 text-slate-900",
+        destructive: "border-transparent bg-red-600 text-white",
+        outline: "text-slate-900 border-slate-300",
+        red: "border-transparent bg-red-100 text-red-800",
+        orange: "border-transparent bg-orange-100 text-orange-800",
+        blue: "border-transparent bg-blue-100 text-blue-800",
+        green: "border-transparent bg-green-100 text-green-800",
+        gray: "border-transparent bg-slate-100 text-slate-600",
+        yellow: "border-transparent bg-yellow-100 text-yellow-800",
+        purple: "border-transparent bg-purple-100 text-purple-800",
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: "default",
     },
-  },
+  }
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
 export { Badge, badgeVariants };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,46 +1,48 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
-import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: 'bg-slate-900 text-white hover:bg-slate-800 focus-visible:ring-slate-900',
+        default:
+          "bg-slate-900 text-white hover:bg-slate-800 focus-visible:ring-slate-900",
         destructive:
-          'bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600',
+          "bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600",
         outline:
-          'border border-slate-300 bg-white hover:bg-slate-50 text-slate-900 focus-visible:ring-slate-400',
+          "border border-slate-300 bg-white hover:bg-slate-50 text-slate-900 focus-visible:ring-slate-400",
         secondary:
-          'bg-slate-100 text-slate-900 hover:bg-slate-200 focus-visible:ring-slate-400',
-        ghost: 'hover:bg-slate-100 text-slate-900 focus-visible:ring-slate-400',
-        link: 'text-slate-900 underline-offset-4 hover:underline focus-visible:ring-slate-400',
+          "bg-slate-100 text-slate-900 hover:bg-slate-200 focus-visible:ring-slate-400",
+        ghost: "hover:bg-slate-100 text-slate-900 focus-visible:ring-slate-400",
+        link: "text-slate-900 underline-offset-4 hover:underline focus-visible:ring-slate-400",
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
-        icon: 'h-9 w-9',
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
-  },
+  }
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
@@ -48,8 +50,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       />
     );
-  },
+  }
 );
-Button.displayName = 'Button';
+Button.displayName = "Button";
 
 export { Button, buttonVariants };

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
-import { Check } from 'lucide-react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+import { cn } from "../../lib/utils";
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
@@ -10,12 +10,14 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-slate-300 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=checked]:text-white data-[state=checked]:border-slate-900',
-      className,
+      "peer h-4 w-4 shrink-0 rounded-sm border border-slate-300 shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-slate-900 data-[state=checked]:bg-slate-900 data-[state=checked]:text-white",
+      className
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
 
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
@@ -15,8 +15,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className,
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60",
+      className
     )}
     {...props}
   />
@@ -32,8 +32,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 bg-white p-6 shadow-xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
-        className,
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg bg-white p-6 shadow-xl duration-200",
+        className
       )}
       {...props}
     >
@@ -47,28 +47,37 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
-      {...props}
-    />
-  );
-}
-DialogHeader.displayName = 'DialogHeader';
-
-function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+function DialogHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
-        className,
+        "flex flex-col space-y-1.5 text-center sm:text-left",
+        className
       )}
       {...props}
     />
   );
 }
-DialogFooter.displayName = 'DialogFooter';
+DialogHeader.displayName = "DialogHeader";
+
+function DialogFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -76,7 +85,10 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
     {...props}
   />
 ));
@@ -88,7 +100,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-slate-500', className)}
+    className={cn("text-sm text-slate-500", className)}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import { cn } from "../../lib/utils";
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
@@ -9,15 +9,15 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-md border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50',
-          className,
+          "flex h-9 w-full rounded-md border border-slate-300 bg-white px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+          className
         )}
         ref={ref}
         {...props}
       />
     );
-  },
+  }
 );
-Input.displayName = 'Input';
+Input.displayName = "Input";
 
 export { Input };

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import * as LabelPrimitive from '@radix-ui/react-label';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "../../lib/utils";
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
@@ -9,8 +9,8 @@ const Label = React.forwardRef<
   <LabelPrimitive.Root
     ref={ref}
     className={cn(
-      'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
-      className,
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
     )}
     {...props}
   />

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import * as SelectPrimitive from '@radix-ui/react-select';
-import { Check, ChevronDown, ChevronUp } from 'lucide-react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "../../lib/utils";
 
 const Select = SelectPrimitive.Root;
 const SelectGroup = SelectPrimitive.Group;
@@ -14,8 +14,8 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
-      className,
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
     )}
     {...props}
   >
@@ -33,7 +33,10 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
@@ -47,26 +50,30 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
+>(({ className, children, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-900 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className,
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-900 shadow-md",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
       )}
       position={position}
       {...props}
@@ -74,9 +81,9 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
-          position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}
@@ -93,7 +100,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
   />
 ));
@@ -106,8 +113,8 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className,
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
     )}
     {...props}
   >
@@ -127,7 +134,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-slate-100', className)}
+    className={cn("-mx-1 my-1 h-px bg-slate-100", className)}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,34 +1,39 @@
-import * as React from 'react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import { cn } from "../../lib/utils";
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table
-        ref={ref}
-        className={cn('w-full caption-bottom text-sm', className)}
-        {...props}
-      />
-    </div>
-  ),
-);
-Table.displayName = 'Table';
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
 ));
-TableHeader.displayName = 'TableHeader';
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
 ));
-TableBody.displayName = 'TableBody';
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -36,11 +41,14 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn('border-t bg-slate-50 font-medium [&>tr]:last:border-b-0', className)}
+    className={cn(
+      "border-t bg-slate-50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
     {...props}
   />
 ));
-TableFooter.displayName = 'TableFooter';
+TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
@@ -49,13 +57,13 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b transition-colors hover:bg-slate-50 data-[state=selected]:bg-slate-100',
-      className,
+      "border-b transition-colors hover:bg-slate-50 data-[state=selected]:bg-slate-100",
+      className
     )}
     {...props}
   />
 ));
-TableRow.displayName = 'TableRow';
+TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -64,13 +72,13 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 px-4 text-left align-middle font-medium text-slate-500 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
-      className,
+      "h-10 px-4 text-left align-middle font-medium text-slate-500 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
     )}
     {...props}
   />
 ));
-TableHead.displayName = 'TableHead';
+TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -79,13 +87,13 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      'p-4 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
-      className,
+      "p-4 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
     )}
     {...props}
   />
 ));
-TableCell.displayName = 'TableCell';
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -93,11 +101,11 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn('mt-4 text-sm text-slate-500', className)}
+    className={cn("mt-4 text-sm text-slate-500", className)}
     {...props}
   />
 ));
-TableCaption.displayName = 'TableCaption';
+TableCaption.displayName = "TableCaption";
 
 export {
   Table,

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { cn } from '../../lib/utils';
+import * as React from "react";
+import { cn } from "../../lib/utils";
 
 export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
@@ -8,15 +8,15 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[60px] w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50',
-          className,
+          "flex min-h-[60px] w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+          className
         )}
         ref={ref}
         {...props}
       />
     );
-  },
+  }
 );
-Textarea.displayName = 'Textarea';
+Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -48,7 +48,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     await apiClient.post("/api/auth/logout");
-    setUser(null);
     window.location.href = "/login";
   }, []);
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,70 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+import apiClient from "../api/client";
+
+interface AuthUser {
+  member_id: number | null;
+  name: string;
+  role: string | null;
+  discord_id: string | null;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient
+      .get("/api/auth/me")
+      .then((res) => {
+        if (!cancelled) setUser(res.data);
+      })
+      .catch(() => {
+        if (!cancelled) setUser(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const logout = useCallback(async () => {
+    await apiClient.post("/api/auth/logout");
+    setUser(null);
+    window.location.href = "/login";
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{ user, isAuthenticated: user !== null, isLoading, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/lib/buildingColors.ts
+++ b/frontend/src/lib/buildingColors.ts
@@ -1,4 +1,4 @@
-import type { BuildingType } from '../api/types';
+import type { BuildingType } from "../api/types";
 
 export type BuildingColorClass = {
   header: string;
@@ -10,46 +10,46 @@ export type BuildingColorClass = {
 
 export const BUILDING_COLORS: Record<BuildingType, BuildingColorClass> = {
   stronghold: {
-    header: 'bg-red-600',
-    headerText: 'text-red-700',
-    border: 'border-red-200',
-    bg: 'bg-red-50',
-    sectionHeader: 'bg-red-50 border-red-200 text-red-800',
+    header: "bg-red-600",
+    headerText: "text-red-700",
+    border: "border-red-200",
+    bg: "bg-red-50",
+    sectionHeader: "bg-red-50 border-red-200 text-red-800",
   },
   mana_shrine: {
-    header: 'bg-amber-500',
-    headerText: 'text-amber-700',
-    border: 'border-amber-200',
-    bg: 'bg-amber-50',
-    sectionHeader: 'bg-amber-50 border-amber-200 text-amber-800',
+    header: "bg-amber-500",
+    headerText: "text-amber-700",
+    border: "border-amber-200",
+    bg: "bg-amber-50",
+    sectionHeader: "bg-amber-50 border-amber-200 text-amber-800",
   },
   magic_tower: {
-    header: 'bg-blue-600',
-    headerText: 'text-blue-700',
-    border: 'border-blue-200',
-    bg: 'bg-blue-50',
-    sectionHeader: 'bg-blue-50 border-blue-200 text-blue-800',
+    header: "bg-blue-600",
+    headerText: "text-blue-700",
+    border: "border-blue-200",
+    bg: "bg-blue-50",
+    sectionHeader: "bg-blue-50 border-blue-200 text-blue-800",
   },
   defense_tower: {
-    header: 'bg-green-600',
-    headerText: 'text-green-700',
-    border: 'border-green-200',
-    bg: 'bg-green-50',
-    sectionHeader: 'bg-green-50 border-green-200 text-green-800',
+    header: "bg-green-600",
+    headerText: "text-green-700",
+    border: "border-green-200",
+    bg: "bg-green-50",
+    sectionHeader: "bg-green-50 border-green-200 text-green-800",
   },
   post: {
-    header: 'bg-slate-500',
-    headerText: 'text-slate-700',
-    border: 'border-slate-200',
-    bg: 'bg-slate-50',
-    sectionHeader: 'bg-slate-50 border-slate-200 text-slate-800',
+    header: "bg-slate-500",
+    headerText: "text-slate-700",
+    border: "border-slate-200",
+    bg: "bg-slate-50",
+    sectionHeader: "bg-slate-50 border-slate-200 text-slate-800",
   },
 };
 
 export const BUILDING_LABELS: Record<BuildingType, string> = {
-  stronghold: 'Stronghold',
-  mana_shrine: 'Mana Shrine',
-  magic_tower: 'Magic Tower',
-  defense_tower: 'Defense Tower',
-  post: 'Post',
+  stronghold: "Stronghold",
+  mana_shrine: "Mana Shrine",
+  magic_tower: "Magic Tower",
+  defense_tower: "Defense Tower",
+  post: "Post",
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,15 +4,18 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import App from "./App.tsx";
+import { AuthProvider } from "./context/AuthContext";
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </QueryClientProvider>
+    </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo, type ReactNode } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useMemo, type ReactNode } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
   DragOverlay,
@@ -11,12 +11,18 @@ import {
   useSensors,
   type DragEndEvent,
   type DragStartEvent,
-} from '@dnd-kit/core';
-import { CSS } from '@dnd-kit/utilities';
-import { getBoard, updatePosition } from '../api/board';
-import { getSiege, getSiegeMembers, previewAutofill, applyAutofill, validateSiege } from '../api/sieges';
-import { getPostPriorities } from '../api/posts';
-import { PostsTab } from '../components/PostsTab';
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { getBoard, updatePosition } from "../api/board";
+import {
+  getSiege,
+  getSiegeMembers,
+  previewAutofill,
+  applyAutofill,
+  validateSiege,
+} from "../api/sieges";
+import { getPostPriorities } from "../api/posts";
+import { PostsTab } from "../components/PostsTab";
 import type {
   BuildingType,
   BuildingResponse,
@@ -25,10 +31,10 @@ import type {
   SiegeMember,
   AutofillPreviewResult,
   ValidationResult,
-} from '../api/types';
-import { Button } from '../components/ui/button';
-import { Badge } from '../components/ui/badge';
-import { Input } from '../components/ui/input';
+} from "../api/types";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
+import { Input } from "../components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -36,7 +42,7 @@ import {
   DialogTitle,
   DialogFooter,
   DialogDescription,
-} from '../components/ui/dialog';
+} from "../components/ui/dialog";
 import {
   ArrowLeft,
   ChevronDown,
@@ -44,16 +50,16 @@ import {
   LayoutGrid,
   MessageSquare,
   Search,
-} from 'lucide-react';
-import { BUILDING_COLORS, BUILDING_LABELS } from '../lib/buildingColors';
+} from "lucide-react";
+import { BUILDING_COLORS, BUILDING_LABELS } from "../lib/buildingColors";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const ROLE_LABELS: Record<string, string> = {
-  heavy_hitter: 'HH',
-  advanced: 'Adv',
-  medium: 'Med',
-  novice: 'Nov',
+  heavy_hitter: "HH",
+  advanced: "Adv",
+  medium: "Med",
+  novice: "Nov",
 };
 
 const ROLE_PRIORITY: Record<string, number> = {
@@ -64,41 +70,41 @@ const ROLE_PRIORITY: Record<string, number> = {
 };
 
 const ROLE_COLORS: Record<string, string> = {
-  heavy_hitter: 'border-red-500 bg-red-50',
-  advanced: 'border-amber-500 bg-amber-50',
-  medium: 'border-green-500 bg-green-50',
-  novice: 'border-blue-400 bg-blue-50',
+  heavy_hitter: "border-red-500 bg-red-50",
+  advanced: "border-amber-500 bg-amber-50",
+  medium: "border-green-500 bg-green-50",
+  novice: "border-blue-400 bg-blue-50",
 };
 
 const ROLE_BADGE_COLORS: Record<string, string> = {
-  heavy_hitter: 'bg-red-100 text-red-700',
-  advanced: 'bg-amber-100 text-amber-700',
-  medium: 'bg-green-100 text-green-700',
-  novice: 'bg-blue-100 text-blue-700',
+  heavy_hitter: "bg-red-100 text-red-700",
+  advanced: "bg-amber-100 text-amber-700",
+  medium: "bg-green-100 text-green-700",
+  novice: "bg-blue-100 text-blue-700",
 };
 
 // Role-colored chip for member name inside a position cell
 const ROLE_CHIP_COLORS: Record<string, string> = {
-  heavy_hitter: 'bg-red-100 text-red-800',
-  advanced: 'bg-amber-100 text-amber-800',
-  medium: 'bg-green-100 text-green-800',
-  novice: 'bg-blue-100 text-blue-800',
+  heavy_hitter: "bg-red-100 text-red-800",
+  advanced: "bg-amber-100 text-amber-800",
+  medium: "bg-green-100 text-green-800",
+  novice: "bg-blue-100 text-blue-800",
 };
 
 const POWER_LABELS: Record<string, string> = {
-  lt_10m: '<10M',
-  '10_15m': '10-15M',
-  '16_20m': '16-20M',
-  '21_25m': '21-25M',
-  gt_25m: '>25M',
+  lt_10m: "<10M",
+  "10_15m": "10-15M",
+  "16_20m": "16-20M",
+  "21_25m": "21-25M",
+  gt_25m: ">25M",
 };
 
 // Canonical sort order for building sections
 const BUILDING_TYPE_ORDER: BuildingType[] = [
-  'stronghold',
-  'mana_shrine',
-  'magic_tower',
-  'defense_tower',
+  "stronghold",
+  "mana_shrine",
+  "magic_tower",
+  "defense_tower",
 ];
 
 // ─── PositionCell ──────────────────────────────────────────────────────────────
@@ -132,28 +138,39 @@ function PositionCell({
       has_no_assignment?: boolean;
     }) => updatePosition(siegeId, position.id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['board', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
       onUpdate();
       setMenuOpen(false);
     },
   });
 
-  const role = position.member_id != null ? memberRoleMap[position.member_id] : undefined;
-  const chipColor = role ? ROLE_CHIP_COLORS[role] ?? 'bg-slate-100 text-slate-700' : '';
+  const role =
+    position.member_id != null ? memberRoleMap[position.member_id] : undefined;
+  const chipColor = role
+    ? (ROLE_CHIP_COLORS[role] ?? "bg-slate-100 text-slate-700")
+    : "";
 
   function cellContent() {
     if (position.is_disabled) {
-      return <span className="text-xs text-slate-400 line-through">DISABLED</span>;
+      return (
+        <span className="text-xs text-slate-400 line-through">DISABLED</span>
+      );
     }
     if (position.is_reserve) {
-      return <Badge variant="yellow" className="text-xs px-1 py-0">RESERVE</Badge>;
+      return (
+        <Badge variant="yellow" className="px-1 py-0 text-xs">
+          RESERVE
+        </Badge>
+      );
     }
     if (position.has_no_assignment) {
       return <span className="text-xs text-slate-400">N/A</span>;
     }
     if (position.member_id != null) {
       return (
-        <span className={`truncate rounded px-1 text-xs font-medium ${chipColor}`}>
+        <span
+          className={`truncate rounded px-1 text-xs font-medium ${chipColor}`}
+        >
           {position.member_name}
         </span>
       );
@@ -161,15 +178,15 @@ function PositionCell({
     return <span className="text-xs text-slate-300">—</span>;
   }
 
-  const cellBg = position.is_disabled ? 'bg-slate-100' : 'bg-white';
+  const cellBg = position.is_disabled ? "bg-slate-100" : "bg-white";
 
   const borderStyle = isOver
-    ? 'border-violet-400 ring-2 ring-violet-400'
+    ? "border-violet-400 ring-2 ring-violet-400"
     : position.is_disabled
-      ? 'border-slate-200'
+      ? "border-slate-200"
       : position.member_id != null
-        ? 'border-slate-200'
-        : 'border-dashed border-slate-200';
+        ? "border-slate-200"
+        : "border-dashed border-slate-200";
 
   return (
     <>
@@ -177,8 +194,12 @@ function PositionCell({
         ref={setNodeRef}
         className={`group relative flex min-h-[28px] items-center justify-between rounded border px-1.5 py-0.5 ${cellBg} ${borderStyle} cursor-default`}
       >
-        <span className="mr-1 shrink-0 text-xs text-slate-400">{position.position_number}.</span>
-        <div className="flex min-w-0 flex-1 items-center overflow-hidden">{cellContent()}</div>
+        <span className="mr-1 shrink-0 text-xs text-slate-400">
+          {position.position_number}.
+        </span>
+        <div className="flex min-w-0 flex-1 items-center overflow-hidden">
+          {cellContent()}
+        </div>
         {!position.is_disabled && !isLocked && (
           <button
             className="ml-0.5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
@@ -194,14 +215,20 @@ function PositionCell({
           <DialogHeader>
             <DialogTitle>Position {position.position_number}</DialogTitle>
             <DialogDescription>
-              {position.member_name ?? 'Unassigned'}
+              {position.member_name ?? "Unassigned"}
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-2">
             <Button
               variant="outline"
               size="sm"
-              onClick={() => mutation.mutate({ is_reserve: true, has_no_assignment: false, member_id: null })}
+              onClick={() =>
+                mutation.mutate({
+                  is_reserve: true,
+                  has_no_assignment: false,
+                  member_id: null,
+                })
+              }
               disabled={mutation.isPending}
             >
               Mark RESERVE
@@ -209,7 +236,13 @@ function PositionCell({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => mutation.mutate({ has_no_assignment: true, is_reserve: false, member_id: null })}
+              onClick={() =>
+                mutation.mutate({
+                  has_no_assignment: true,
+                  is_reserve: false,
+                  member_id: null,
+                })
+              }
               disabled={mutation.isPending}
             >
               Mark No Assignment
@@ -217,7 +250,13 @@ function PositionCell({
             <Button
               variant="outline"
               size="sm"
-              onClick={() => mutation.mutate({ member_id: null, is_reserve: false, has_no_assignment: false })}
+              onClick={() =>
+                mutation.mutate({
+                  member_id: null,
+                  is_reserve: false,
+                  has_no_assignment: false,
+                })
+              }
               disabled={mutation.isPending}
             >
               Clear
@@ -242,16 +281,21 @@ function DraggableMemberRow({
   scrollLimit: number;
   isLocked: boolean;
 }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
-    id: `member-${member.member_id}`,
-    disabled: isLocked,
-  });
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: `member-${member.member_id}`,
+      disabled: isLocked,
+    });
 
-  const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined;
 
   const overLimit = scrollLimit > 0 && count > scrollLimit;
-  const roleColor = ROLE_COLORS[member.member_role] ?? 'border-slate-300 bg-white';
-  const badgeColor = ROLE_BADGE_COLORS[member.member_role] ?? 'bg-slate-100 text-slate-600';
+  const roleColor =
+    ROLE_COLORS[member.member_role] ?? "border-slate-300 bg-white";
+  const badgeColor =
+    ROLE_BADGE_COLORS[member.member_role] ?? "bg-slate-100 text-slate-600";
   const tooltip = [
     member.member_power_level
       ? (POWER_LABELS[member.member_power_level] ?? member.member_power_level)
@@ -259,28 +303,30 @@ function DraggableMemberRow({
     member.attack_day ? `Day ${member.attack_day}` : null,
   ]
     .filter(Boolean)
-    .join(' · ');
+    .join(" · ");
 
   return (
     <div
       ref={setNodeRef}
       style={style}
       title={tooltip || undefined}
-      className={`flex items-center gap-1.5 border-l-4 px-2 py-1.5 ${overLimit ? 'bg-red-50 border-red-300' : roleColor} ${
-        isDragging ? 'opacity-40' : ''
-      } ${!isLocked ? 'cursor-grab active:cursor-grabbing' : ''}`}
+      className={`flex items-center gap-1.5 border-l-4 px-2 py-1.5 ${overLimit ? "border-red-300 bg-red-50" : roleColor} ${
+        isDragging ? "opacity-40" : ""
+      } ${!isLocked ? "cursor-grab active:cursor-grabbing" : ""}`}
       {...listeners}
       {...attributes}
     >
       <span className="min-w-0 flex-1 truncate text-xs font-medium text-slate-800">
         {member.member_name}
       </span>
-      <span className={`shrink-0 rounded px-1 py-0.5 text-xs font-medium ${badgeColor}`}>
+      <span
+        className={`shrink-0 rounded px-1 py-0.5 text-xs font-medium ${badgeColor}`}
+      >
         {ROLE_LABELS[member.member_role] ?? member.member_role}
       </span>
       <span
         className={`shrink-0 rounded-full px-1.5 py-0 text-xs font-semibold tabular-nums ${
-          overLimit ? 'bg-red-100 text-red-700' : 'bg-slate-100 text-slate-600'
+          overLimit ? "bg-red-100 text-red-700" : "bg-slate-100 text-slate-600"
         }`}
       >
         {count}
@@ -293,18 +339,22 @@ function DraggableMemberRow({
 // Floating chip rendered by DragOverlay while a member is being dragged.
 
 function MemberDragOverlay({ member }: { member: SiegeMember }) {
-  const roleColor = ROLE_COLORS[member.member_role] ?? 'border-slate-300 bg-white';
-  const badgeColor = ROLE_BADGE_COLORS[member.member_role] ?? 'bg-slate-100 text-slate-600';
+  const roleColor =
+    ROLE_COLORS[member.member_role] ?? "border-slate-300 bg-white";
+  const badgeColor =
+    ROLE_BADGE_COLORS[member.member_role] ?? "bg-slate-100 text-slate-600";
 
   return (
     <div
       className={`flex items-center gap-1.5 rounded border-l-4 bg-white px-2 py-1.5 shadow-lg ${roleColor}`}
-      style={{ width: '13rem' }}
+      style={{ width: "13rem" }}
     >
       <span className="min-w-0 flex-1 truncate text-xs font-medium text-slate-800">
         {member.member_name}
       </span>
-      <span className={`shrink-0 rounded px-1 py-0.5 text-xs font-medium ${badgeColor}`}>
+      <span
+        className={`shrink-0 rounded px-1 py-0.5 text-xs font-medium ${badgeColor}`}
+      >
         {ROLE_LABELS[member.member_role] ?? member.member_role}
       </span>
     </div>
@@ -313,14 +363,14 @@ function MemberDragOverlay({ member }: { member: SiegeMember }) {
 
 // ─── MemberBucket ──────────────────────────────────────────────────────────────
 
-type RoleFilter = 'all' | 'heavy_hitter' | 'advanced' | 'medium' | 'novice';
+type RoleFilter = "all" | "heavy_hitter" | "advanced" | "medium" | "novice";
 
 const ROLE_FILTER_OPTIONS: { value: RoleFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'heavy_hitter', label: 'Heavy Hitter' },
-  { value: 'advanced', label: 'Advanced' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'novice', label: 'Novice' },
+  { value: "all", label: "All" },
+  { value: "heavy_hitter", label: "Heavy Hitter" },
+  { value: "advanced", label: "Advanced" },
+  { value: "medium", label: "Medium" },
+  { value: "novice", label: "Novice" },
 ];
 
 function MemberBucket({
@@ -334,19 +384,23 @@ function MemberBucket({
   scrollLimit: number;
   isLocked: boolean;
 }) {
-  const [search, setSearch] = useState('');
-  const [roleFilter, setRoleFilter] = useState<RoleFilter>('all');
+  const [search, setSearch] = useState("");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
     return siegeMembers
       .filter((m) => !q || m.member_name.toLowerCase().includes(q))
-      .filter((m) => roleFilter === 'all' || m.member_role === roleFilter)
+      .filter((m) => roleFilter === "all" || m.member_role === roleFilter)
       .slice()
       .sort((a, b) => {
-        const roleDiff = (ROLE_PRIORITY[a.member_role] ?? 99) - (ROLE_PRIORITY[b.member_role] ?? 99);
+        const roleDiff =
+          (ROLE_PRIORITY[a.member_role] ?? 99) -
+          (ROLE_PRIORITY[b.member_role] ?? 99);
         if (roleDiff !== 0) return roleDiff;
-        const countDiff = (memberAssignments[a.member_id] ?? 0) - (memberAssignments[b.member_id] ?? 0);
+        const countDiff =
+          (memberAssignments[a.member_id] ?? 0) -
+          (memberAssignments[b.member_id] ?? 0);
         if (countDiff !== 0) return countDiff;
         return a.member_name.localeCompare(b.member_name);
       });
@@ -355,7 +409,12 @@ function MemberBucket({
   return (
     <div
       className="flex w-52 shrink-0 flex-col"
-      style={{ height: 'calc(100vh - 200px)', position: 'sticky', top: '16px', alignSelf: 'flex-start' }}
+      style={{
+        height: "calc(100vh - 200px)",
+        position: "sticky",
+        top: "16px",
+        alignSelf: "flex-start",
+      }}
     >
       <div className="mb-2 flex items-center justify-between">
         <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
@@ -388,7 +447,9 @@ function MemberBucket({
 
       <div className="flex-1 overflow-y-auto rounded-lg border border-slate-200 bg-white">
         {filtered.length === 0 ? (
-          <p className="px-3 py-4 text-center text-xs text-slate-400">No members</p>
+          <p className="px-3 py-4 text-center text-xs text-slate-400">
+            No members
+          </p>
         ) : (
           <div className="divide-y divide-slate-100">
             {filtered.map((m) => (
@@ -435,7 +496,11 @@ function BuildingTableRow({
 
   const allPositions = building.groups.flatMap((g) => g.positions);
   const filledCount = allPositions.filter(
-    (p) => !p.is_disabled && !p.is_reserve && !p.has_no_assignment && p.member_id != null,
+    (p) =>
+      !p.is_disabled &&
+      !p.is_reserve &&
+      !p.has_no_assignment &&
+      p.member_id != null
   ).length;
   const activeCount = allPositions.filter((p) => !p.is_disabled).length;
 
@@ -450,7 +515,7 @@ function BuildingTableRow({
         </p>
         <p className="mt-0.5 text-xs opacity-75">
           Lv {building.level}
-          {building.is_broken ? ' · Broken' : ''}
+          {building.is_broken ? " · Broken" : ""}
         </p>
         <p className="mt-0.5 text-xs opacity-75">
           {filledCount}/{activeCount} filled
@@ -462,7 +527,7 @@ function BuildingTableRow({
         {groupChunks.map((chunk, chunkIdx) => (
           <div
             key={chunkIdx}
-            className={`flex flex-1 ${chunkIdx > 0 ? `border-t ${colors.border}` : ''}`}
+            className={`flex flex-1 ${chunkIdx > 0 ? `border-t ${colors.border}` : ""}`}
           >
             {chunk.map((group) => (
               <div
@@ -488,9 +553,14 @@ function BuildingTableRow({
             ))}
             {/* Pad empty columns so rows are uniform width when fewer than max groups */}
             {chunk.length < MAX_GROUPS_PER_ROW &&
-              Array.from({ length: MAX_GROUPS_PER_ROW - chunk.length }).map((_, i) => (
-                <div key={`pad-${i}`} className="flex-1 border-l border-transparent" />
-              ))}
+              Array.from({ length: MAX_GROUPS_PER_ROW - chunk.length }).map(
+                (_, i) => (
+                  <div
+                    key={`pad-${i}`}
+                    className="flex-1 border-l border-transparent"
+                  />
+                )
+              )}
           </div>
         ))}
       </div>
@@ -573,18 +643,18 @@ function BuildingsTab({
   onUpdate: () => void;
   isLocked?: boolean;
 }) {
-  const nonPostBuildings = buildings.filter((b) => b.building_type !== 'post');
+  const nonPostBuildings = buildings.filter((b) => b.building_type !== "post");
 
   if (nonPostBuildings.length === 0) {
     return (
       <div className="py-12 text-center text-slate-500">
-        No buildings configured.{' '}
+        No buildings configured.{" "}
         <Link
           to={`/sieges/${siegeId}`}
           className="text-violet-600 hover:underline"
         >
           Add buildings
-        </Link>{' '}
+        </Link>{" "}
         in siege settings.
       </div>
     );
@@ -604,7 +674,9 @@ function BuildingsTab({
 
   return (
     <div>
-      {BUILDING_TYPE_ORDER.filter((t) => grouped[t] && grouped[t]!.length > 0).map((type) => (
+      {BUILDING_TYPE_ORDER.filter(
+        (t) => grouped[t] && grouped[t]!.length > 0
+      ).map((type) => (
         <BuildingTypeSection
           key={type}
           type={type}
@@ -656,37 +728,38 @@ function ConditionalDndContext({
 
 // ─── BoardPage ─────────────────────────────────────────────────────────────────
 
-type ActiveTab = 'buildings' | 'posts';
+type ActiveTab = "buildings" | "posts";
 
 export default function BoardPage() {
   const { id } = useParams<{ id: string }>();
   const siegeId = Number(id);
   const queryClient = useQueryClient();
 
-  const [activeTab, setActiveTab] = useState<ActiveTab>('buildings');
-  const [autofillPreview, setAutofillPreview] = useState<AutofillPreviewResult | null>(null);
+  const [activeTab, setActiveTab] = useState<ActiveTab>("buildings");
+  const [autofillPreview, setAutofillPreview] =
+    useState<AutofillPreviewResult | null>(null);
   const [autofillOpen, setAutofillOpen] = useState(false);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
   const [validationOpen, setValidationOpen] = useState(false);
   const [activeMemberId, setActiveMemberId] = useState<number | null>(null);
 
   const { data: board, isLoading: boardLoading } = useQuery({
-    queryKey: ['board', siegeId],
+    queryKey: ["board", siegeId],
     queryFn: () => getBoard(siegeId),
   });
 
   const { data: siegeMembers } = useQuery({
-    queryKey: ['siegeMembers', siegeId],
+    queryKey: ["siegeMembers", siegeId],
     queryFn: () => getSiegeMembers(siegeId),
   });
 
   const { data: siege } = useQuery({
-    queryKey: ['siege', siegeId],
+    queryKey: ["siege", siegeId],
     queryFn: () => getSiege(siegeId),
   });
 
   const { data: postPriorities } = useQuery({
-    queryKey: ['postPriorities'],
+    queryKey: ["postPriorities"],
     queryFn: getPostPriorities,
   });
 
@@ -704,7 +777,7 @@ export default function BoardPage() {
   const applyMutation = useMutation({
     mutationFn: () => applyAutofill(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['board', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
       setAutofillOpen(false);
       setAutofillPreview(null);
     },
@@ -721,18 +794,28 @@ export default function BoardPage() {
   // ── Derived stats ────────────────────────────────────────────────────────────
 
   const allPositions = useMemo(
-    () => board?.buildings.flatMap((b) => b.groups.flatMap((g) => g.positions)) ?? [],
-    [board],
+    () =>
+      board?.buildings.flatMap((b) => b.groups.flatMap((g) => g.positions)) ??
+      [],
+    [board]
   );
 
   const totalSlots = allPositions.length;
   const assignedCount = allPositions.filter(
-    (p) => !p.is_disabled && !p.is_reserve && !p.has_no_assignment && p.member_id != null,
+    (p) =>
+      !p.is_disabled &&
+      !p.is_reserve &&
+      !p.has_no_assignment &&
+      p.member_id != null
   ).length;
   const reserveCount = allPositions.filter((p) => p.is_reserve).length;
   const noAssignCount = allPositions.filter((p) => p.has_no_assignment).length;
   const emptyCount = allPositions.filter(
-    (p) => !p.is_disabled && !p.is_reserve && !p.has_no_assignment && p.member_id == null,
+    (p) =>
+      !p.is_disabled &&
+      !p.is_reserve &&
+      !p.has_no_assignment &&
+      p.member_id == null
   ).length;
   const disabledCount = allPositions.filter((p) => p.is_disabled).length;
 
@@ -770,21 +853,25 @@ export default function BoardPage() {
   }, [siegeMembers]);
 
   const sortedSiegeMembers = useMemo(
-    () => (siegeMembers ?? []).slice().sort((a, b) => a.member_name.localeCompare(b.member_name)),
-    [siegeMembers],
+    () =>
+      (siegeMembers ?? [])
+        .slice()
+        .sort((a, b) => a.member_name.localeCompare(b.member_name)),
+    [siegeMembers]
   );
 
   const totalScrolls = siege?.computed_scroll_count ?? 0;
   const scrollsPerMember = totalScrolls < 90 ? 3 : 4;
-  const isLocked = siege?.status === 'complete';
+  const isLocked = siege?.status === "complete";
 
   // The member currently being dragged (for the DragOverlay chip)
   const activeMember = useMemo(
     () =>
       activeMemberId != null
-        ? (sortedSiegeMembers.find((m) => m.member_id === activeMemberId) ?? null)
+        ? (sortedSiegeMembers.find((m) => m.member_id === activeMemberId) ??
+          null)
         : null,
-    [activeMemberId, sortedSiegeMembers],
+    [activeMemberId, sortedSiegeMembers]
   );
 
   // ── DnD ──────────────────────────────────────────────────────────────────────
@@ -793,19 +880,19 @@ export default function BoardPage() {
     useSensor(PointerSensor, {
       // Short distance before activation so chevron button clicks still work
       activationConstraint: { distance: 6 },
-    }),
+    })
   );
 
   function handleDragStart(event: DragStartEvent) {
-    document.body.style.overflowX = 'hidden';
+    document.body.style.overflowX = "hidden";
     const activeId = String(event.active.id);
-    if (activeId.startsWith('member-')) {
-      setActiveMemberId(Number(activeId.replace('member-', '')));
+    if (activeId.startsWith("member-")) {
+      setActiveMemberId(Number(activeId.replace("member-", "")));
     }
   }
 
   function handleDragEnd(event: DragEndEvent) {
-    document.body.style.overflowX = '';
+    document.body.style.overflowX = "";
     setActiveMemberId(null);
     const { active, over } = event;
     if (!over) return;
@@ -813,10 +900,11 @@ export default function BoardPage() {
     const activeId = String(active.id);
     const overId = String(over.id);
 
-    if (!activeId.startsWith('member-') || !overId.startsWith('position-')) return;
+    if (!activeId.startsWith("member-") || !overId.startsWith("position-"))
+      return;
 
-    const memberId = Number(activeId.replace('member-', ''));
-    const positionId = Number(overId.replace('position-', ''));
+    const memberId = Number(activeId.replace("member-", ""));
+    const positionId = Number(overId.replace("position-", ""));
     if (!memberId || !positionId) return;
 
     updatePosition(siegeId, positionId, {
@@ -824,7 +912,7 @@ export default function BoardPage() {
       is_reserve: false,
       has_no_assignment: false,
     }).then(() => {
-      queryClient.invalidateQueries({ queryKey: ['board', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
     });
   }
 
@@ -835,7 +923,9 @@ export default function BoardPage() {
   // ── Render ───────────────────────────────────────────────────────────────────
 
   if (boardLoading) {
-    return <div className="py-12 text-center text-slate-500">Loading board...</div>;
+    return (
+      <div className="py-12 text-center text-slate-500">Loading board...</div>
+    );
   }
 
   return (
@@ -863,14 +953,14 @@ export default function BoardPage() {
             onClick={() => validateMutation.mutate()}
             disabled={validateMutation.isPending}
           >
-            {validateMutation.isPending ? 'Validating...' : 'Validate'}
+            {validateMutation.isPending ? "Validating..." : "Validate"}
           </Button>
           <Button
             size="sm"
             onClick={() => previewMutation.mutate()}
             disabled={previewMutation.isPending || isLocked}
           >
-            {previewMutation.isPending ? 'Loading...' : 'Preview Auto-fill'}
+            {previewMutation.isPending ? "Loading..." : "Preview Auto-fill"}
           </Button>
         </div>
       </div>
@@ -878,28 +968,44 @@ export default function BoardPage() {
       {/* ── Summary bar ── */}
       <div className="mb-4 flex flex-wrap gap-3 rounded-lg border border-slate-200 bg-white px-4 py-2.5">
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-slate-900">{totalSlots}</span> total
+          <span className="font-semibold text-slate-900">{totalSlots}</span>{" "}
+          total
         </span>
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-green-700">{assignedCount}</span> assigned
+          <span className="font-semibold text-green-700">{assignedCount}</span>{" "}
+          assigned
         </span>
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-amber-600">{reserveCount}</span> reserve
+          <span className="font-semibold text-amber-600">{reserveCount}</span>{" "}
+          reserve
         </span>
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-slate-500">{noAssignCount}</span> N/A
+          <span className="font-semibold text-slate-500">{noAssignCount}</span>{" "}
+          N/A
         </span>
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-orange-600">{emptyCount}</span> empty
+          <span className="font-semibold text-orange-600">{emptyCount}</span>{" "}
+          empty
         </span>
         <span className="text-sm text-slate-600">
-          <span className="font-semibold text-slate-400">{disabledCount}</span> disabled
+          <span className="font-semibold text-slate-400">{disabledCount}</span>{" "}
+          disabled
         </span>
         {totalScrolls > 0 && (
           <span className="text-sm text-slate-600">
-            <span className="font-semibold text-violet-700">{totalScrolls}</span> scrolls
+            <span className="font-semibold text-violet-700">
+              {totalScrolls}
+            </span>{" "}
+            scrolls
             {scrollsPerMember > 0 && (
-              <> · <span className="font-semibold text-violet-700">{scrollsPerMember}</span>/member</>
+              <>
+                {" "}
+                ·{" "}
+                <span className="font-semibold text-violet-700">
+                  {scrollsPerMember}
+                </span>
+                /member
+              </>
             )}
           </span>
         )}
@@ -911,8 +1017,13 @@ export default function BoardPage() {
         sensors={sensors}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
-        onDragCancel={() => { document.body.style.overflowX = ''; setActiveMemberId(null); }}
-        overlay={activeMember ? <MemberDragOverlay member={activeMember} /> : null}
+        onDragCancel={() => {
+          document.body.style.overflowX = "";
+          setActiveMemberId(null);
+        }}
+        overlay={
+          activeMember ? <MemberDragOverlay member={activeMember} /> : null
+        }
       >
         <div className="flex items-start gap-4">
           {/* Left: Member Bucket */}
@@ -929,22 +1040,22 @@ export default function BoardPage() {
             <div className="mb-3 flex border-b border-slate-200">
               <button
                 className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-                  activeTab === 'buildings'
-                    ? 'border-violet-600 text-violet-700'
-                    : 'border-transparent text-slate-500 hover:text-slate-700'
+                  activeTab === "buildings"
+                    ? "border-violet-600 text-violet-700"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
                 }`}
-                onClick={() => setActiveTab('buildings')}
+                onClick={() => setActiveTab("buildings")}
               >
                 <LayoutGrid className="h-4 w-4" />
                 Buildings
               </button>
               <button
                 className={`flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-                  activeTab === 'posts'
-                    ? 'border-violet-600 text-violet-700'
-                    : 'border-transparent text-slate-500 hover:text-slate-700'
+                  activeTab === "posts"
+                    ? "border-violet-600 text-violet-700"
+                    : "border-transparent text-slate-500 hover:text-slate-700"
                 }`}
-                onClick={() => setActiveTab('posts')}
+                onClick={() => setActiveTab("posts")}
               >
                 <MessageSquare className="h-4 w-4" />
                 Posts
@@ -952,7 +1063,7 @@ export default function BoardPage() {
             </div>
 
             {/* Tab content */}
-            {activeTab === 'buildings' && (
+            {activeTab === "buildings" && (
               <BuildingsTab
                 buildings={board?.buildings ?? []}
                 siegeId={siegeId}
@@ -961,7 +1072,7 @@ export default function BoardPage() {
                 isLocked={isLocked}
               />
             )}
-            {activeTab === 'posts' && (
+            {activeTab === "posts" && (
               <PostsTab
                 buildings={board?.buildings ?? []}
                 siegeId={siegeId}
@@ -985,7 +1096,8 @@ export default function BoardPage() {
           </DialogHeader>
           <div className="space-y-1">
             {autofillPreview?.assignments.map((a) => {
-              const member = a.member_id != null ? memberLookup[a.member_id] : null;
+              const member =
+                a.member_id != null ? memberLookup[a.member_id] : null;
               const pos = positionLookup[a.position_id];
               return (
                 <div
@@ -1012,8 +1124,11 @@ export default function BoardPage() {
             <Button variant="outline" onClick={() => setAutofillOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={() => applyMutation.mutate()} disabled={applyMutation.isPending}>
-              {applyMutation.isPending ? 'Applying...' : 'Apply'}
+            <Button
+              onClick={() => applyMutation.mutate()}
+              disabled={applyMutation.isPending}
+            >
+              {applyMutation.isPending ? "Applying..." : "Apply"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -1027,11 +1142,15 @@ export default function BoardPage() {
           </DialogHeader>
           {validation && (
             <div className="space-y-2">
-              {validation.errors.length === 0 && validation.warnings.length === 0 && (
-                <p className="text-sm text-green-600">No issues found.</p>
-              )}
+              {validation.errors.length === 0 &&
+                validation.warnings.length === 0 && (
+                  <p className="text-sm text-green-600">No issues found.</p>
+                )}
               {validation.errors.map((e, i) => (
-                <div key={i} className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2">
+                <div
+                  key={i}
+                  className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2"
+                >
                   <Badge variant="destructive" className="mt-0.5 shrink-0">
                     Error {e.rule}
                   </Badge>

--- a/frontend/src/pages/ComparisonPage.tsx
+++ b/frontend/src/pages/ComparisonPage.tsx
@@ -1,36 +1,36 @@
-import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { getSieges, compareSieges, compareSiegesSpecific } from '../api/sieges';
-import type { PositionKey, MemberDiff } from '../api/types';
+import { useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getSieges, compareSieges, compareSiegesSpecific } from "../api/sieges";
+import type { PositionKey, MemberDiff } from "../api/types";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
-import { Label } from '../components/ui/label';
-import { ArrowLeft } from 'lucide-react';
-import { cn } from '../lib/utils';
+} from "../components/ui/select";
+import { Label } from "../components/ui/label";
+import { ArrowLeft } from "lucide-react";
+import { cn } from "../lib/utils";
 
 function formatPosition(pos: PositionKey): string {
-  return `${pos.building_type.replace(/_/g, ' ')} #${pos.building_number} G${pos.group_number} P${pos.position_number}`;
+  return `${pos.building_type.replace(/_/g, " ")} #${pos.building_number} G${pos.group_number} P${pos.position_number}`;
 }
 
 interface PositionTagProps {
   pos: PositionKey;
-  variant: 'added' | 'removed' | 'unchanged';
+  variant: "added" | "removed" | "unchanged";
 }
 
 function PositionTag({ pos, variant }: PositionTagProps) {
   return (
     <span
       className={cn(
-        'inline-block rounded px-1.5 py-0.5 text-xs font-medium capitalize',
-        variant === 'added' && 'bg-green-100 text-green-800',
-        variant === 'removed' && 'bg-red-100 text-red-800',
-        variant === 'unchanged' && 'bg-slate-100 text-slate-600',
+        "inline-block rounded px-1.5 py-0.5 text-xs font-medium capitalize",
+        variant === "added" && "bg-green-100 text-green-800",
+        variant === "removed" && "bg-red-100 text-red-800",
+        variant === "unchanged" && "bg-slate-100 text-slate-600"
       )}
     >
       {formatPosition(pos)}
@@ -67,17 +67,17 @@ function MemberNewPositionsCell({ diff }: { diff: MemberDiff }) {
 export default function ComparisonPage() {
   const { id } = useParams<{ id: string }>();
   const siegeId = Number(id);
-  const [compareToId, setCompareToId] = useState<string>('default');
+  const [compareToId, setCompareToId] = useState<string>("default");
   const [diffsOnly, setDiffsOnly] = useState(false);
 
   const { data: completedSieges } = useQuery({
-    queryKey: ['sieges', 'complete'],
-    queryFn: () => getSieges({ status: 'complete' }),
+    queryKey: ["sieges", "complete"],
+    queryFn: () => getSieges({ status: "complete" }),
   });
 
   const otherSieges = completedSieges?.filter((s) => s.id !== siegeId) ?? [];
 
-  const isSpecific = compareToId !== 'default';
+  const isSpecific = compareToId !== "default";
   const specificId = isSpecific ? Number(compareToId) : undefined;
 
   const {
@@ -85,7 +85,7 @@ export default function ComparisonPage() {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['comparison', siegeId, compareToId],
+    queryKey: ["comparison", siegeId, compareToId],
     queryFn: () =>
       isSpecific && specificId != null
         ? compareSiegesSpecific(siegeId, specificId)
@@ -94,10 +94,16 @@ export default function ComparisonPage() {
   });
 
   const membersWithChanges =
-    comparison?.members.filter((m) => m.added.length > 0 || m.removed.length > 0) ?? [];
-  const totalAdded = comparison?.members.reduce((acc, m) => acc + m.added.length, 0) ?? 0;
-  const totalRemoved = comparison?.members.reduce((acc, m) => acc + m.removed.length, 0) ?? 0;
-  const visibleMembers = diffsOnly ? membersWithChanges : (comparison?.members ?? []);
+    comparison?.members.filter(
+      (m) => m.added.length > 0 || m.removed.length > 0
+    ) ?? [];
+  const totalAdded =
+    comparison?.members.reduce((acc, m) => acc + m.added.length, 0) ?? 0;
+  const totalRemoved =
+    comparison?.members.reduce((acc, m) => acc + m.removed.length, 0) ?? 0;
+  const visibleMembers = diffsOnly
+    ? membersWithChanges
+    : (comparison?.members ?? []);
 
   return (
     <div className="max-w-5xl">
@@ -144,16 +150,17 @@ export default function ComparisonPage() {
       {comparison && (
         <div className="mb-4 flex items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
           <span>
-            <strong>{membersWithChanges.length}</strong> members with changes &bull;{' '}
+            <strong>{membersWithChanges.length}</strong> members with changes
+            &bull;{" "}
             <span className="text-green-700">
               <strong>{totalAdded}</strong> positions added
-            </span>{' '}
-            &bull;{' '}
+            </span>{" "}
+            &bull;{" "}
             <span className="text-red-700">
               <strong>{totalRemoved}</strong> positions removed
             </span>
           </span>
-          <label className="flex cursor-pointer items-center gap-2 select-none">
+          <label className="flex cursor-pointer select-none items-center gap-2">
             <input
               type="checkbox"
               checked={diffsOnly}
@@ -167,12 +174,14 @@ export default function ComparisonPage() {
 
       {/* Loading / error */}
       {isLoading && (
-        <div className="py-12 text-center text-slate-500">Loading comparison...</div>
+        <div className="py-12 text-center text-slate-500">
+          Loading comparison...
+        </div>
       )}
       {error && (
         <div className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-          Failed to load comparison. The siege may not have a previous completed siege to compare
-          against.
+          Failed to load comparison. The siege may not have a previous completed
+          siege to compare against.
         </div>
       )}
 
@@ -182,7 +191,9 @@ export default function ComparisonPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-200 bg-slate-50">
-                <th className="px-4 py-3 text-left font-semibold text-slate-700">Member</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-700">
+                  Member
+                </th>
                 <th className="px-4 py-3 text-left font-semibold text-slate-700">
                   Old Positions (Siege #{comparison.siege_a_id})
                 </th>
@@ -194,8 +205,13 @@ export default function ComparisonPage() {
             <tbody>
               {visibleMembers.length === 0 && (
                 <tr>
-                  <td colSpan={3} className="px-4 py-8 text-center text-slate-500">
-                    {diffsOnly ? 'No members with changes.' : 'No members to compare.'}
+                  <td
+                    colSpan={3}
+                    className="px-4 py-8 text-center text-slate-500"
+                  >
+                    {diffsOnly
+                      ? "No members with changes."
+                      : "No members to compare."}
                   </td>
                 </tr>
               )}
@@ -203,11 +219,14 @@ export default function ComparisonPage() {
                 <tr
                   key={diff.member_id}
                   className={cn(
-                    'border-b border-slate-100 last:border-0',
-                    (diff.added.length > 0 || diff.removed.length > 0) && 'bg-amber-50/40',
+                    "border-b border-slate-100 last:border-0",
+                    (diff.added.length > 0 || diff.removed.length > 0) &&
+                      "bg-amber-50/40"
                   )}
                 >
-                  <td className="px-4 py-3 font-medium text-slate-900">{diff.member_name}</td>
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    {diff.member_name}
+                  </td>
                   <td className="px-4 py-3">
                     <MemberPositionsCell diff={diff} />
                   </td>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,50 @@
+import { useSearchParams } from "react-router-dom";
+import apiClient from "../api/client";
+import { Shield } from "lucide-react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  service_unavailable:
+    "Login is temporarily unavailable. Please try again in a moment.",
+};
+const DEFAULT_ERROR = "You are not authorized to access this app.";
+
+export default function LoginPage() {
+  const [searchParams] = useSearchParams();
+  const error = searchParams.get("error");
+
+  const handleLogin = async () => {
+    const { data } = await apiClient.get("/api/auth/login");
+    window.location.href = data.url;
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50">
+      <div className="w-full max-w-sm space-y-6 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+        <div className="flex flex-col items-center gap-2">
+          <Shield className="h-8 w-8 text-violet-600" />
+          <h1 className="text-xl font-semibold text-slate-900">
+            Siege Assignments
+          </h1>
+        </div>
+        {error && (
+          <div className="rounded-md bg-red-50 p-3 text-center text-sm text-red-700">
+            {ERROR_MESSAGES[error] ?? DEFAULT_ERROR}
+          </div>
+        )}
+        <div className="space-y-4">
+          <button
+            onClick={handleLogin}
+            className="flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium text-white transition-colors"
+            style={{ backgroundColor: "#5865F2" }}
+          >
+            Sign in with Discord
+          </button>
+          <p className="text-center text-xs text-slate-500">
+            We only request access to your Discord username and avatar. Guild
+            membership is verified privately using our bot.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import apiClient from "../api/client";
 import { Shield } from "lucide-react";
@@ -11,10 +12,16 @@ const DEFAULT_ERROR = "You are not authorized to access this app.";
 export default function LoginPage() {
   const [searchParams] = useSearchParams();
   const error = searchParams.get("error");
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleLogin = async () => {
-    const { data } = await apiClient.get("/api/auth/login");
-    window.location.href = data.url;
+    setIsLoading(true);
+    try {
+      const { data } = await apiClient.get("/api/auth/login");
+      window.location.href = data.url;
+    } catch {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -34,10 +41,11 @@ export default function LoginPage() {
         <div className="space-y-4">
           <button
             onClick={handleLogin}
-            className="flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium text-white transition-colors"
+            disabled={isLoading}
+            className="flex w-full items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
             style={{ backgroundColor: "#5865F2" }}
           >
-            Sign in with Discord
+            {isLoading ? "Signing in..." : "Sign in with Discord"}
           </button>
           <p className="text-center text-xs text-slate-500">
             We only request access to your Discord username and avatar. Guild

--- a/frontend/src/pages/MemberDetailPage.tsx
+++ b/frontend/src/pages/MemberDetailPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
-import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect } from "react";
+import { useNavigate, useParams, Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getMember,
   createMember,
@@ -8,19 +8,19 @@ import {
   getPostConditions,
   getMemberPreferences,
   updateMemberPreferences,
-} from '../api/members';
-import type { MemberRole, PostCondition } from '../api/types';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Label } from '../components/ui/label';
-import { Checkbox } from '../components/ui/checkbox';
+} from "../api/members";
+import type { MemberRole, PostCondition } from "../api/types";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Checkbox } from "../components/ui/checkbox";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
+} from "../components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -28,15 +28,15 @@ import {
   DialogTitle,
   DialogFooter,
   DialogDescription,
-} from '../components/ui/dialog';
-import { ArrowLeft } from 'lucide-react';
-import { isAxiosError } from 'axios';
+} from "../components/ui/dialog";
+import { ArrowLeft } from "lucide-react";
+import { isAxiosError } from "axios";
 
 const ROLE_OPTIONS: { value: MemberRole; label: string }[] = [
-  { value: 'heavy_hitter', label: 'Heavy Hitter' },
-  { value: 'advanced', label: 'Advanced' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'novice', label: 'Novice' },
+  { value: "heavy_hitter", label: "Heavy Hitter" },
+  { value: "advanced", label: "Advanced" },
+  { value: "medium", label: "Medium" },
+  { value: "novice", label: "Novice" },
 ];
 
 function groupByLevel(conditions: PostCondition[]) {
@@ -50,35 +50,37 @@ function groupByLevel(conditions: PostCondition[]) {
 
 export default function MemberDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const isNew = id === undefined || id === 'new';
+  const isNew = id === undefined || id === "new";
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [name, setName] = useState('');
-  const [discord, setDiscord] = useState('');
-  const [role, setRole] = useState<MemberRole>('novice');
-  const [powerLevel, setPowerLevel] = useState<string>('');
+  const [name, setName] = useState("");
+  const [discord, setDiscord] = useState("");
+  const [role, setRole] = useState<MemberRole>("novice");
+  const [powerLevel, setPowerLevel] = useState<string>("");
   const [deactivateOpen, setDeactivateOpen] = useState(false);
-  const [selectedConditions, setSelectedConditions] = useState<Set<number>>(new Set());
-  const [prefFilter, setPrefFilter] = useState('');
-  const [saveError, setSaveError] = useState('');
+  const [selectedConditions, setSelectedConditions] = useState<Set<number>>(
+    new Set()
+  );
+  const [prefFilter, setPrefFilter] = useState("");
+  const [saveError, setSaveError] = useState("");
 
   const memberId = isNew ? null : Number(id);
 
   const { data: member, isLoading: memberLoading } = useQuery({
-    queryKey: ['member', memberId],
+    queryKey: ["member", memberId],
     queryFn: () => getMember(memberId!),
     enabled: memberId != null,
   });
 
   const { data: allConditions } = useQuery({
-    queryKey: ['postConditions'],
+    queryKey: ["postConditions"],
     queryFn: getPostConditions,
     enabled: !isNew,
   });
 
   const { data: preferences } = useQuery({
-    queryKey: ['memberPreferences', memberId],
+    queryKey: ["memberPreferences", memberId],
     queryFn: () => getMemberPreferences(memberId!),
     enabled: memberId != null,
   });
@@ -86,9 +88,9 @@ export default function MemberDetailPage() {
   useEffect(() => {
     if (member) {
       setName(member.name);
-      setDiscord(member.discord_username ?? '');
+      setDiscord(member.discord_username ?? "");
       setRole(member.role);
-      setPowerLevel(member.power_level ?? '');
+      setPowerLevel(member.power_level ?? "");
     }
   }, [member]);
 
@@ -107,11 +109,15 @@ export default function MemberDetailPage() {
         power_level: powerLevel || null,
       }),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['members'] });
+      queryClient.invalidateQueries({ queryKey: ["members"] });
       navigate(`/members/${data.id}`);
     },
     onError: (err) => {
-      setSaveError(isAxiosError(err) ? (err.response?.data?.detail ?? 'Save failed') : 'Save failed');
+      setSaveError(
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Save failed")
+          : "Save failed"
+      );
     },
   });
 
@@ -124,19 +130,23 @@ export default function MemberDetailPage() {
         power_level: powerLevel || null,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['members'] });
-      queryClient.invalidateQueries({ queryKey: ['member', memberId] });
+      queryClient.invalidateQueries({ queryKey: ["members"] });
+      queryClient.invalidateQueries({ queryKey: ["member", memberId] });
     },
     onError: (err) => {
-      setSaveError(isAxiosError(err) ? (err.response?.data?.detail ?? 'Save failed') : 'Save failed');
+      setSaveError(
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Save failed")
+          : "Save failed"
+      );
     },
   });
 
   const deactivateMutation = useMutation({
     mutationFn: () => updateMember(memberId!, { is_active: false }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['members'] });
-      queryClient.invalidateQueries({ queryKey: ['member', memberId] });
+      queryClient.invalidateQueries({ queryKey: ["members"] });
+      queryClient.invalidateQueries({ queryKey: ["member", memberId] });
       setDeactivateOpen(false);
     },
   });
@@ -144,12 +154,14 @@ export default function MemberDetailPage() {
   const prefMutation = useMutation({
     mutationFn: (ids: number[]) => updateMemberPreferences(memberId!, ids),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['memberPreferences', memberId] });
+      queryClient.invalidateQueries({
+        queryKey: ["memberPreferences", memberId],
+      });
     },
   });
 
   function handleSave() {
-    setSaveError('');
+    setSaveError("");
     if (isNew) {
       createMutation.mutate();
     } else {
@@ -187,7 +199,7 @@ export default function MemberDetailPage() {
       </Link>
 
       <h1 className="mb-6 text-2xl font-bold text-slate-900">
-        {isNew ? 'Add Member' : member?.name ?? 'Edit Member'}
+        {isNew ? "Add Member" : (member?.name ?? "Edit Member")}
       </h1>
 
       <div className="rounded-lg border border-slate-200 bg-white p-6">
@@ -214,7 +226,10 @@ export default function MemberDetailPage() {
 
           <div className="space-y-1.5">
             <Label htmlFor="role">Role</Label>
-            <Select value={role} onValueChange={(v) => setRole(v as MemberRole)}>
+            <Select
+              value={role}
+              onValueChange={(v) => setRole(v as MemberRole)}
+            >
               <SelectTrigger id="role">
                 <SelectValue />
               </SelectTrigger>
@@ -244,16 +259,16 @@ export default function MemberDetailPage() {
             </Select>
           </div>
 
-          {saveError && (
-            <p className="text-sm text-red-600">{saveError}</p>
-          )}
+          {saveError && <p className="text-sm text-red-600">{saveError}</p>}
 
           <div className="flex gap-3 pt-2">
             <Button
               onClick={handleSave}
               disabled={createMutation.isPending || updateMutation.isPending}
             >
-              {createMutation.isPending || updateMutation.isPending ? 'Saving...' : 'Save'}
+              {createMutation.isPending || updateMutation.isPending
+                ? "Saving..."
+                : "Save"}
             </Button>
             {!isNew && member?.is_active && (
               <Button
@@ -270,7 +285,9 @@ export default function MemberDetailPage() {
       {/* Post Preferences (only for existing members) */}
       {!isNew && allConditions && (
         <div className="mt-6 rounded-lg border border-slate-200 bg-white p-6">
-          <h2 className="mb-4 text-lg font-semibold text-slate-900">Post Preferences</h2>
+          <h2 className="mb-4 text-lg font-semibold text-slate-900">
+            Post Preferences
+          </h2>
           <p className="mb-4 text-sm text-slate-500">
             Select the post conditions this member prefers to fill.
           </p>
@@ -286,7 +303,11 @@ export default function MemberDetailPage() {
             .sort(([a], [b]) => Number(a) - Number(b))
             .map(([level, conds]) => {
               const filtered = prefFilter
-                ? conds.filter((c) => c.description.toLowerCase().includes(prefFilter.toLowerCase()))
+                ? conds.filter((c) =>
+                    c.description
+                      .toLowerCase()
+                      .includes(prefFilter.toLowerCase())
+                  )
                 : conds;
               if (filtered.length === 0) return null;
               return (
@@ -317,7 +338,7 @@ export default function MemberDetailPage() {
             onClick={handleSavePreferences}
             disabled={prefMutation.isPending}
           >
-            {prefMutation.isPending ? 'Saving...' : 'Save Preferences'}
+            {prefMutation.isPending ? "Saving..." : "Save Preferences"}
           </Button>
           {prefMutation.isSuccess && (
             <p className="mt-2 text-sm text-green-600">Preferences saved.</p>
@@ -330,8 +351,8 @@ export default function MemberDetailPage() {
           <DialogHeader>
             <DialogTitle>Deactivate Member</DialogTitle>
             <DialogDescription>
-              Are you sure you want to deactivate {member?.name}? They will no longer appear
-              in active member lists.
+              Are you sure you want to deactivate {member?.name}? They will no
+              longer appear in active member lists.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate, Link } from 'react-router-dom';
-import { getMembers } from '../api/members';
-import type { MemberRole } from '../api/types';
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, Link } from "react-router-dom";
+import { getMembers } from "../api/members";
+import type { MemberRole } from "../api/types";
 import {
   Table,
   TableBody,
@@ -10,59 +10,63 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '../components/ui/table';
-import { Button } from '../components/ui/button';
-import { Badge } from '../components/ui/badge';
+} from "../components/ui/table";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
-import { Checkbox } from '../components/ui/checkbox';
-import { Label } from '../components/ui/label';
-import { UserPlus, ChevronRight, RefreshCw } from 'lucide-react';
-import DiscordSyncModal from '../components/DiscordSyncModal';
+} from "../components/ui/select";
+import { Checkbox } from "../components/ui/checkbox";
+import { Label } from "../components/ui/label";
+import { UserPlus, ChevronRight, RefreshCw } from "lucide-react";
+import DiscordSyncModal from "../components/DiscordSyncModal";
 
 const POWER_LABELS: Record<string, string> = {
-  lt_10m: '< 10M',
-  '10_15m': '10-15M',
-  '16_20m': '16-20M',
-  '21_25m': '21-25M',
-  gt_25m: '> 25M',
+  lt_10m: "< 10M",
+  "10_15m": "10-15M",
+  "16_20m": "16-20M",
+  "21_25m": "21-25M",
+  gt_25m: "> 25M",
 };
 
 const ROLE_LABELS: Record<MemberRole, string> = {
-  heavy_hitter: 'Heavy Hitter',
-  advanced: 'Advanced',
-  medium: 'Medium',
-  novice: 'Novice',
+  heavy_hitter: "Heavy Hitter",
+  advanced: "Advanced",
+  medium: "Medium",
+  novice: "Novice",
 };
 
-type RoleBadgeVariant = 'red' | 'orange' | 'blue' | 'gray';
+type RoleBadgeVariant = "red" | "orange" | "blue" | "gray";
 
 const ROLE_VARIANTS: Record<MemberRole, RoleBadgeVariant> = {
-  heavy_hitter: 'red',
-  advanced: 'orange',
-  medium: 'blue',
-  novice: 'gray',
+  heavy_hitter: "red",
+  advanced: "orange",
+  medium: "blue",
+  novice: "gray",
 };
 
 export default function MembersPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [roleFilter, setRoleFilter] = useState<string>('all');
+  const [roleFilter, setRoleFilter] = useState<string>("all");
   const [activeOnly, setActiveOnly] = useState(true);
   const [syncOpen, setSyncOpen] = useState(false);
 
-  const { data: members, isLoading, error } = useQuery({
-    queryKey: ['members', activeOnly],
+  const {
+    data: members,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["members", activeOnly],
     queryFn: () => getMembers({ is_active: activeOnly ? true : undefined }),
   });
 
   const filtered = members
-    ?.filter((m) => roleFilter !== 'all' ? m.role === roleFilter : true)
+    ?.filter((m) => (roleFilter !== "all" ? m.role === roleFilter : true))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
@@ -74,7 +78,7 @@ export default function MembersPage() {
             <RefreshCw className="h-4 w-4" />
             Sync Discord
           </Button>
-          <Button onClick={() => navigate('/members/new')}>
+          <Button onClick={() => navigate("/members/new")}>
             <UserPlus className="h-4 w-4" />
             Add Member
           </Button>
@@ -86,7 +90,7 @@ export default function MembersPage() {
         onClose={() => setSyncOpen(false)}
         onApplied={() => {
           setSyncOpen(false);
-          queryClient.invalidateQueries({ queryKey: ['members'] });
+          queryClient.invalidateQueries({ queryKey: ["members"] });
         }}
       />
 
@@ -138,7 +142,10 @@ export default function MembersPage() {
             <TableBody>
               {filtered?.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={5} className="py-8 text-center text-slate-500">
+                  <TableCell
+                    colSpan={5}
+                    className="py-8 text-center text-slate-500"
+                  >
                     No members found.
                   </TableCell>
                 </TableRow>
@@ -156,11 +163,13 @@ export default function MembersPage() {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    {m.power_level ? POWER_LABELS[m.power_level] ?? m.power_level : '-'}
+                    {m.power_level
+                      ? (POWER_LABELS[m.power_level] ?? m.power_level)
+                      : "-"}
                   </TableCell>
                   <TableCell>
-                    <Badge variant={m.is_active ? 'green' : 'gray'}>
-                      {m.is_active ? 'Active' : 'Inactive'}
+                    <Badge variant={m.is_active ? "green" : "gray"}>
+                      {m.is_active ? "Active" : "Inactive"}
                     </Badge>
                   </TableCell>
                   <TableCell>

--- a/frontend/src/pages/PostPrioritiesPage.tsx
+++ b/frontend/src/pages/PostPrioritiesPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getPostPriorities, updatePostPriority } from '../api/posts';
-import { getPostConditions } from '../api/members';
-import type { PostCondition } from '../api/types';
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getPostPriorities, updatePostPriority } from "../api/posts";
+import { getPostConditions } from "../api/members";
+import type { PostCondition } from "../api/types";
 import {
   Table,
   TableBody,
@@ -10,17 +10,17 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '../components/ui/table';
+} from "../components/ui/table";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
-import { Input } from '../components/ui/input';
-import { Badge } from '../components/ui/badge';
-import { cn } from '../lib/utils';
+} from "../components/ui/select";
+import { Input } from "../components/ui/input";
+import { Badge } from "../components/ui/badge";
+import { cn } from "../lib/utils";
 
 function groupByLevel(conds: PostCondition[]) {
   const groups: Record<number, PostCondition[]> = {};
@@ -31,15 +31,21 @@ function groupByLevel(conds: PostCondition[]) {
   return groups;
 }
 
-function DescriptionCell({ postNumber, value }: { postNumber: number; value: string | null }) {
+function DescriptionCell({
+  postNumber,
+  value,
+}: {
+  postNumber: number;
+  value: string | null;
+}) {
   const queryClient = useQueryClient();
-  const [desc, setDesc] = useState(value ?? '');
+  const [desc, setDesc] = useState(value ?? "");
 
   const mutation = useMutation({
     mutationFn: (description: string | null) =>
       updatePostPriority(postNumber, { description }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['postPriorities'] });
+      queryClient.invalidateQueries({ queryKey: ["postPriorities"] });
     },
   });
 
@@ -59,27 +65,32 @@ function DescriptionCell({ postNumber, value }: { postNumber: number; value: str
   );
 }
 
-type Tab = 'priorities' | 'conditions';
+type Tab = "priorities" | "conditions";
 
 export default function PostPrioritiesPage() {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<Tab>('priorities');
+  const [activeTab, setActiveTab] = useState<Tab>("priorities");
 
   const { data: priorities, isLoading } = useQuery({
-    queryKey: ['postPriorities'],
+    queryKey: ["postPriorities"],
     queryFn: getPostPriorities,
   });
 
   const { data: conditions } = useQuery({
-    queryKey: ['postConditions'],
+    queryKey: ["postConditions"],
     queryFn: getPostConditions,
   });
 
   const mutation = useMutation({
-    mutationFn: ({ postNumber, priority }: { postNumber: number; priority: number }) =>
-      updatePostPriority(postNumber, { priority }),
+    mutationFn: ({
+      postNumber,
+      priority,
+    }: {
+      postNumber: number;
+      priority: number;
+    }) => updatePostPriority(postNumber, { priority }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['postPriorities'] });
+      queryClient.invalidateQueries({ queryKey: ["postPriorities"] });
     },
   });
 
@@ -91,33 +102,34 @@ export default function PostPrioritiesPage() {
       <div className="mb-6 flex gap-1 rounded-lg border border-slate-200 bg-slate-100 p-1">
         <button
           className={cn(
-            'flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors',
-            activeTab === 'priorities'
-              ? 'bg-white text-slate-900 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900',
+            "flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+            activeTab === "priorities"
+              ? "bg-white text-slate-900 shadow-sm"
+              : "text-slate-600 hover:text-slate-900"
           )}
-          onClick={() => setActiveTab('priorities')}
+          onClick={() => setActiveTab("priorities")}
         >
           Priorities
         </button>
         <button
           className={cn(
-            'flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors',
-            activeTab === 'conditions'
-              ? 'bg-white text-slate-900 shadow-sm'
-              : 'text-slate-600 hover:text-slate-900',
+            "flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+            activeTab === "conditions"
+              ? "bg-white text-slate-900 shadow-sm"
+              : "text-slate-600 hover:text-slate-900"
           )}
-          onClick={() => setActiveTab('conditions')}
+          onClick={() => setActiveTab("conditions")}
         >
           Conditions
         </button>
       </div>
 
       {/* Priorities tab */}
-      {activeTab === 'priorities' && (
+      {activeTab === "priorities" && (
         <>
           <p className="mb-4 text-sm text-slate-500">
-            Global priority and description for each post. Copied to new sieges when created.
+            Global priority and description for each post. Copied to new sieges
+            when created.
           </p>
           {isLoading ? (
             <div className="py-12 text-center text-slate-500">Loading...</div>
@@ -134,12 +146,17 @@ export default function PostPrioritiesPage() {
                 <TableBody>
                   {priorities?.map((p) => (
                     <TableRow key={p.post_number}>
-                      <TableCell className="font-medium">Post {p.post_number}</TableCell>
+                      <TableCell className="font-medium">
+                        Post {p.post_number}
+                      </TableCell>
                       <TableCell>
                         <Select
                           value={String(p.priority)}
                           onValueChange={(val) =>
-                            mutation.mutate({ postNumber: p.post_number, priority: Number(val) })
+                            mutation.mutate({
+                              postNumber: p.post_number,
+                              priority: Number(val),
+                            })
                           }
                         >
                           <SelectTrigger className="w-32">
@@ -153,7 +170,10 @@ export default function PostPrioritiesPage() {
                         </Select>
                       </TableCell>
                       <TableCell>
-                        <DescriptionCell postNumber={p.post_number} value={p.description} />
+                        <DescriptionCell
+                          postNumber={p.post_number}
+                          value={p.description}
+                        />
                       </TableCell>
                     </TableRow>
                   ))}
@@ -165,7 +185,7 @@ export default function PostPrioritiesPage() {
       )}
 
       {/* Conditions tab */}
-      {activeTab === 'conditions' && (
+      {activeTab === "conditions" && (
         <>
           <p className="mb-4 text-sm text-slate-500">
             Reference list of all post conditions by stronghold level.
@@ -175,10 +195,15 @@ export default function PostPrioritiesPage() {
               {Object.entries(groupByLevel(conditions))
                 .sort(([a], [b]) => Number(a) - Number(b))
                 .map(([level, conds]) => (
-                  <div key={level} className="rounded-lg border border-slate-200 bg-white p-4">
+                  <div
+                    key={level}
+                    className="rounded-lg border border-slate-200 bg-white p-4"
+                  >
                     <h3 className="mb-3 text-sm font-semibold text-slate-900">
                       Stronghold Level {level}
-                      <Badge variant="secondary" className="ml-2">{conds.length}</Badge>
+                      <Badge variant="secondary" className="ml-2">
+                        {conds.length}
+                      </Badge>
                     </h3>
                     <ul className="space-y-1.5">
                       {conds.map((c) => (

--- a/frontend/src/pages/PostsPage.tsx
+++ b/frontend/src/pages/PostsPage.tsx
@@ -1,19 +1,24 @@
-import { useState } from 'react';
-import { useParams, Link, useSearchParams } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getPosts, setPostConditions } from '../api/posts';
-import { getPostConditions } from '../api/members';
-import { getSiege } from '../api/sieges';
-import { getBoard } from '../api/board';
-import type { Post, PostConditionRef, BuildingResponse } from '../api/types';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Label } from '../components/ui/label';
-import { Checkbox } from '../components/ui/checkbox';
-import { Badge } from '../components/ui/badge';
-import { ArrowLeft, ChevronDown, ChevronUp } from 'lucide-react';
+import { useState } from "react";
+import { useParams, Link, useSearchParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getPosts, setPostConditions } from "../api/posts";
+import { getPostConditions } from "../api/members";
+import { getSiege } from "../api/sieges";
+import { getBoard } from "../api/board";
+import type { Post, PostConditionRef, BuildingResponse } from "../api/types";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Checkbox } from "../components/ui/checkbox";
+import { Badge } from "../components/ui/badge";
+import { ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
 
-const PRIORITY_LABELS: Record<number, string> = { 0: 'Unset', 1: 'Low', 2: 'Medium', 3: 'High' };
+const PRIORITY_LABELS: Record<number, string> = {
+  0: "Unset",
+  1: "Low",
+  2: "Medium",
+  3: "High",
+};
 
 function groupConditionsByLevel(conditions: PostConditionRef[]) {
   const groups: Record<number, PostConditionRef[]> = {};
@@ -39,21 +44,22 @@ function PostRow({
 }) {
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(initialExpanded);
-  const [condFilter, setCondFilter] = useState('');
+  const [condFilter, setCondFilter] = useState("");
   const [selectedConditions, setSelectedConditions] = useState<Set<number>>(
-    new Set(post.active_conditions.map((c) => c.id)),
+    new Set(post.active_conditions.map((c) => c.id))
   );
 
   const { data: allConditions } = useQuery({
-    queryKey: ['postConditions'],
+    queryKey: ["postConditions"],
     queryFn: getPostConditions,
     enabled: expanded,
   });
 
   const condMutation = useMutation({
-    mutationFn: () => setPostConditions(siegeId, post.id, Array.from(selectedConditions)),
+    mutationFn: () =>
+      setPostConditions(siegeId, post.id, Array.from(selectedConditions)),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["posts", siegeId] });
     },
   });
 
@@ -81,7 +87,9 @@ function PostRow({
 
   const matchedCondition =
     assignedPosition && assignedPosition.matched_condition_id !== null
-      ? post.active_conditions.find((c) => c.id === assignedPosition.matched_condition_id)
+      ? post.active_conditions.find(
+          (c) => c.id === assignedPosition.matched_condition_id
+        )
       : undefined;
 
   // matchBadge is the element to render, or null when no member is assigned
@@ -89,14 +97,14 @@ function PostRow({
     assignedPosition == null ? null : matchedCondition != null ? (
       <Badge
         variant="default"
-        className="shrink-0 text-xs bg-green-100 text-green-800 border border-green-200 hover:bg-green-100"
+        className="shrink-0 border border-green-200 bg-green-100 text-xs text-green-800 hover:bg-green-100"
       >
         ✓ {matchedCondition.description}
       </Badge>
     ) : (
       <Badge
         variant="secondary"
-        className="shrink-0 text-xs bg-amber-50 text-amber-700 border border-amber-200"
+        className="shrink-0 border border-amber-200 bg-amber-50 text-xs text-amber-700"
       >
         No condition match
       </Badge>
@@ -108,10 +116,14 @@ function PostRow({
         <span className="text-sm font-semibold text-slate-900">
           Post {post.building_number}
         </span>
-        <span className="text-sm text-slate-500">Priority: {PRIORITY_LABELS[post.priority] ?? post.priority}</span>
+        <span className="text-sm text-slate-500">
+          Priority: {PRIORITY_LABELS[post.priority] ?? post.priority}
+        </span>
         {matchBadge}
         {post.description && (
-          <span className="text-sm text-slate-600 truncate">{post.description}</span>
+          <span className="truncate text-sm text-slate-600">
+            {post.description}
+          </span>
         )}
         <div className="ml-auto flex items-center gap-2">
           {post.active_conditions.map((c) => (
@@ -135,7 +147,7 @@ function PostRow({
       </div>
 
       {expanded && !isLocked && (
-        <div className="border-t border-slate-100 px-4 py-4 space-y-4">
+        <div className="space-y-4 border-t border-slate-100 px-4 py-4">
           <div>
             <h4 className="mb-2 text-sm font-medium text-slate-700">
               Conditions (max 3)
@@ -150,7 +162,11 @@ function PostRow({
               .sort(([a], [b]) => Number(a) - Number(b))
               .map(([level, conds]) => {
                 const filtered = condFilter
-                  ? conds.filter((c) => c.description.toLowerCase().includes(condFilter.toLowerCase()))
+                  ? conds.filter((c) =>
+                      c.description
+                        .toLowerCase()
+                        .includes(condFilter.toLowerCase())
+                    )
                   : conds;
                 if (filtered.length === 0) return null;
                 return (
@@ -161,7 +177,8 @@ function PostRow({
                     <div className="grid grid-cols-2 gap-1.5">
                       {filtered.map((c) => {
                         const checked = selectedConditions.has(c.id);
-                        const disabled = !checked && selectedConditions.size >= 3;
+                        const disabled =
+                          !checked && selectedConditions.size >= 3;
                         return (
                           <div key={c.id} className="flex items-center gap-2">
                             <Checkbox
@@ -202,20 +219,26 @@ export default function PostsPage() {
   const { id } = useParams<{ id: string }>();
   const siegeId = Number(id);
   const [searchParams] = useSearchParams();
-  const expandPostNumber = searchParams.get('post') ? Number(searchParams.get('post')) : null;
+  const expandPostNumber = searchParams.get("post")
+    ? Number(searchParams.get("post"))
+    : null;
 
   const { data: siege } = useQuery({
-    queryKey: ['siege', siegeId],
+    queryKey: ["siege", siegeId],
     queryFn: () => getSiege(siegeId),
   });
 
-  const { data: posts, isLoading, error } = useQuery({
-    queryKey: ['posts', siegeId],
+  const {
+    data: posts,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["posts", siegeId],
     queryFn: () => getPosts(siegeId),
   });
 
   const { data: board } = useQuery({
-    queryKey: ['board', siegeId],
+    queryKey: ["board", siegeId],
     queryFn: () => getBoard(siegeId),
   });
 
@@ -231,7 +254,9 @@ export default function PostsPage() {
           <ArrowLeft className="h-4 w-4" />
           Back to Sieges
         </Link>
-        <h1 className="text-2xl font-bold text-slate-900">Posts — Siege #{siegeId}</h1>
+        <h1 className="text-2xl font-bold text-slate-900">
+          Posts — Siege #{siegeId}
+        </h1>
         <p className="mt-1 text-sm text-slate-500">
           Set post conditions for each post in this siege.
         </p>
@@ -256,7 +281,7 @@ export default function PostsPage() {
               key={post.id}
               post={post}
               siegeId={siegeId}
-              isLocked={siege?.status === 'complete'}
+              isLocked={siege?.status === "complete"}
               initialExpanded={expandPostNumber === post.building_number}
               building={board?.buildings.find((b) => b.id === post.building_id)}
             />

--- a/frontend/src/pages/SiegeCreatePage.tsx
+++ b/frontend/src/pages/SiegeCreatePage.tsx
@@ -1,19 +1,19 @@
-import { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { createSiege, cloneSiege, getSieges } from '../api/sieges';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Label } from '../components/ui/label';
+import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createSiege, cloneSiege, getSieges } from "../api/sieges";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
-import { ArrowLeft } from 'lucide-react';
-import { isAxiosError } from 'axios';
+} from "../components/ui/select";
+import { ArrowLeft } from "lucide-react";
+import { isAxiosError } from "axios";
 
 /** Returns the next Tuesday that is at least `daysAhead` days from today (local time). */
 function nextTuesdayFrom(from: Date): Date {
@@ -26,15 +26,15 @@ function nextTuesdayFrom(from: Date): Date {
 
 function formatDateLocal(d: Date): string {
   const yyyy = d.getFullYear();
-  const mm = String(d.getMonth() + 1).padStart(2, '0');
-  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
   return `${yyyy}-${mm}-${dd}`;
 }
 
 function suggestNextSiegeDate(recentDate: string | null): string {
   if (recentDate) {
     // Parse the ISO date string as local date to avoid UTC offset shifting the day
-    const [y, m, day] = recentDate.split('-').map(Number);
+    const [y, m, day] = recentDate.split("-").map(Number);
     const last = new Date(y, m - 1, day);
     const twoWeeksLater = new Date(last);
     twoWeeksLater.setDate(last.getDate() + 14);
@@ -46,22 +46,23 @@ function suggestNextSiegeDate(recentDate: string | null): string {
 export default function SiegeCreatePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [cloneFromId, setCloneFromId] = useState<string>('none');
+  const [cloneFromId, setCloneFromId] = useState<string>("none");
 
   const { data: sieges } = useQuery({
-    queryKey: ['sieges'],
+    queryKey: ["sieges"],
     queryFn: () => getSieges(),
   });
 
   // Derive the suggested date once sieges have loaded; fall back to '' while loading
-  const mostRecentDate = sieges && sieges.length > 0 ? (sieges[0].date ?? null) : null;
+  const mostRecentDate =
+    sieges && sieges.length > 0 ? (sieges[0].date ?? null) : null;
   const suggestedDate =
-    sieges !== undefined ? suggestNextSiegeDate(mostRecentDate) : '';
+    sieges !== undefined ? suggestNextSiegeDate(mostRecentDate) : "";
 
-  const [date, setDate] = useState('');
+  const [date, setDate] = useState("");
   // Once the suggestion is ready and the user hasn't typed yet, apply it
   const effectiveDate = date || suggestedDate;
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   const createMutation = useMutation({
     mutationFn: () =>
@@ -69,31 +70,39 @@ export default function SiegeCreatePage() {
         date: effectiveDate || undefined,
       }),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
       navigate(`/sieges/${data.id}`);
     },
     onError: (err) => {
-      setError(isAxiosError(err) ? (err.response?.data?.detail ?? 'Failed to create siege') : 'Failed to create siege');
+      setError(
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Failed to create siege")
+          : "Failed to create siege"
+      );
     },
   });
 
   const cloneMutation = useMutation({
     mutationFn: (sourceId: number) => cloneSiege(sourceId),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
       navigate(`/sieges/${data.id}`);
     },
     onError: (err) => {
-      setError(isAxiosError(err) ? (err.response?.data?.detail ?? 'Failed to clone siege') : 'Failed to clone siege');
+      setError(
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Failed to clone siege")
+          : "Failed to clone siege"
+      );
     },
   });
 
-  const isCloning = cloneFromId !== 'none';
+  const isCloning = cloneFromId !== "none";
   const isPending = createMutation.isPending || cloneMutation.isPending;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setError('');
+    setError("");
     if (isCloning) {
       cloneMutation.mutate(Number(cloneFromId));
     } else {
@@ -116,7 +125,9 @@ export default function SiegeCreatePage() {
       <div className="rounded-lg border border-slate-200 bg-white p-6">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
-            <Label htmlFor="clone-from">Clone from existing siege (optional)</Label>
+            <Label htmlFor="clone-from">
+              Clone from existing siege (optional)
+            </Label>
             <Select value={cloneFromId} onValueChange={setCloneFromId}>
               <SelectTrigger id="clone-from">
                 <SelectValue placeholder="No — create blank siege" />
@@ -132,7 +143,8 @@ export default function SiegeCreatePage() {
             </Select>
             {isCloning && (
               <p className="text-xs text-slate-500">
-                Buildings and member assignments will be copied from the selected siege. Date and status will be reset to planning.
+                Buildings and member assignments will be copied from the
+                selected siege. Date and status will be reset to planning.
               </p>
             )}
           </div>
@@ -148,7 +160,6 @@ export default function SiegeCreatePage() {
                   onChange={(e) => setDate(e.target.value)}
                 />
               </div>
-
             </>
           )}
 
@@ -157,13 +168,17 @@ export default function SiegeCreatePage() {
           <div className="flex gap-3 pt-2">
             <Button type="submit" disabled={isPending}>
               {isPending
-                ? isCloning ? 'Cloning...' : 'Creating...'
-                : isCloning ? 'Clone Siege' : 'Create Siege'}
+                ? isCloning
+                  ? "Cloning..."
+                  : "Creating..."
+                : isCloning
+                  ? "Clone Siege"
+                  : "Create Siege"}
             </Button>
             <Button
               type="button"
               variant="outline"
-              onClick={() => navigate('/sieges')}
+              onClick={() => navigate("/sieges")}
             >
               Cancel
             </Button>

--- a/frontend/src/pages/SiegeMembersPage.tsx
+++ b/frontend/src/pages/SiegeMembersPage.tsx
@@ -1,6 +1,6 @@
-import { useParams, Link } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useParams, Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import {
   getSiege,
   getSiegeMembers,
@@ -8,9 +8,9 @@ import {
   updateSiegeMember,
   previewAttackDay,
   applyAttackDay,
-} from '../api/sieges';
-import { getMembers } from '../api/members';
-import type { SiegeMember, AttackDayPreviewResult } from '../api/types';
+} from "../api/sieges";
+import { getMembers } from "../api/members";
+import type { SiegeMember, AttackDayPreviewResult } from "../api/types";
 import {
   Table,
   TableBody,
@@ -18,16 +18,16 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '../components/ui/table';
-import { Button } from '../components/ui/button';
-import { Checkbox } from '../components/ui/checkbox';
+} from "../components/ui/table";
+import { Button } from "../components/ui/button";
+import { Checkbox } from "../components/ui/checkbox";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '../components/ui/select';
+} from "../components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -35,8 +35,8 @@ import {
   DialogTitle,
   DialogFooter,
   DialogDescription,
-} from '../components/ui/dialog';
-import { ArrowLeft, Lock, UserPlus, Loader2 } from 'lucide-react';
+} from "../components/ui/dialog";
+import { ArrowLeft, Lock, UserPlus, Loader2 } from "lucide-react";
 
 function AttackDaySelect({
   value,
@@ -47,8 +47,8 @@ function AttackDaySelect({
 }) {
   return (
     <Select
-      value={value != null ? String(value) : 'none'}
-      onValueChange={(v) => onChange(v === 'none' ? null : Number(v))}
+      value={value != null ? String(value) : "none"}
+      onValueChange={(v) => onChange(v === "none" ? null : Number(v))}
     >
       <SelectTrigger className="h-7 w-20 text-xs">
         <SelectValue />
@@ -62,7 +62,15 @@ function AttackDaySelect({
   );
 }
 
-function SiegeMemberRow({ member, siegeId, isLocked }: { member: SiegeMember; siegeId: number; isLocked?: boolean }) {
+function SiegeMemberRow({
+  member,
+  siegeId,
+  isLocked,
+}: {
+  member: SiegeMember;
+  siegeId: number;
+  isLocked?: boolean;
+}) {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
@@ -72,7 +80,7 @@ function SiegeMemberRow({ member, siegeId, isLocked }: { member: SiegeMember; si
       attack_day_override?: boolean;
     }) => updateSiegeMember(siegeId, member.member_id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siegeMembers', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["siegeMembers", siegeId] });
     },
   });
 
@@ -80,13 +88,18 @@ function SiegeMemberRow({ member, siegeId, isLocked }: { member: SiegeMember; si
     <TableRow>
       <TableCell className="font-medium">{member.member_name}</TableCell>
       <TableCell className="text-sm text-slate-600">
-        {{ heavy_hitter: 'Heavy Hitter', advanced: 'Advanced', medium: 'Medium', novice: 'Novice' }[member.member_role] ?? member.member_role}
+        {{
+          heavy_hitter: "Heavy Hitter",
+          advanced: "Advanced",
+          medium: "Medium",
+          novice: "Novice",
+        }[member.member_role] ?? member.member_role}
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-1.5">
           {isLocked ? (
             <span className="text-sm text-slate-600">
-              {member.attack_day ? `Day ${member.attack_day}` : '-'}
+              {member.attack_day ? `Day ${member.attack_day}` : "-"}
             </span>
           ) : (
             <AttackDaySelect
@@ -103,14 +116,22 @@ function SiegeMemberRow({ member, siegeId, isLocked }: { member: SiegeMember; si
         <Checkbox
           checked={Boolean(member.attack_day_override)}
           disabled={isLocked}
-          onCheckedChange={isLocked ? undefined : (v) => mutation.mutate({ attack_day_override: Boolean(v) })}
+          onCheckedChange={
+            isLocked
+              ? undefined
+              : (v) => mutation.mutate({ attack_day_override: Boolean(v) })
+          }
         />
       </TableCell>
       <TableCell>
         <Checkbox
           checked={Boolean(member.has_reserve_set)}
           disabled={isLocked}
-          onCheckedChange={isLocked ? undefined : (v) => mutation.mutate({ has_reserve_set: Boolean(v) })}
+          onCheckedChange={
+            isLocked
+              ? undefined
+              : (v) => mutation.mutate({ has_reserve_set: Boolean(v) })
+          }
         />
       </TableCell>
     </TableRow>
@@ -124,25 +145,29 @@ export default function SiegeMembersPage() {
   const [previewOpen, setPreviewOpen] = useState(false);
   const [preview, setPreview] = useState<AttackDayPreviewResult | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [selectedMemberId, setSelectedMemberId] = useState<string>('');
+  const [selectedMemberId, setSelectedMemberId] = useState<string>("");
   const [addError, setAddError] = useState<string | null>(null);
   const [reserveAssigning, setReserveAssigning] = useState(false);
 
   const { data: siege } = useQuery({
-    queryKey: ['siege', siegeId],
+    queryKey: ["siege", siegeId],
     queryFn: () => getSiege(siegeId),
   });
 
-  const { data: members, isLoading, error } = useQuery({
-    queryKey: ['siegeMembers', siegeId],
+  const {
+    data: members,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["siegeMembers", siegeId],
     queryFn: () => getSiegeMembers(siegeId),
   });
 
   // Only fetch available members when the add dialog is open and siege is planning
   const { data: allMembers } = useQuery({
-    queryKey: ['members', { is_active: true }],
+    queryKey: ["members", { is_active: true }],
     queryFn: () => getMembers({ is_active: true }),
-    enabled: addOpen && siege?.status === 'planning',
+    enabled: addOpen && siege?.status === "planning",
   });
 
   const siegeMemberIds = new Set(members?.map((m) => m.member_id) ?? []);
@@ -153,14 +178,16 @@ export default function SiegeMembersPage() {
   const addMutation = useMutation({
     mutationFn: (memberId: number) => addSiegeMember(siegeId, memberId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siegeMembers', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["siegeMembers", siegeId] });
       setAddOpen(false);
-      setSelectedMemberId('');
+      setSelectedMemberId("");
       setAddError(null);
     },
     onError: (err: unknown) => {
       const message =
-        err instanceof Error ? err.message : 'Failed to add member. Please try again.';
+        err instanceof Error
+          ? err.message
+          : "Failed to add member. Please try again.";
       setAddError(message);
     },
   });
@@ -176,7 +203,7 @@ export default function SiegeMembersPage() {
   const applyMutation = useMutation({
     mutationFn: () => applyAttackDay(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siegeMembers', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["siegeMembers", siegeId] });
       setPreviewOpen(false);
       setPreview(null);
     },
@@ -188,9 +215,11 @@ export default function SiegeMembersPage() {
     setReserveAssigning(true);
     try {
       for (const m of day2Members) {
-        await updateSiegeMember(siegeId, m.member_id, { has_reserve_set: true });
+        await updateSiegeMember(siegeId, m.member_id, {
+          has_reserve_set: true,
+        });
       }
-      queryClient.invalidateQueries({ queryKey: ['siegeMembers', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["siegeMembers", siegeId] });
     } finally {
       setReserveAssigning(false);
     }
@@ -205,12 +234,12 @@ export default function SiegeMembersPage() {
   function handleAddOpenChange(open: boolean) {
     setAddOpen(open);
     if (!open) {
-      setSelectedMemberId('');
+      setSelectedMemberId("");
       setAddError(null);
     }
   }
 
-  const isPlanning = siege?.status === 'planning';
+  const isPlanning = siege?.status === "planning";
 
   // Build a quick name lookup for the preview dialog
   const nameLookup: Record<number, string> = {};
@@ -234,31 +263,40 @@ export default function SiegeMembersPage() {
           </h1>
         </div>
         <div className="flex gap-2">
-            {isPlanning && (
-              <Button size="sm" variant="outline" onClick={() => setAddOpen(true)}>
-                <UserPlus className="mr-1.5 h-4 w-4" />
-                Add Member
-              </Button>
-            )}
+          {isPlanning && (
             <Button
+              size="sm"
               variant="outline"
-              size="sm"
-              onClick={handleAutoAssignReserves}
-              disabled={reserveAssigning || siege?.status === 'complete'}
+              onClick={() => setAddOpen(true)}
             >
-              {reserveAssigning ? (
-                <><Loader2 className="mr-1.5 h-4 w-4 animate-spin" />Assigning...</>
-              ) : (
-                'Auto-Assign Reserves'
-              )}
+              <UserPlus className="mr-1.5 h-4 w-4" />
+              Add Member
             </Button>
-            <Button
-              size="sm"
-              onClick={() => previewMutation.mutate()}
-              disabled={previewMutation.isPending || siege?.status === 'complete'}
-            >
-              {previewMutation.isPending ? 'Loading...' : 'Auto-Assign Attack Days'}
-            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAutoAssignReserves}
+            disabled={reserveAssigning || siege?.status === "complete"}
+          >
+            {reserveAssigning ? (
+              <>
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                Assigning...
+              </>
+            ) : (
+              "Auto-Assign Reserves"
+            )}
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => previewMutation.mutate()}
+            disabled={previewMutation.isPending || siege?.status === "complete"}
+          >
+            {previewMutation.isPending
+              ? "Loading..."
+              : "Auto-Assign Attack Days"}
+          </Button>
         </div>
       </div>
 
@@ -285,14 +323,25 @@ export default function SiegeMembersPage() {
             <TableBody>
               {members?.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={4} className="py-8 text-center text-slate-500">
+                  <TableCell
+                    colSpan={4}
+                    className="py-8 text-center text-slate-500"
+                  >
                     No members in this siege.
                   </TableCell>
                 </TableRow>
               )}
-              {members?.slice().sort((a, b) => a.member_name.localeCompare(b.member_name)).map((m) => (
-                <SiegeMemberRow key={m.member_id} member={m} siegeId={siegeId} isLocked={siege?.status === 'complete'} />
-              ))}
+              {members
+                ?.slice()
+                .sort((a, b) => a.member_name.localeCompare(b.member_name))
+                .map((m) => (
+                  <SiegeMemberRow
+                    key={m.member_id}
+                    member={m}
+                    siegeId={siegeId}
+                    isLocked={siege?.status === "complete"}
+                  />
+                ))}
             </TableBody>
           </Table>
         </div>
@@ -308,7 +357,10 @@ export default function SiegeMembersPage() {
             </DialogDescription>
           </DialogHeader>
           <div className="py-2">
-            <Select value={selectedMemberId} onValueChange={setSelectedMemberId}>
+            <Select
+              value={selectedMemberId}
+              onValueChange={setSelectedMemberId}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Select a member..." />
               </SelectTrigger>
@@ -326,17 +378,22 @@ export default function SiegeMembersPage() {
                 )}
               </SelectContent>
             </Select>
-            {addError && <p className="mt-2 text-sm text-red-600">{addError}</p>}
+            {addError && (
+              <p className="mt-2 text-sm text-red-600">{addError}</p>
+            )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => handleAddOpenChange(false)}>
+            <Button
+              variant="outline"
+              onClick={() => handleAddOpenChange(false)}
+            >
               Cancel
             </Button>
             <Button
               onClick={handleAddConfirm}
               disabled={!selectedMemberId || addMutation.isPending}
             >
-              {addMutation.isPending ? 'Adding...' : 'Add'}
+              {addMutation.isPending ? "Adding..." : "Add"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -351,49 +408,68 @@ export default function SiegeMembersPage() {
               {preview?.assignments.length ?? 0} members will be assigned.
             </DialogDescription>
           </DialogHeader>
-          {preview && (() => {
-            const byName = (a: { member_id: number }, b: { member_id: number }) =>
-              (nameLookup[a.member_id] ?? '').localeCompare(nameLookup[b.member_id] ?? '');
-            const day1 = preview.assignments.filter((a) => a.attack_day === 1).sort(byName);
-            const day2 = preview.assignments.filter((a) => a.attack_day === 2).sort(byName);
-            const rows = Math.max(day1.length, day2.length);
-            return (
-              <div className="grid grid-cols-2 divide-x divide-slate-200 rounded-md border border-slate-200">
-                <div>
-                  <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    Day 1 ({day1.length})
-                  </div>
-                  {Array.from({ length: rows }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="px-3 py-1.5 text-sm odd:bg-slate-50"
-                    >
-                      {day1[i] ? (nameLookup[day1[i].member_id] ?? `Member ${day1[i].member_id}`) : ''}
+          {preview &&
+            (() => {
+              const byName = (
+                a: { member_id: number },
+                b: { member_id: number }
+              ) =>
+                (nameLookup[a.member_id] ?? "").localeCompare(
+                  nameLookup[b.member_id] ?? ""
+                );
+              const day1 = preview.assignments
+                .filter((a) => a.attack_day === 1)
+                .sort(byName);
+              const day2 = preview.assignments
+                .filter((a) => a.attack_day === 2)
+                .sort(byName);
+              const rows = Math.max(day1.length, day2.length);
+              return (
+                <div className="grid grid-cols-2 divide-x divide-slate-200 rounded-md border border-slate-200">
+                  <div>
+                    <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Day 1 ({day1.length})
                     </div>
-                  ))}
-                </div>
-                <div>
-                  <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    Day 2 ({day2.length})
+                    {Array.from({ length: rows }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="px-3 py-1.5 text-sm odd:bg-slate-50"
+                      >
+                        {day1[i]
+                          ? (nameLookup[day1[i].member_id] ??
+                            `Member ${day1[i].member_id}`)
+                          : ""}
+                      </div>
+                    ))}
                   </div>
-                  {Array.from({ length: rows }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="px-3 py-1.5 text-sm odd:bg-slate-50"
-                    >
-                      {day2[i] ? (nameLookup[day2[i].member_id] ?? `Member ${day2[i].member_id}`) : ''}
+                  <div>
+                    <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Day 2 ({day2.length})
                     </div>
-                  ))}
+                    {Array.from({ length: rows }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="px-3 py-1.5 text-sm odd:bg-slate-50"
+                      >
+                        {day2[i]
+                          ? (nameLookup[day2[i].member_id] ??
+                            `Member ${day2[i].member_id}`)
+                          : ""}
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              </div>
-            );
-          })()}
+              );
+            })()}
           <DialogFooter>
             <Button variant="outline" onClick={() => setPreviewOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={() => applyMutation.mutate()} disabled={applyMutation.isPending}>
-              {applyMutation.isPending ? 'Applying...' : 'Apply'}
+            <Button
+              onClick={() => applyMutation.mutate()}
+              disabled={applyMutation.isPending}
+            >
+              {applyMutation.isPending ? "Applying..." : "Apply"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/pages/SiegeSettingsPage.tsx
+++ b/frontend/src/pages/SiegeSettingsPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getSiege,
   updateSiege,
@@ -13,23 +13,23 @@ import {
   getBuildings,
   updateBuilding,
   getSiegeMembers,
-} from '../api/sieges';
+} from "../api/sieges";
 import {
   notifySiegeMembers,
   getNotificationBatch,
   postToChannel,
   generateImages,
-} from '../api/notifications';
+} from "../api/notifications";
 import type {
   ValidationIssue,
   ValidationResult,
   NotifyResponse,
   NotificationResultItem,
-} from '../api/types';
-import { Button } from '../components/ui/button';
-import { Input } from '../components/ui/input';
-import { Label } from '../components/ui/label';
-import { Checkbox } from '../components/ui/checkbox';
+} from "../api/types";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Checkbox } from "../components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -37,8 +37,8 @@ import {
   DialogTitle,
   DialogFooter,
   DialogDescription,
-} from '../components/ui/dialog';
-import { Badge } from '../components/ui/badge';
+} from "../components/ui/dialog";
+import { Badge } from "../components/ui/badge";
 import {
   ArrowLeft,
   MessageSquare,
@@ -49,10 +49,10 @@ import {
   Download,
   Send,
   Image,
-} from 'lucide-react';
-import { isAxiosError } from 'axios';
-import { cn } from '../lib/utils';
-import { BUILDING_COLORS, BUILDING_LABELS } from '../lib/buildingColors';
+} from "lucide-react";
+import { isAxiosError } from "axios";
+import { cn } from "../lib/utils";
+import { BUILDING_COLORS, BUILDING_LABELS } from "../lib/buildingColors";
 
 export default function SiegeSettingsPage() {
   const { id } = useParams<{ id: string }>();
@@ -60,8 +60,8 @@ export default function SiegeSettingsPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [date, setDate] = useState('');
-  const [settingsError, setSettingsError] = useState('');
+  const [date, setDate] = useState("");
+  const [settingsError, setSettingsError] = useState("");
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [cloneConfirmOpen, setCloneConfirmOpen] = useState(false);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
@@ -71,7 +71,9 @@ export default function SiegeSettingsPage() {
   const [notifyConfirmOpen, setNotifyConfirmOpen] = useState(false);
   const [postConfirmOpen, setPostConfirmOpen] = useState(false);
   const [notifyBatch, setNotifyBatch] = useState<NotifyResponse | null>(null);
-  const [postChannelResult, setPostChannelResult] = useState<string | null>(null);
+  const [postChannelResult, setPostChannelResult] = useState<string | null>(
+    null
+  );
   const [postChannelError, setPostChannelError] = useState<string | null>(null);
   const [notifyError, setNotifyError] = useState<string | null>(null);
   const [generatedImages, setGeneratedImages] = useState<{
@@ -80,26 +82,27 @@ export default function SiegeSettingsPage() {
   } | null>(null);
 
   const { data: siege, isLoading: siegeLoading } = useQuery({
-    queryKey: ['siege', siegeId],
+    queryKey: ["siege", siegeId],
     queryFn: () => getSiege(siegeId),
   });
 
   const { data: buildings } = useQuery({
-    queryKey: ['buildings', siegeId],
+    queryKey: ["buildings", siegeId],
     queryFn: () => getBuildings(siegeId),
   });
 
   const { data: siegeMembers } = useQuery({
-    queryKey: ['siegeMembers', siegeId],
+    queryKey: ["siegeMembers", siegeId],
     queryFn: () => getSiegeMembers(siegeId),
   });
 
   // Notification batch polling — runs until all results have success !== null or status === "completed"
   const batchDone = (results: NotificationResultItem[], status: string) =>
-    status === 'completed' || (results.length > 0 && results.every((r) => r.success !== null));
+    status === "completed" ||
+    (results.length > 0 && results.every((r) => r.success !== null));
 
   const { data: batchData } = useQuery({
-    queryKey: ['notificationBatch', siegeId, notifyBatch?.batch_id],
+    queryKey: ["notificationBatch", siegeId, notifyBatch?.batch_id],
     queryFn: () => getNotificationBatch(siegeId, notifyBatch!.batch_id),
     enabled: notifyBatch != null,
     refetchInterval: (query) => {
@@ -111,20 +114,25 @@ export default function SiegeSettingsPage() {
 
   const batchInProgress =
     notifyBatch !== null &&
-    !batchDone(batchData?.results ?? [], batchData?.status ?? notifyBatch?.status ?? '');
+    !batchDone(
+      batchData?.results ?? [],
+      batchData?.status ?? notifyBatch?.status ?? ""
+    );
 
-  const batchComplete = batchData?.status === 'completed';
+  const batchComplete = batchData?.status === "completed";
 
   useEffect(() => {
     if (siege) {
-      setDate(siege.date ?? '');
+      setDate(siege.date ?? "");
     }
   }, [siege]);
 
   // Eagerly run validation on mount so the Notify button is correctly gated
   // even if the user hasn't manually clicked "Validate" in this session.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { validateMutation.mutate(); }, [siegeId]);
+  useEffect(() => {
+    validateMutation.mutate();
+  }, [siegeId]);
 
   const updateMutation = useMutation({
     mutationFn: () =>
@@ -132,40 +140,57 @@ export default function SiegeSettingsPage() {
         date: date || null,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siege', siegeId] });
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
-      setSettingsError('');
+      queryClient.invalidateQueries({ queryKey: ["siege", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
+      setSettingsError("");
     },
     onError: (err) => {
-      setSettingsError(isAxiosError(err) ? (err.response?.data?.detail ?? 'Save failed') : 'Save failed');
+      setSettingsError(
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Save failed")
+          : "Save failed"
+      );
     },
   });
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteSiege(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
-      navigate('/sieges');
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
+      navigate("/sieges");
     },
   });
 
   const activateMutation = useMutation({
     mutationFn: () => activateSiege(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siege', siegeId] });
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["siege", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
       setActivateErrors([]);
     },
     onError: (err) => {
       if (isAxiosError(err) && err.response?.status === 400) {
         const detail = err.response.data?.detail;
-        if (Array.isArray(detail) && detail.length > 0 && typeof detail[0].rule === 'number') {
+        if (
+          Array.isArray(detail) &&
+          detail.length > 0 &&
+          typeof detail[0].rule === "number"
+        ) {
           setActivateErrors(detail as ValidationIssue[]);
         } else {
-          setActivateErrors([{ rule: 0, message: typeof detail === 'string' ? detail : 'Activation failed', context: null }]);
+          setActivateErrors([
+            {
+              rule: 0,
+              message:
+                typeof detail === "string" ? detail : "Activation failed",
+              context: null,
+            },
+          ]);
         }
       } else {
-        setActivateErrors([{ rule: 0, message: 'Activation failed', context: null }]);
+        setActivateErrors([
+          { rule: 0, message: "Activation failed", context: null },
+        ]);
       }
     },
   });
@@ -173,15 +198,15 @@ export default function SiegeSettingsPage() {
   const completeMutation = useMutation({
     mutationFn: () => completeSiege(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siege', siegeId] });
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["siege", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
     },
   });
 
   const cloneMutation = useMutation({
     mutationFn: () => cloneSiege(siegeId),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
       navigate(`/sieges/${data.id}`);
     },
   });
@@ -189,8 +214,8 @@ export default function SiegeSettingsPage() {
   const reopenMutation = useMutation({
     mutationFn: () => reopenSiege(siegeId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['siege', siegeId] });
-      queryClient.invalidateQueries({ queryKey: ['sieges'] });
+      queryClient.invalidateQueries({ queryKey: ["siege", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["sieges"] });
     },
   });
 
@@ -208,8 +233,8 @@ export default function SiegeSettingsPage() {
       data: { level?: number; is_broken?: boolean };
     }) => updateBuilding(siegeId, buildingId, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['buildings', siegeId] });
-      queryClient.invalidateQueries({ queryKey: ['siege', siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["buildings", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["siege", siegeId] });
     },
   });
 
@@ -222,7 +247,9 @@ export default function SiegeSettingsPage() {
     },
     onError: (err) => {
       setNotifyError(
-        isAxiosError(err) ? (err.response?.data?.detail ?? 'Failed to send notifications.') : 'Failed to send notifications.',
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Failed to send notifications.")
+          : "Failed to send notifications."
       );
       setNotifyConfirmOpen(false);
     },
@@ -231,13 +258,19 @@ export default function SiegeSettingsPage() {
   const postChannelMutation = useMutation({
     mutationFn: () => postToChannel(siegeId),
     onSuccess: (data) => {
-      setPostChannelResult(data.status === 'ok' ? 'Posted successfully.' : (data.detail ?? 'Posted.'));
+      setPostChannelResult(
+        data.status === "ok"
+          ? "Posted successfully."
+          : (data.detail ?? "Posted.")
+      );
       setPostChannelError(null);
       setPostConfirmOpen(false);
     },
     onError: (err) => {
       setPostChannelError(
-        isAxiosError(err) ? (err.response?.data?.detail ?? 'Post failed') : 'Post failed',
+        isAxiosError(err)
+          ? (err.response?.data?.detail ?? "Post failed")
+          : "Post failed"
       );
       setPostChannelResult(null);
       setPostConfirmOpen(false);
@@ -256,9 +289,9 @@ export default function SiegeSettingsPage() {
     for (let i = 0; i < byteString.length; i++) {
       ia[i] = byteString.charCodeAt(i);
     }
-    const blob = new Blob([ab], { type: 'image/png' });
+    const blob = new Blob([ab], { type: "image/png" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
     a.download = filename;
     a.click();
@@ -289,18 +322,20 @@ export default function SiegeSettingsPage() {
       <section className="mb-6 rounded-lg border border-slate-200 bg-white p-6">
         <div className="mb-4 flex items-center gap-3">
           <h2 className="text-base font-semibold text-slate-900">Lifecycle</h2>
-          {siege?.status === 'planning' && (
+          {siege?.status === "planning" && (
             <Badge variant="secondary">Planning</Badge>
           )}
-          {siege?.status === 'active' && (
-            <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Active</Badge>
+          {siege?.status === "active" && (
+            <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+              Active
+            </Badge>
           )}
-          {siege?.status === 'complete' && (
+          {siege?.status === "complete" && (
             <Badge variant="outline">Complete</Badge>
           )}
         </div>
         <div className="flex flex-row flex-wrap items-center gap-3">
-          {siege?.status === 'planning' && (
+          {siege?.status === "planning" && (
             <Button
               variant="default"
               onClick={() => activateMutation.mutate()}
@@ -309,7 +344,7 @@ export default function SiegeSettingsPage() {
               Start Siege
             </Button>
           )}
-          {siege?.status === 'active' && (
+          {siege?.status === "active" && (
             <Button
               variant="secondary"
               onClick={() => completeMutation.mutate()}
@@ -318,7 +353,7 @@ export default function SiegeSettingsPage() {
               Close Siege
             </Button>
           )}
-          {siege?.status === 'complete' && (
+          {siege?.status === "complete" && (
             <Button
               variant="outline"
               onClick={() => reopenMutation.mutate()}
@@ -334,7 +369,7 @@ export default function SiegeSettingsPage() {
           >
             Clone
           </Button>
-          {siege?.status === 'planning' && (
+          {siege?.status === "planning" && (
             <Button variant="destructive" onClick={() => setDeleteOpen(true)}>
               Delete
             </Button>
@@ -343,7 +378,10 @@ export default function SiegeSettingsPage() {
         {activateErrors.length > 0 && (
           <div className="mt-4 space-y-2">
             {activateErrors.map((e, i) => (
-              <div key={i} className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2">
+              <div
+                key={i}
+                className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2"
+              >
                 {e.rule > 0 && (
                   <Badge variant="destructive" className="mt-0.5 shrink-0">
                     Error {e.rule}
@@ -358,7 +396,9 @@ export default function SiegeSettingsPage() {
 
       {/* Discord Notifications */}
       <section className="mb-6 rounded-lg border border-slate-200 bg-white p-6">
-        <h2 className="mb-4 text-base font-semibold text-slate-900">Discord Notifications</h2>
+        <h2 className="mb-4 text-base font-semibold text-slate-900">
+          Discord Notifications
+        </h2>
 
         {/* Action buttons in a horizontal row */}
         <div className="mb-4 flex flex-wrap items-center gap-3">
@@ -369,38 +409,58 @@ export default function SiegeSettingsPage() {
             disabled={
               notifyMutation.isPending ||
               batchInProgress ||
-              siege?.status === 'complete' ||
+              siege?.status === "complete" ||
               !siege?.date ||
               (validation !== null && validation.errors.length > 0)
             }
-            title={!siege?.date ? 'Set a siege date before sending to Discord' : undefined}
+            title={
+              !siege?.date
+                ? "Set a siege date before sending to Discord"
+                : undefined
+            }
           >
-            {(notifyMutation.isPending || batchInProgress)
-              ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              : <Send className="mr-1.5 h-4 w-4" />}
+            {notifyMutation.isPending || batchInProgress ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="mr-1.5 h-4 w-4" />
+            )}
             Notify Members
           </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={() => setPostConfirmOpen(true)}
-            disabled={postChannelMutation.isPending || siege?.status === 'complete' || !siege?.date}
-            title={!siege?.date ? 'Set a siege date before sending to Discord' : undefined}
+            disabled={
+              postChannelMutation.isPending ||
+              siege?.status === "complete" ||
+              !siege?.date
+            }
+            title={
+              !siege?.date
+                ? "Set a siege date before sending to Discord"
+                : undefined
+            }
           >
-            {postChannelMutation.isPending
-              ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              : <MessageSquare className="mr-1.5 h-4 w-4" />}
+            {postChannelMutation.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <MessageSquare className="mr-1.5 h-4 w-4" />
+            )}
             Post to Discord
           </Button>
           <Button
             variant="outline"
             size="sm"
             onClick={() => generateImagesMutation.mutate()}
-            disabled={generateImagesMutation.isPending || siege?.status === 'complete'}
+            disabled={
+              generateImagesMutation.isPending || siege?.status === "complete"
+            }
           >
-            {generateImagesMutation.isPending
-              ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              : <Image className="mr-1.5 h-4 w-4" />}
+            {generateImagesMutation.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Image className="mr-1.5 h-4 w-4" />
+            )}
             Generate Images
           </Button>
         </div>
@@ -415,8 +475,10 @@ export default function SiegeSettingsPage() {
         {validation !== null && validation.errors.length > 0 && (
           <p className="flex items-center gap-1.5 text-sm text-red-600">
             <AlertCircle className="h-4 w-4 shrink-0" />
-            Notifications blocked: resolve {validation.errors.length} validation error
-            {validation.errors.length !== 1 ? 's' : ''} before notifying members.
+            Notifications blocked: resolve {validation.errors.length} validation
+            error
+            {validation.errors.length !== 1 ? "s" : ""} before notifying
+            members.
           </p>
         )}
 
@@ -433,13 +495,14 @@ export default function SiegeSettingsPage() {
           {notifyBatch && (
             <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
               <p className="mb-2 text-xs text-slate-500">
-                Batch #{notifyBatch.batch_id} &bull; {notifyBatch.member_count} members &bull;{' '}
+                Batch #{notifyBatch.batch_id} &bull; {notifyBatch.member_count}{" "}
+                members &bull;{" "}
                 <span
                   className={cn(
-                    'font-medium',
-                    batchData?.status === 'completed'
-                      ? 'text-green-600'
-                      : 'text-amber-600',
+                    "font-medium",
+                    batchData?.status === "completed"
+                      ? "text-green-600"
+                      : "text-amber-600"
                   )}
                 >
                   {batchData?.status ?? notifyBatch.status}
@@ -447,40 +510,58 @@ export default function SiegeSettingsPage() {
               </p>
               <ul className="space-y-1">
                 {(batchData?.results ?? []).map((item) => (
-                  <li key={item.member_id} className="flex items-center gap-2 text-sm">
+                  <li
+                    key={item.member_id}
+                    className="flex items-center gap-2 text-sm"
+                  >
                     {item.success === true && (
                       <Check className="h-4 w-4 shrink-0 text-green-600" />
                     )}
                     {item.success === false && (
                       <X className="h-4 w-4 shrink-0 text-red-600" />
                     )}
-                    {item.discord_username === null && item.success === null && (
-                      <AlertCircle className="h-4 w-4 shrink-0 text-yellow-500" />
-                    )}
-                    {item.discord_username !== null && item.success === null && !batchComplete && (
-                      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-slate-400" />
-                    )}
-                    {item.discord_username !== null && item.success === null && batchComplete && (
-                      <AlertCircle className="h-4 w-4 shrink-0 text-red-400" />
-                    )}
+                    {item.discord_username === null &&
+                      item.success === null && (
+                        <AlertCircle className="h-4 w-4 shrink-0 text-yellow-500" />
+                      )}
+                    {item.discord_username !== null &&
+                      item.success === null &&
+                      !batchComplete && (
+                        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-slate-400" />
+                      )}
+                    {item.discord_username !== null &&
+                      item.success === null &&
+                      batchComplete && (
+                        <AlertCircle className="h-4 w-4 shrink-0 text-red-400" />
+                      )}
                     <span
                       className={cn(
-                        item.success === true && 'text-slate-700',
-                        item.success === false && 'text-red-700',
-                        item.discord_username === null && item.success === null && 'text-yellow-700',
-                        item.discord_username !== null && item.success === null && !batchComplete && 'text-slate-500',
-                        item.discord_username !== null && item.success === null && batchComplete && 'text-red-700',
+                        item.success === true && "text-slate-700",
+                        item.success === false && "text-red-700",
+                        item.discord_username === null &&
+                          item.success === null &&
+                          "text-yellow-700",
+                        item.discord_username !== null &&
+                          item.success === null &&
+                          !batchComplete &&
+                          "text-slate-500",
+                        item.discord_username !== null &&
+                          item.success === null &&
+                          batchComplete &&
+                          "text-red-700"
                       )}
                     >
                       {item.member_name}
                       {item.discord_username === null && item.success === null
-                        ? ' — No Discord username'
+                        ? " — No Discord username"
                         : null}
                       {item.success === false && item.error
                         ? ` — ${item.error}`
                         : null}
-                      {item.discord_username !== null && item.success === null && batchComplete
-                        ? ' — Status unknown'
+                      {item.discord_username !== null &&
+                      item.success === null &&
+                      batchComplete
+                        ? " — Status unknown"
                         : null}
                     </span>
                   </li>
@@ -501,8 +582,9 @@ export default function SiegeSettingsPage() {
           {generateImagesMutation.isError && (
             <p className="text-sm text-red-600">
               {isAxiosError(generateImagesMutation.error)
-                ? (generateImagesMutation.error.response?.data?.detail ?? 'Generation failed')
-                : 'Generation failed'}
+                ? (generateImagesMutation.error.response?.data?.detail ??
+                  "Generation failed")
+                : "Generation failed"}
             </p>
           )}
 
@@ -511,7 +593,9 @@ export default function SiegeSettingsPage() {
             <div className="space-y-4">
               <div>
                 <div className="mb-1.5 flex items-center gap-2">
-                  <span className="text-sm font-medium text-slate-700">Assignments</span>
+                  <span className="text-sm font-medium text-slate-700">
+                    Assignments
+                  </span>
                   <Button
                     variant="outline"
                     size="sm"
@@ -519,7 +603,7 @@ export default function SiegeSettingsPage() {
                     onClick={() =>
                       downloadImage(
                         generatedImages.assignments_image,
-                        `siege-${siegeId}-assignments.png`,
+                        `siege-${siegeId}-assignments.png`
                       )
                     }
                   >
@@ -535,7 +619,9 @@ export default function SiegeSettingsPage() {
               </div>
               <div>
                 <div className="mb-1.5 flex items-center gap-2">
-                  <span className="text-sm font-medium text-slate-700">Reserves</span>
+                  <span className="text-sm font-medium text-slate-700">
+                    Reserves
+                  </span>
                   <Button
                     variant="outline"
                     size="sm"
@@ -543,7 +629,7 @@ export default function SiegeSettingsPage() {
                     onClick={() =>
                       downloadImage(
                         generatedImages.reserves_image,
-                        `siege-${siegeId}-reserves.png`,
+                        `siege-${siegeId}-reserves.png`
                       )
                     }
                   >
@@ -564,7 +650,9 @@ export default function SiegeSettingsPage() {
 
       {/* Siege Settings */}
       <section className="mb-6 rounded-lg border border-slate-200 bg-white p-6">
-        <h2 className="mb-4 text-base font-semibold text-slate-900">Siege Settings</h2>
+        <h2 className="mb-4 text-base font-semibold text-slate-900">
+          Siege Settings
+        </h2>
         <div className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="date">Date</Label>
@@ -573,7 +661,7 @@ export default function SiegeSettingsPage() {
               type="date"
               value={date}
               onChange={(e) => setDate(e.target.value)}
-              disabled={siege?.status === 'complete'}
+              disabled={siege?.status === "complete"}
             />
           </div>
           <div className="space-y-1.5">
@@ -584,7 +672,7 @@ export default function SiegeSettingsPage() {
               </p>
               {siegeMembers !== undefined && siegeMembers.length > 0 && (
                 <p className="text-sm text-slate-500">
-                  Scrolls per member:{' '}
+                  Scrolls per member:{" "}
                   <span className="font-medium text-slate-900">
                     {(siege?.computed_scroll_count ?? 0) < 90 ? 3 : 4}
                   </span>
@@ -592,9 +680,14 @@ export default function SiegeSettingsPage() {
               )}
             </div>
           </div>
-          {settingsError && <p className="text-sm text-red-600">{settingsError}</p>}
-          <Button onClick={() => updateMutation.mutate()} disabled={updateMutation.isPending || siege?.status === 'complete'}>
-            {updateMutation.isPending ? 'Saving...' : 'Save Settings'}
+          {settingsError && (
+            <p className="text-sm text-red-600">{settingsError}</p>
+          )}
+          <Button
+            onClick={() => updateMutation.mutate()}
+            disabled={updateMutation.isPending || siege?.status === "complete"}
+          >
+            {updateMutation.isPending ? "Saving..." : "Save Settings"}
           </Button>
           {updateMutation.isSuccess && (
             <span className="ml-3 text-sm text-green-600">Saved.</span>
@@ -604,86 +697,98 @@ export default function SiegeSettingsPage() {
 
       {/* Buildings */}
       <section className="mb-6 rounded-lg border border-slate-200 bg-white p-6">
-        <h2 className="mb-4 text-base font-semibold text-slate-900">Buildings</h2>
+        <h2 className="mb-4 text-base font-semibold text-slate-900">
+          Buildings
+        </h2>
         {buildings && buildings.length > 0 && (
           <div className="mb-4 space-y-2">
-            {buildings.filter((b) => b.building_type !== 'post').map((b) => {
-              const colors = BUILDING_COLORS[b.building_type];
-              return (
-                <div
-                  key={b.id}
-                  className={cn(
-                    'flex overflow-hidden rounded-md border',
-                    colors.border,
-                    b.is_broken && 'opacity-60',
-                  )}
-                >
-                  {/* Colored label bar — mirrors the Board page building header */}
+            {buildings
+              .filter((b) => b.building_type !== "post")
+              .map((b) => {
+                const colors = BUILDING_COLORS[b.building_type];
+                return (
                   <div
+                    key={b.id}
                     className={cn(
-                      colors.header,
-                      'flex w-36 shrink-0 flex-col justify-center px-2 py-2 text-white',
+                      "flex overflow-hidden rounded-md border",
+                      colors.border,
+                      b.is_broken && "opacity-60"
                     )}
                   >
-                    <p className="text-xs font-semibold leading-tight">
-                      {BUILDING_LABELS[b.building_type]} {b.building_number}
-                    </p>
-                    <p className="mt-0.5 text-xs opacity-75">
-                      Lv {b.level}
-                      {b.is_broken ? ' · Broken' : ''}
-                    </p>
-                  </div>
-
-                  {/* Controls area */}
-                  <div className={cn('flex flex-1 items-center gap-4 px-3 py-2', colors.bg)}>
-                    <div className="flex items-center gap-1">
-                      <span className="mr-1 text-xs text-slate-500">Lvl</span>
-                      {[1, 2, 3, 4, 5, 6].map((lvl) => (
-                        <button
-                          key={lvl}
-                          className={cn(
-                            'h-7 w-7 rounded text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-                            b.level === lvl
-                              ? cn(colors.header, 'text-white')
-                              : 'bg-white text-slate-600 hover:bg-slate-100',
-                          )}
-                          disabled={siege?.status === 'complete'}
-                          onClick={() => {
-                            if (lvl !== b.level) {
-                              updateBuildingMutation.mutate({
-                                buildingId: b.id,
-                                data: { level: lvl },
-                              });
-                            }
-                          }}
-                        >
-                          {lvl}
-                        </button>
-                      ))}
+                    {/* Colored label bar — mirrors the Board page building header */}
+                    <div
+                      className={cn(
+                        colors.header,
+                        "flex w-36 shrink-0 flex-col justify-center px-2 py-2 text-white"
+                      )}
+                    >
+                      <p className="text-xs font-semibold leading-tight">
+                        {BUILDING_LABELS[b.building_type]} {b.building_number}
+                      </p>
+                      <p className="mt-0.5 text-xs opacity-75">
+                        Lv {b.level}
+                        {b.is_broken ? " · Broken" : ""}
+                      </p>
                     </div>
-                    <div className="flex items-center gap-1.5">
-                      <Checkbox
-                        id={`broken-${b.id}`}
-                        checked={b.is_broken}
-                        disabled={siege?.status === 'complete'}
-                        onCheckedChange={
-                          siege?.status === 'complete'
-                            ? undefined
-                            : (v) =>
+
+                    {/* Controls area */}
+                    <div
+                      className={cn(
+                        "flex flex-1 items-center gap-4 px-3 py-2",
+                        colors.bg
+                      )}
+                    >
+                      <div className="flex items-center gap-1">
+                        <span className="mr-1 text-xs text-slate-500">Lvl</span>
+                        {[1, 2, 3, 4, 5, 6].map((lvl) => (
+                          <button
+                            key={lvl}
+                            className={cn(
+                              "h-7 w-7 rounded text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                              b.level === lvl
+                                ? cn(colors.header, "text-white")
+                                : "bg-white text-slate-600 hover:bg-slate-100"
+                            )}
+                            disabled={siege?.status === "complete"}
+                            onClick={() => {
+                              if (lvl !== b.level) {
                                 updateBuildingMutation.mutate({
                                   buildingId: b.id,
-                                  data: { is_broken: Boolean(v) },
-                                })
-                        }
-                      />
-                      <Label htmlFor={`broken-${b.id}`} className="text-xs text-slate-500">
-                        Broken
-                      </Label>
+                                  data: { level: lvl },
+                                });
+                              }
+                            }}
+                          >
+                            {lvl}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <Checkbox
+                          id={`broken-${b.id}`}
+                          checked={b.is_broken}
+                          disabled={siege?.status === "complete"}
+                          onCheckedChange={
+                            siege?.status === "complete"
+                              ? undefined
+                              : (v) =>
+                                  updateBuildingMutation.mutate({
+                                    buildingId: b.id,
+                                    data: { is_broken: Boolean(v) },
+                                  })
+                          }
+                        />
+                        <Label
+                          htmlFor={`broken-${b.id}`}
+                          className="text-xs text-slate-500"
+                        >
+                          Broken
+                        </Label>
+                      </div>
                     </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
           </div>
         )}
       </section>
@@ -698,16 +803,20 @@ export default function SiegeSettingsPage() {
             onClick={() => validateMutation.mutate()}
             disabled={validateMutation.isPending}
           >
-            {validateMutation.isPending ? 'Checking...' : 'Run Validation'}
+            {validateMutation.isPending ? "Checking..." : "Run Validation"}
           </Button>
         </div>
         {validation && (
           <div className="space-y-2">
-            {validation.errors.length === 0 && validation.warnings.length === 0 && (
-              <p className="text-sm text-green-600">No issues found.</p>
-            )}
+            {validation.errors.length === 0 &&
+              validation.warnings.length === 0 && (
+                <p className="text-sm text-green-600">No issues found.</p>
+              )}
             {validation.errors.map((e, i) => (
-              <div key={i} className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2">
+              <div
+                key={i}
+                className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2"
+              >
                 <Badge variant="destructive" className="mt-0.5 shrink-0">
                   Error {e.rule}
                 </Badge>
@@ -715,7 +824,10 @@ export default function SiegeSettingsPage() {
               </div>
             ))}
             {validation.warnings.map((w, i) => (
-              <div key={i} className="flex items-start gap-2 rounded-md bg-yellow-50 px-3 py-2">
+              <div
+                key={i}
+                className="flex items-start gap-2 rounded-md bg-yellow-50 px-3 py-2"
+              >
                 <Badge variant="yellow" className="mt-0.5 shrink-0">
                   Warning {w.rule}
                 </Badge>
@@ -732,8 +844,8 @@ export default function SiegeSettingsPage() {
           <DialogHeader>
             <DialogTitle>Delete Siege</DialogTitle>
             <DialogDescription>
-              This action cannot be undone. All buildings and assignments will be permanently
-              deleted.
+              This action cannot be undone. All buildings and assignments will
+              be permanently deleted.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -757,11 +869,15 @@ export default function SiegeSettingsPage() {
           <DialogHeader>
             <DialogTitle>Notify Members</DialogTitle>
             <DialogDescription>
-              Send Discord DMs to all members with their siege assignments. This cannot be undone.
+              Send Discord DMs to all members with their siege assignments. This
+              cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setNotifyConfirmOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setNotifyConfirmOpen(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -784,7 +900,10 @@ export default function SiegeSettingsPage() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCloneConfirmOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setCloneConfirmOpen(false)}
+            >
               Cancel
             </Button>
             <Button
@@ -806,7 +925,8 @@ export default function SiegeSettingsPage() {
           <DialogHeader>
             <DialogTitle>Post to Discord</DialogTitle>
             <DialogDescription>
-              Post the siege assignment images to the configured Discord channel.
+              Post the siege assignment images to the configured Discord
+              channel.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/frontend/src/pages/SiegesPage.tsx
+++ b/frontend/src/pages/SiegesPage.tsx
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
-import { useNavigate, Link } from 'react-router-dom';
-import { getSieges } from '../api/sieges';
-import type { SiegeStatus } from '../api/types';
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, Link } from "react-router-dom";
+import { getSieges } from "../api/sieges";
+import type { SiegeStatus } from "../api/types";
 import {
   Table,
   TableBody,
@@ -9,29 +9,33 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '../components/ui/table';
-import { Button } from '../components/ui/button';
-import { Badge } from '../components/ui/badge';
-import { PlusCircle } from 'lucide-react';
+} from "../components/ui/table";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
+import { PlusCircle } from "lucide-react";
 
-type StatusBadgeVariant = 'blue' | 'green' | 'gray';
+type StatusBadgeVariant = "blue" | "green" | "gray";
 
 const STATUS_VARIANTS: Record<SiegeStatus, StatusBadgeVariant> = {
-  planning: 'blue',
-  active: 'green',
-  complete: 'gray',
+  planning: "blue",
+  active: "green",
+  complete: "gray",
 };
 
 const STATUS_LABELS: Record<SiegeStatus, string> = {
-  planning: 'Planning',
-  active: 'Active',
-  complete: 'Complete',
+  planning: "Planning",
+  active: "Active",
+  complete: "Complete",
 };
 
 export default function SiegesPage() {
   const navigate = useNavigate();
-  const { data: sieges, isLoading, error } = useQuery({
-    queryKey: ['sieges'],
+  const {
+    data: sieges,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["sieges"],
     queryFn: () => getSieges(),
   });
 
@@ -39,7 +43,7 @@ export default function SiegesPage() {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-slate-900">Sieges</h1>
-        <Button onClick={() => navigate('/sieges/new')}>
+        <Button onClick={() => navigate("/sieges/new")}>
           <PlusCircle className="h-4 w-4" />
           New Siege
         </Button>
@@ -66,7 +70,10 @@ export default function SiegesPage() {
             <TableBody>
               {sieges?.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={3} className="py-8 text-center text-slate-500">
+                  <TableCell
+                    colSpan={3}
+                    className="py-8 text-center text-slate-500"
+                  >
                     No sieges yet. Create one to get started.
                   </TableCell>
                 </TableRow>

--- a/frontend/src/pages/SystemPage.tsx
+++ b/frontend/src/pages/SystemPage.tsx
@@ -1,14 +1,14 @@
-import { cn } from '../lib/utils';
-import { useVersion } from '../api/version';
+import { cn } from "../lib/utils";
+import { useVersion } from "../api/version";
 
 // ── Static UI library manifest ──────────────────────────────────────────────
 
 const UI_LIBRARIES = [
-  { label: 'React', value: '18', detail: '^18.3.1' },
-  { label: 'React Router', value: 'v6', detail: '^6.28.0' },
-  { label: 'React Query', value: 'v5', detail: '^5.62.7' },
-  { label: 'Tailwind CSS', value: 'v3', detail: '^3.4.16' },
-  { label: 'shadcn/ui', value: '—', detail: 'component library' },
+  { label: "React", value: "18", detail: "^18.3.1" },
+  { label: "React Router", value: "v6", detail: "^6.28.0" },
+  { label: "React Query", value: "v5", detail: "^5.62.7" },
+  { label: "Tailwind CSS", value: "v3", detail: "^3.4.16" },
+  { label: "shadcn/ui", value: "—", detail: "component library" },
 ] as const;
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -25,11 +25,16 @@ function SectionPanel({
   return (
     <div
       className={cn(
-        'rounded-lg border border-slate-200 bg-white overflow-hidden',
+        "overflow-hidden rounded-lg border border-slate-200 bg-white"
       )}
     >
       {/* Header bar with left accent stripe */}
-      <div className={cn('flex items-center gap-3 border-b border-slate-200 px-6 py-4', accent)}>
+      <div
+        className={cn(
+          "flex items-center gap-3 border-b border-slate-200 px-6 py-4",
+          accent
+        )}
+      >
         <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">
           {title}
         </h2>
@@ -53,19 +58,19 @@ function DataRow({
   skeleton?: boolean;
 }) {
   return (
-    <div className="flex items-center px-6 py-3.5 gap-4">
+    <div className="flex items-center gap-4 px-6 py-3.5">
       <span className="w-44 shrink-0 text-sm text-slate-500">{label}</span>
       {skeleton ? (
         <div className="h-4 w-32 animate-pulse rounded bg-slate-100" />
       ) : (
         <span
           className={cn(
-            'text-sm',
-            mono && 'font-mono',
-            muted ? 'text-slate-400 italic' : 'text-slate-900',
+            "text-sm",
+            mono && "font-mono",
+            muted ? "italic text-slate-400" : "text-slate-900"
           )}
         >
-          {value ?? <span className="text-slate-300 italic">unavailable</span>}
+          {value ?? <span className="italic text-slate-300">unavailable</span>}
         </span>
       )}
     </div>
@@ -82,7 +87,7 @@ function LibraryRow({
   detail: string;
 }) {
   return (
-    <div className="flex items-center px-6 py-3.5 gap-4">
+    <div className="flex items-center gap-4 px-6 py-3.5">
       <span className="w-44 shrink-0 text-sm text-slate-500">{label}</span>
       <span className="font-mono text-sm text-slate-900">{value}</span>
       <span className="ml-2 text-xs text-slate-400">{detail}</span>
@@ -97,7 +102,9 @@ export default function SystemPage() {
 
   // Resolve frontend version: prefer API response, fall back to build-time inject.
   const frontendVersion =
-    data?.frontend_version ?? (import.meta.env.VITE_APP_VERSION as string | undefined) ?? null;
+    data?.frontend_version ??
+    (import.meta.env.VITE_APP_VERSION as string | undefined) ??
+    null;
 
   const gitSha = data?.git_sha ? data.git_sha.slice(0, 8) : null;
 
@@ -112,7 +119,8 @@ export default function SystemPage() {
 
       {error && (
         <div className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
-          Could not reach the version endpoint. Component versions may be incomplete.
+          Could not reach the version endpoint. Component versions may be
+          incomplete.
         </div>
       )}
 
@@ -149,7 +157,12 @@ export default function SystemPage() {
         {/* ── UI Libraries ── */}
         <SectionPanel title="UI Libraries" accent="bg-white">
           {UI_LIBRARIES.map((lib) => (
-            <LibraryRow key={lib.label} label={lib.label} value={lib.value} detail={lib.detail} />
+            <LibraryRow
+              key={lib.label}
+              label={lib.label}
+              value={lib.value}
+              detail={lib.detail}
+            />
           ))}
         </SectionPanel>
       </div>

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -12,31 +12,33 @@
  *  4. No pill for reserve slots (is_reserve=true)
  */
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
-import { server } from '../server';
-import { renderWithProviders } from '../utils';
-import BoardPage from '../../pages/BoardPage';
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import BoardPage from "../../pages/BoardPage";
 import type {
   BoardResponse,
   PositionResponse,
   SiegeMember,
   Siege,
   Post,
-} from '../../api/types';
+} from "../../api/types";
 
 // ─── Server lifecycle ──────────────────────────────────────────────────────────
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 // ─── Fixture factories ─────────────────────────────────────────────────────────
 
-function makePosition(overrides: Partial<PositionResponse> = {}): PositionResponse {
+function makePosition(
+  overrides: Partial<PositionResponse> = {}
+): PositionResponse {
   return {
     id: 1,
     position_number: 1,
@@ -60,7 +62,7 @@ function makePostBoard(positions: PositionResponse[] = []): BoardResponse {
     buildings: [
       {
         id: 20,
-        building_type: 'post',
+        building_type: "post",
         building_number: 1,
         level: 3,
         is_broken: false,
@@ -80,12 +82,12 @@ function makePostBoard(positions: PositionResponse[] = []): BoardResponse {
 function makeSiege(overrides: Partial<Siege> = {}): Siege {
   return {
     id: 42,
-    date: '2026-03-22',
-    status: 'active',
+    date: "2026-03-22",
+    status: "active",
     defense_scroll_count: 0,
     computed_scroll_count: 0,
-    created_at: '2026-03-19T00:00:00Z',
-    updated_at: '2026-03-19T00:00:00Z',
+    created_at: "2026-03-19T00:00:00Z",
+    updated_at: "2026-03-19T00:00:00Z",
     ...overrides,
   };
 }
@@ -94,9 +96,9 @@ function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
   return {
     siege_id: 42,
     member_id: 1,
-    member_name: 'Aethon',
-    member_role: 'heavy_hitter',
-    member_power_level: 'gt_25m',
+    member_name: "Aethon",
+    member_role: "heavy_hitter",
+    member_power_level: "gt_25m",
     attack_day: 1,
     has_reserve_set: false,
     attack_day_override: false,
@@ -126,109 +128,130 @@ function setupHandlers(
   board: BoardResponse,
   siege: Siege = makeSiege(),
   members: SiegeMember[] = [],
-  posts: Post[] = [],
+  posts: Post[] = []
 ) {
   server.use(
-    http.get('/api/sieges/42/board', () => HttpResponse.json(board)),
-    http.get('/api/sieges/42', () => HttpResponse.json(siege)),
-    http.get('/api/sieges/42/members', () => HttpResponse.json(members)),
-    http.get('/api/post-priorities', () => HttpResponse.json([])),
-    http.get('/api/sieges/42/posts', () => HttpResponse.json(posts)),
-    http.get('/api/sieges/42/members/preferences', () => HttpResponse.json([])),
+    http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+    http.get("/api/sieges/42", () => HttpResponse.json(siege)),
+    http.get("/api/sieges/42/members", () => HttpResponse.json(members)),
+    http.get("/api/post-priorities", () => HttpResponse.json([])),
+    http.get("/api/sieges/42/posts", () => HttpResponse.json(posts)),
+    http.get("/api/sieges/42/members/preferences", () => HttpResponse.json([]))
   );
 }
 
-function renderBoard(initialPath = '/sieges/42/board') {
+function renderBoard(initialPath = "/sieges/42/board") {
   return renderWithProviders(
     <Routes>
       <Route path="/sieges/:id/board" element={<BoardPage />} />
     </Routes>,
-    { initialEntries: [initialPath] },
+    { initialEntries: [initialPath] }
   );
 }
 
 /** Wait for the board to load and then click the Posts tab button. */
 async function navigateToPostsTab(user: ReturnType<typeof userEvent.setup>) {
   await waitFor(() =>
-    expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument(),
+    expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
   );
-  await user.click(screen.getByRole('button', { name: /posts/i }));
+  await user.click(screen.getByRole("button", { name: /posts/i }));
   // Wait for PostsTab to finish loading its own queries
   await waitFor(() =>
-    expect(screen.queryByText(/loading posts/i)).not.toBeInTheDocument(),
+    expect(screen.queryByText(/loading posts/i)).not.toBeInTheDocument()
   );
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-describe('PostsTab — matched condition display', () => {
-  it('shows condition pill in collapsed row when matched_condition_id matches an active condition', async () => {
+describe("PostsTab — matched condition display", () => {
+  it("shows condition pill in collapsed row when matched_condition_id matches an active condition", async () => {
     const user = userEvent.setup();
 
     const position = makePosition({
       id: 10,
       member_id: 1,
-      member_name: 'Aethon',
+      member_name: "Aethon",
       matched_condition_id: 5,
     });
     const post = makePost({
-      active_conditions: [{ id: 5, description: 'Condition B', stronghold_level: 3 }],
+      active_conditions: [
+        { id: 5, description: "Condition B", stronghold_level: 3 },
+      ],
     });
 
-    setupHandlers(makePostBoard([position]), makeSiege(), [makeSiegeMember()], [post]);
+    setupHandlers(
+      makePostBoard([position]),
+      makeSiege(),
+      [makeSiegeMember()],
+      [post]
+    );
     renderBoard();
 
     await navigateToPostsTab(user);
 
     // The condition pill is rendered inline in the collapsed row
-    expect(screen.getByText('Condition B')).toBeInTheDocument();
+    expect(screen.getByText("Condition B")).toBeInTheDocument();
   });
 
-  it('does not show condition pill when matched_condition_id is null', async () => {
+  it("does not show condition pill when matched_condition_id is null", async () => {
     const user = userEvent.setup();
 
     const position = makePosition({
       id: 11,
       member_id: 1,
-      member_name: 'Aethon',
+      member_name: "Aethon",
       matched_condition_id: null,
     });
     const post = makePost({
-      active_conditions: [{ id: 5, description: 'Condition B', stronghold_level: 3 }],
+      active_conditions: [
+        { id: 5, description: "Condition B", stronghold_level: 3 },
+      ],
     });
 
-    setupHandlers(makePostBoard([position]), makeSiege(), [makeSiegeMember()], [post]);
+    setupHandlers(
+      makePostBoard([position]),
+      makeSiege(),
+      [makeSiegeMember()],
+      [post]
+    );
     renderBoard();
 
     await navigateToPostsTab(user);
 
     // No condition pill should appear
-    expect(screen.queryByText('Condition B')).not.toBeInTheDocument();
+    expect(screen.queryByText("Condition B")).not.toBeInTheDocument();
   });
 
-  it('does not show condition pill when matched_condition_id does not match any active condition', async () => {
+  it("does not show condition pill when matched_condition_id does not match any active condition", async () => {
     const user = userEvent.setup();
 
     const position = makePosition({
       id: 12,
       member_id: 1,
-      member_name: 'Aethon',
+      member_name: "Aethon",
       matched_condition_id: 99, // id 99 is not in active_conditions
     });
     const post = makePost({
-      active_conditions: [{ id: 5, description: 'Condition B', stronghold_level: 3 }],
+      active_conditions: [
+        { id: 5, description: "Condition B", stronghold_level: 3 },
+      ],
     });
 
-    setupHandlers(makePostBoard([position]), makeSiege(), [makeSiegeMember()], [post]);
+    setupHandlers(
+      makePostBoard([position]),
+      makeSiege(),
+      [makeSiegeMember()],
+      [post]
+    );
     renderBoard();
 
     await navigateToPostsTab(user);
 
     // id 99 has no matching condition — no pill should render
-    expect(screen.queryByText('Condition B')).not.toBeInTheDocument();
+    expect(screen.queryByText("Condition B")).not.toBeInTheDocument();
   });
 
-  it('does not show condition pill for a reserve slot even when matched_condition_id is set', async () => {
+  it("does not show condition pill for a reserve slot even when matched_condition_id is set", async () => {
     const user = userEvent.setup();
 
     const position = makePosition({
@@ -237,16 +260,23 @@ describe('PostsTab — matched condition display', () => {
       matched_condition_id: 5,
     });
     const post = makePost({
-      active_conditions: [{ id: 5, description: 'Condition B', stronghold_level: 3 }],
+      active_conditions: [
+        { id: 5, description: "Condition B", stronghold_level: 3 },
+      ],
     });
 
-    setupHandlers(makePostBoard([position]), makeSiege(), [makeSiegeMember()], [post]);
+    setupHandlers(
+      makePostBoard([position]),
+      makeSiege(),
+      [makeSiegeMember()],
+      [post]
+    );
     renderBoard();
 
     await navigateToPostsTab(user);
 
     // Reserve slots show "RESERVE" but never the condition pill
-    expect(screen.getByText('RESERVE')).toBeInTheDocument();
-    expect(screen.queryByText('Condition B')).not.toBeInTheDocument();
+    expect(screen.getByText("RESERVE")).toBeInTheDocument();
+    expect(screen.queryByText("Condition B")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/test/components/SiegeLayout.test.tsx
+++ b/frontend/src/test/components/SiegeLayout.test.tsx
@@ -1,33 +1,33 @@
-import { screen } from '@testing-library/react';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
-import { server } from '../server';
-import SiegeLayout from '../../components/SiegeLayout';
-import type { Siege } from '../../api/types';
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { server } from "../server";
+import SiegeLayout from "../../components/SiegeLayout";
+import type { Siege } from "../../api/types";
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 function makeSiege(overrides: Partial<Siege> = {}): Siege {
   return {
     id: 42,
-    date: '2026-03-22',
-    status: 'planning',
+    date: "2026-03-22",
+    status: "planning",
     defense_scroll_count: 0,
     computed_scroll_count: 0,
-    created_at: '2026-03-19T00:00:00Z',
-    updated_at: '2026-03-19T00:00:00Z',
+    created_at: "2026-03-19T00:00:00Z",
+    updated_at: "2026-03-19T00:00:00Z",
     ...overrides,
   };
 }
 
 function renderLayout(initialPath: string, siege: Siege = makeSiege()) {
   server.use(
-    http.get(`/api/sieges/${siege.id}`, () => HttpResponse.json(siege)),
+    http.get(`/api/sieges/${siege.id}`, () => HttpResponse.json(siege))
   );
 
   const queryClient = new QueryClient({
@@ -47,58 +47,60 @@ function renderLayout(initialPath: string, siege: Siege = makeSiege()) {
           </Route>
         </Routes>
       </QueryClientProvider>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
-describe('SiegeLayout', () => {
-  it('renders all five nav tabs', () => {
-    renderLayout('/sieges/42/board');
-    expect(screen.getByRole('link', { name: /board/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /posts/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /members/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /compare/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
+describe("SiegeLayout", () => {
+  it("renders all five nav tabs", () => {
+    renderLayout("/sieges/42/board");
+    expect(screen.getByRole("link", { name: /board/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /posts/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /members/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /compare/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeInTheDocument();
   });
 
-  it('highlights the Board tab when on the board route', () => {
-    renderLayout('/sieges/42/board');
-    const boardLink = screen.getByRole('link', { name: /board/i });
-    expect(boardLink).toHaveClass('border-violet-600');
-    expect(boardLink).toHaveClass('text-violet-700');
+  it("highlights the Board tab when on the board route", () => {
+    renderLayout("/sieges/42/board");
+    const boardLink = screen.getByRole("link", { name: /board/i });
+    expect(boardLink).toHaveClass("border-violet-600");
+    expect(boardLink).toHaveClass("text-violet-700");
   });
 
-  it('highlights the Posts tab when on the posts route', () => {
-    renderLayout('/sieges/42/posts');
-    const postsLink = screen.getByRole('link', { name: /posts/i });
-    expect(postsLink).toHaveClass('border-violet-600');
+  it("highlights the Posts tab when on the posts route", () => {
+    renderLayout("/sieges/42/posts");
+    const postsLink = screen.getByRole("link", { name: /posts/i });
+    expect(postsLink).toHaveClass("border-violet-600");
   });
 
-  it('highlights the Settings tab when on the siege index route', () => {
-    renderLayout('/sieges/42');
-    const settingsLink = screen.getByRole('link', { name: /settings/i });
-    expect(settingsLink).toHaveClass('border-violet-600');
+  it("highlights the Settings tab when on the siege index route", () => {
+    renderLayout("/sieges/42");
+    const settingsLink = screen.getByRole("link", { name: /settings/i });
+    expect(settingsLink).toHaveClass("border-violet-600");
   });
 
-  it('inactive tabs have border-transparent', () => {
-    renderLayout('/sieges/42/board');
-    const postsLink = screen.getByRole('link', { name: /posts/i });
-    expect(postsLink).toHaveClass('border-transparent');
-    expect(postsLink).not.toHaveClass('border-violet-600');
+  it("inactive tabs have border-transparent", () => {
+    renderLayout("/sieges/42/board");
+    const postsLink = screen.getByRole("link", { name: /posts/i });
+    expect(postsLink).toHaveClass("border-transparent");
+    expect(postsLink).not.toHaveClass("border-violet-600");
   });
 
-  it('renders the Outlet child content', () => {
-    renderLayout('/sieges/42/board');
-    expect(screen.getByText('Board content')).toBeInTheDocument();
+  it("renders the Outlet child content", () => {
+    renderLayout("/sieges/42/board");
+    expect(screen.getByText("Board content")).toBeInTheDocument();
   });
 
-  it('shows the locked banner when siege status is complete', async () => {
-    renderLayout('/sieges/42/board', makeSiege({ status: 'complete' }));
-    expect(await screen.findByText(/this siege is locked/i)).toBeInTheDocument();
+  it("shows the locked banner when siege status is complete", async () => {
+    renderLayout("/sieges/42/board", makeSiege({ status: "complete" }));
+    expect(
+      await screen.findByText(/this siege is locked/i)
+    ).toBeInTheDocument();
   });
 
-  it('does not show locked banner for a planning siege', () => {
-    renderLayout('/sieges/42/board', makeSiege({ status: 'planning' }));
+  it("does not show locked banner for a planning siege", () => {
+    renderLayout("/sieges/42/board", makeSiege({ status: "planning" }));
     expect(screen.queryByText(/this siege is locked/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/test/context/AuthContext.test.tsx
+++ b/frontend/src/test/context/AuthContext.test.tsx
@@ -1,0 +1,38 @@
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import { useAuth } from "../../context/AuthContext";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function TestConsumer() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  if (isLoading) return <div>Loading...</div>;
+  if (!isAuthenticated) return <div>Not authenticated</div>;
+  return <div>Hello {user?.name}</div>;
+}
+
+describe("AuthContext", () => {
+  it("shows loading state initially then resolves to authenticated", async () => {
+    // Default handler returns authenticated user
+    renderWithProviders(<TestConsumer />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Hello TestUser")).toBeInTheDocument();
+    });
+  });
+
+  it("resolves to not authenticated on 401", async () => {
+    server.use(
+      http.get("/api/auth/me", () => new HttpResponse(null, { status: 401 }))
+    );
+    renderWithProviders(<TestConsumer />);
+    await waitFor(() => {
+      expect(screen.getByText("Not authenticated")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -1,17 +1,57 @@
-import { http, HttpResponse } from 'msw';
-import type { BuildingTypeInfo } from '../api/types';
+import { http, HttpResponse } from "msw";
+import type { BuildingTypeInfo } from "../api/types";
 
 const buildingTypes: BuildingTypeInfo[] = [
-  { value: 'stronghold',    display: 'Stronghold',    count: 1, base_group_count: 4, base_last_group_slots: 3 },
-  { value: 'mana_shrine',   display: 'Mana Shrine',   count: 2, base_group_count: 2, base_last_group_slots: 3 },
-  { value: 'magic_tower',   display: 'Magic Tower',   count: 4, base_group_count: 1, base_last_group_slots: 2 },
-  { value: 'defense_tower', display: 'Defense Tower', count: 5, base_group_count: 1, base_last_group_slots: 2 },
-  { value: 'post',          display: 'Post',          count: 18, base_group_count: 1, base_last_group_slots: 1 },
+  {
+    value: "stronghold",
+    display: "Stronghold",
+    count: 1,
+    base_group_count: 4,
+    base_last_group_slots: 3,
+  },
+  {
+    value: "mana_shrine",
+    display: "Mana Shrine",
+    count: 2,
+    base_group_count: 2,
+    base_last_group_slots: 3,
+  },
+  {
+    value: "magic_tower",
+    display: "Magic Tower",
+    count: 4,
+    base_group_count: 1,
+    base_last_group_slots: 2,
+  },
+  {
+    value: "defense_tower",
+    display: "Defense Tower",
+    count: 5,
+    base_group_count: 1,
+    base_last_group_slots: 2,
+  },
+  {
+    value: "post",
+    display: "Post",
+    count: 18,
+    base_group_count: 1,
+    base_last_group_slots: 1,
+  },
 ];
 
 export const handlers = [
-  http.get('/api/sieges', () => HttpResponse.json([])),
-  http.get('/api/members', () => HttpResponse.json([])),
-  http.get('/api/sieges/building-types', () => HttpResponse.json(buildingTypes)),
-  http.get('/api/post-conditions', () => HttpResponse.json([])),
+  http.get("/api/auth/me", () =>
+    HttpResponse.json({
+      member_id: 1,
+      name: "TestUser",
+      role: "heavy_hitter",
+      discord_id: "111222333",
+    })
+  ),
+  http.get("/api/sieges", () => HttpResponse.json([])),
+  http.get("/api/members", () => HttpResponse.json([])),
+  http.get("/api/sieges/building-types", () =>
+    HttpResponse.json(buildingTypes)
+  ),
+  http.get("/api/post-conditions", () => HttpResponse.json([])),
 ];

--- a/frontend/src/test/pages/BoardPage.test.tsx
+++ b/frontend/src/test/pages/BoardPage.test.tsx
@@ -10,30 +10,32 @@
  *  - Locked (siege complete) board — context menu button hidden, auto-fill disabled
  */
 
-import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { Routes, Route } from 'react-router-dom';
-import { server } from '../server';
-import { renderWithProviders } from '../utils';
-import BoardPage from '../../pages/BoardPage';
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import BoardPage from "../../pages/BoardPage";
 import type {
   BoardResponse,
   PositionResponse,
   SiegeMember,
   Siege,
-} from '../../api/types';
+} from "../../api/types";
 
 // ─── Server lifecycle ──────────────────────────────────────────────────────────
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 // ─── Fixture factories ──────────────────────────────────────────────────────
 
-function makePosition(overrides: Partial<PositionResponse> = {}): PositionResponse {
+function makePosition(
+  overrides: Partial<PositionResponse> = {}
+): PositionResponse {
   return {
     id: 1,
     position_number: 1,
@@ -53,7 +55,7 @@ function makeBoard(positions: PositionResponse[] = []): BoardResponse {
     buildings: [
       {
         id: 10,
-        building_type: 'stronghold',
+        building_type: "stronghold",
         building_number: 1,
         level: 5,
         is_broken: false,
@@ -73,12 +75,12 @@ function makeBoard(positions: PositionResponse[] = []): BoardResponse {
 function makeSiege(overrides: Partial<Siege> = {}): Siege {
   return {
     id: 42,
-    date: '2026-03-22',
-    status: 'active',
+    date: "2026-03-22",
+    status: "active",
     defense_scroll_count: 0,
     computed_scroll_count: 0,
-    created_at: '2026-03-19T00:00:00Z',
-    updated_at: '2026-03-19T00:00:00Z',
+    created_at: "2026-03-19T00:00:00Z",
+    updated_at: "2026-03-19T00:00:00Z",
     ...overrides,
   };
 }
@@ -87,9 +89,9 @@ function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
   return {
     siege_id: 42,
     member_id: 1,
-    member_name: 'Aethon',
-    member_role: 'heavy_hitter',
-    member_power_level: 'gt_25m',
+    member_name: "Aethon",
+    member_role: "heavy_hitter",
+    member_power_level: "gt_25m",
     attack_day: 1,
     has_reserve_set: false,
     attack_day_override: false,
@@ -103,36 +105,36 @@ function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
 function setupDefaultHandlers(
   board: BoardResponse = makeBoard(),
   siege: Siege = makeSiege(),
-  members: SiegeMember[] = [],
+  members: SiegeMember[] = []
 ) {
   server.use(
-    http.get('/api/sieges/42/board', () => HttpResponse.json(board)),
-    http.get('/api/sieges/42', () => HttpResponse.json(siege)),
-    http.get('/api/sieges/42/members', () => HttpResponse.json(members)),
-    http.get('/api/post-priorities', () => HttpResponse.json([])),
+    http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+    http.get("/api/sieges/42", () => HttpResponse.json(siege)),
+    http.get("/api/sieges/42/members", () => HttpResponse.json(members)),
+    http.get("/api/post-priorities", () => HttpResponse.json([]))
   );
 }
 
-function renderBoard(initialPath = '/sieges/42/board') {
+function renderBoard(initialPath = "/sieges/42/board") {
   return renderWithProviders(
     <Routes>
       <Route path="/sieges/:id/board" element={<BoardPage />} />
     </Routes>,
-    { initialEntries: [initialPath] },
+    { initialEntries: [initialPath] }
   );
 }
 
 // ─── Loading state ──────────────────────────────────────────────────────────
 
-describe('BoardPage — loading state', () => {
-  it('shows a loading message while the board is being fetched', () => {
+describe("BoardPage — loading state", () => {
+  it("shows a loading message while the board is being fetched", () => {
     server.use(
-      http.get('/api/sieges/42/board', async () => {
+      http.get("/api/sieges/42/board", async () => {
         await new Promise(() => {}); // never resolves
       }),
-      http.get('/api/sieges/42', () => HttpResponse.json(makeSiege())),
-      http.get('/api/sieges/42/members', () => HttpResponse.json([])),
-      http.get('/api/post-priorities', () => HttpResponse.json([])),
+      http.get("/api/sieges/42", () => HttpResponse.json(makeSiege())),
+      http.get("/api/sieges/42/members", () => HttpResponse.json([])),
+      http.get("/api/post-priorities", () => HttpResponse.json([]))
     );
     renderBoard();
     expect(screen.getByText(/loading board/i)).toBeInTheDocument();
@@ -141,129 +143,154 @@ describe('BoardPage — loading state', () => {
 
 // ─── Summary bar ───────────────────────────────────────────────────────────
 
-describe('BoardPage — summary bar', () => {
-  it('counts each slot category correctly', async () => {
+describe("BoardPage — summary bar", () => {
+  it("counts each slot category correctly", async () => {
     const positions: PositionResponse[] = [
-      makePosition({ id: 1, position_number: 1, member_id: 7, member_name: 'Aethon' }), // assigned
-      makePosition({ id: 2, position_number: 2, is_reserve: true }),                     // reserve
-      makePosition({ id: 3, position_number: 3, has_no_assignment: true }),              // N/A
-      makePosition({ id: 4, position_number: 4 }),                                       // empty
-      makePosition({ id: 5, position_number: 5, is_disabled: true }),                    // disabled
+      makePosition({
+        id: 1,
+        position_number: 1,
+        member_id: 7,
+        member_name: "Aethon",
+      }), // assigned
+      makePosition({ id: 2, position_number: 2, is_reserve: true }), // reserve
+      makePosition({ id: 3, position_number: 3, has_no_assignment: true }), // N/A
+      makePosition({ id: 4, position_number: 4 }), // empty
+      makePosition({ id: 5, position_number: 5, is_disabled: true }), // disabled
     ];
     setupDefaultHandlers(makeBoard(positions), makeSiege(), [
-      makeSiegeMember({ member_id: 7, member_name: 'Aethon' }),
+      makeSiegeMember({ member_id: 7, member_name: "Aethon" }),
     ]);
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // Summary bar contains "5 total"
-    const summaryBar = screen.getByText('total').closest('div')!;
-    expect(within(summaryBar).getByText('5')).toBeInTheDocument();
+    const summaryBar = screen.getByText("total").closest("div")!;
+    expect(within(summaryBar).getByText("5")).toBeInTheDocument();
     // assigned, reserve, N/A, empty each show '1'; disabled also '1'
-    const ones = within(summaryBar).getAllByText('1');
+    const ones = within(summaryBar).getAllByText("1");
     expect(ones.length).toBeGreaterThanOrEqual(4);
   });
 });
 
 // ─── Position cell states ──────────────────────────────────────────────────
 
-describe('BoardPage — position cell states', () => {
-  it('renders an assigned member name inside a position cell', async () => {
-    const positions = [makePosition({ id: 1, member_id: 7, member_name: 'Aethon' })];
+describe("BoardPage — position cell states", () => {
+  it("renders an assigned member name inside a position cell", async () => {
+    const positions = [
+      makePosition({ id: 1, member_id: 7, member_name: "Aethon" }),
+    ];
     setupDefaultHandlers(makeBoard(positions), makeSiege(), [
-      makeSiegeMember({ member_id: 7, member_name: 'Aethon' }),
+      makeSiegeMember({ member_id: 7, member_name: "Aethon" }),
     ]);
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
     // Aethon appears in both the position cell and the member bucket
-    expect(screen.getAllByText('Aethon').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Aethon").length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders RESERVE badge for a reserve position', async () => {
+  it("renders RESERVE badge for a reserve position", async () => {
     const positions = [makePosition({ id: 1, is_reserve: true })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
-    expect(screen.getByText('RESERVE')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
+    expect(screen.getByText("RESERVE")).toBeInTheDocument();
   });
 
-  it('renders N/A text for a no-assignment position', async () => {
+  it("renders N/A text for a no-assignment position", async () => {
     const positions = [makePosition({ id: 1, has_no_assignment: true })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
     // N/A appears in both the position cell and the summary bar label
-    expect(screen.getAllByText('N/A').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("N/A").length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders DISABLED text with strikethrough style for a disabled position', async () => {
+  it("renders DISABLED text with strikethrough style for a disabled position", async () => {
     const positions = [makePosition({ id: 1, is_disabled: true })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
-    const disabledEl = screen.getByText('DISABLED');
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
+    const disabledEl = screen.getByText("DISABLED");
     expect(disabledEl).toBeInTheDocument();
-    expect(disabledEl).toHaveClass('line-through');
+    expect(disabledEl).toHaveClass("line-through");
   });
 
-  it('renders an em-dash placeholder for an empty position', async () => {
+  it("renders an em-dash placeholder for an empty position", async () => {
     const positions = [makePosition({ id: 1 })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
 
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
     // Empty positions show the "—" character
-    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
   });
 });
 
 // ─── Context menu actions ──────────────────────────────────────────────────
 
-describe('BoardPage — position context menu', () => {
-  it('opens the context dialog when the chevron button is clicked', async () => {
+describe("BoardPage — position context menu", () => {
+  it("opens the context dialog when the chevron button is clicked", async () => {
     const user = userEvent.setup();
     const positions = [makePosition({ id: 1, position_number: 3 })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // The chevron button is opacity-0 until hovered; userEvent.hover makes it visible
-    const cell = screen.getByText('3.').closest('div')!;
+    const cell = screen.getByText("3.").closest("div")!;
     await user.hover(cell);
 
-    const chevron = cell.querySelector('button');
+    const chevron = cell.querySelector("button");
     expect(chevron).not.toBeNull();
     await user.click(chevron!);
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText(/position 3/i)).toBeInTheDocument();
   });
 
-  it('calls the update endpoint with is_reserve=true when Mark RESERVE is clicked', async () => {
+  it("calls the update endpoint with is_reserve=true when Mark RESERVE is clicked", async () => {
     const user = userEvent.setup();
     const positions = [makePosition({ id: 55, position_number: 1 })];
     setupDefaultHandlers(makeBoard(positions));
 
     let capturedBody: Record<string, unknown> | null = null;
     server.use(
-      http.put('/api/sieges/42/positions/55', async ({ request }) => {
+      http.put("/api/sieges/42/positions/55", async ({ request }) => {
         capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(makePosition({ id: 55, position_number: 1, is_reserve: true }));
-      }),
+        return HttpResponse.json(
+          makePosition({ id: 55, position_number: 1, is_reserve: true })
+        );
+      })
     );
 
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    const cell = screen.getByText('1.').closest('div')!;
+    const cell = screen.getByText("1.").closest("div")!;
     await user.hover(cell);
-    await user.click(cell.querySelector('button')!);
-    await user.click(screen.getByRole('button', { name: /mark reserve/i }));
+    await user.click(cell.querySelector("button")!);
+    await user.click(screen.getByRole("button", { name: /mark reserve/i }));
 
     await waitFor(() => expect(capturedBody).not.toBeNull());
     expect(capturedBody).toMatchObject({
@@ -273,28 +300,32 @@ describe('BoardPage — position context menu', () => {
     });
   });
 
-  it('calls the update endpoint with has_no_assignment=true when Mark No Assignment is clicked', async () => {
+  it("calls the update endpoint with has_no_assignment=true when Mark No Assignment is clicked", async () => {
     const user = userEvent.setup();
     const positions = [makePosition({ id: 56, position_number: 1 })];
     setupDefaultHandlers(makeBoard(positions));
 
     let capturedBody: Record<string, unknown> | null = null;
     server.use(
-      http.put('/api/sieges/42/positions/56', async ({ request }) => {
+      http.put("/api/sieges/42/positions/56", async ({ request }) => {
         capturedBody = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json(
-          makePosition({ id: 56, position_number: 1, has_no_assignment: true }),
+          makePosition({ id: 56, position_number: 1, has_no_assignment: true })
         );
-      }),
+      })
     );
 
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    const cell = screen.getByText('1.').closest('div')!;
+    const cell = screen.getByText("1.").closest("div")!;
     await user.hover(cell);
-    await user.click(cell.querySelector('button')!);
-    await user.click(screen.getByRole('button', { name: /mark no assignment/i }));
+    await user.click(cell.querySelector("button")!);
+    await user.click(
+      screen.getByRole("button", { name: /mark no assignment/i })
+    );
 
     await waitFor(() => expect(capturedBody).not.toBeNull());
     expect(capturedBody).toMatchObject({
@@ -304,28 +335,37 @@ describe('BoardPage — position context menu', () => {
     });
   });
 
-  it('calls the update endpoint with member_id=null when Clear is clicked', async () => {
+  it("calls the update endpoint with member_id=null when Clear is clicked", async () => {
     const user = userEvent.setup();
-    const positions = [makePosition({ id: 57, position_number: 1, member_id: 7, member_name: 'Aethon' })];
+    const positions = [
+      makePosition({
+        id: 57,
+        position_number: 1,
+        member_id: 7,
+        member_name: "Aethon",
+      }),
+    ];
     setupDefaultHandlers(makeBoard(positions), makeSiege(), [
-      makeSiegeMember({ member_id: 7, member_name: 'Aethon' }),
+      makeSiegeMember({ member_id: 7, member_name: "Aethon" }),
     ]);
 
     let capturedBody: Record<string, unknown> | null = null;
     server.use(
-      http.put('/api/sieges/42/positions/57', async ({ request }) => {
+      http.put("/api/sieges/42/positions/57", async ({ request }) => {
         capturedBody = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json(makePosition({ id: 57, position_number: 1 }));
-      }),
+      })
     );
 
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    const cell = screen.getByText('1.').closest('div')!;
+    const cell = screen.getByText("1.").closest("div")!;
     await user.hover(cell);
-    await user.click(cell.querySelector('button')!);
-    await user.click(screen.getByRole('button', { name: /^clear$/i }));
+    await user.click(cell.querySelector("button")!);
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
 
     await waitFor(() => expect(capturedBody).not.toBeNull());
     expect(capturedBody).toMatchObject({
@@ -335,188 +375,259 @@ describe('BoardPage — position context menu', () => {
     });
   });
 
-  it('does not render a chevron button on a disabled position', async () => {
-    const positions = [makePosition({ id: 1, position_number: 1, is_disabled: true })];
+  it("does not render a chevron button on a disabled position", async () => {
+    const positions = [
+      makePosition({ id: 1, position_number: 1, is_disabled: true }),
+    ];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // The DISABLED text sits inside the cell; no button should be present
-    const disabledSpan = screen.getByText('DISABLED');
+    const disabledSpan = screen.getByText("DISABLED");
     const cell = disabledSpan.closest('[class*="group"]');
-    expect(cell?.querySelector('button')).toBeNull();
+    expect(cell?.querySelector("button")).toBeNull();
   });
 });
 
 // ─── Locked board (siege complete) ────────────────────────────────────────
 
-describe('BoardPage — locked board', () => {
-  it('hides the chevron context button on all positions when siege is complete', async () => {
+describe("BoardPage — locked board", () => {
+  it("hides the chevron context button on all positions when siege is complete", async () => {
     const positions = [makePosition({ id: 1, position_number: 1 })];
-    setupDefaultHandlers(makeBoard(positions), makeSiege({ status: 'complete' }));
+    setupDefaultHandlers(
+      makeBoard(positions),
+      makeSiege({ status: "complete" })
+    );
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // When isLocked=true the button is not rendered at all (conditional render, not just hidden)
-    const cell = screen.getByText('1.').closest('[class*="group"]');
-    expect(cell?.querySelector('button')).toBeNull();
+    const cell = screen.getByText("1.").closest('[class*="group"]');
+    expect(cell?.querySelector("button")).toBeNull();
   });
 
-  it('disables the Preview Auto-fill button when siege is complete', async () => {
-    setupDefaultHandlers(makeBoard(), makeSiege({ status: 'complete' }));
+  it("disables the Preview Auto-fill button when siege is complete", async () => {
+    setupDefaultHandlers(makeBoard(), makeSiege({ status: "complete" }));
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    expect(screen.getByRole('button', { name: /preview auto-fill/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /preview auto-fill/i })
+    ).toBeDisabled();
   });
 });
 
 // ─── MemberBucket ─────────────────────────────────────────────────────────
 
-describe('BoardPage — MemberBucket', () => {
+describe("BoardPage — MemberBucket", () => {
   const members: SiegeMember[] = [
-    makeSiegeMember({ member_id: 1, member_name: 'Aethon', member_role: 'heavy_hitter' }),
-    makeSiegeMember({ member_id: 2, member_name: 'Brint', member_role: 'novice' }),
-    makeSiegeMember({ member_id: 3, member_name: 'Calyx', member_role: 'advanced' }),
+    makeSiegeMember({
+      member_id: 1,
+      member_name: "Aethon",
+      member_role: "heavy_hitter",
+    }),
+    makeSiegeMember({
+      member_id: 2,
+      member_name: "Brint",
+      member_role: "novice",
+    }),
+    makeSiegeMember({
+      member_id: 3,
+      member_name: "Calyx",
+      member_role: "advanced",
+    }),
   ];
 
-  it('renders all siege members in the bucket', async () => {
+  it("renders all siege members in the bucket", async () => {
     setupDefaultHandlers(makeBoard(), makeSiege(), members);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    expect(screen.getByText('Aethon')).toBeInTheDocument();
-    expect(screen.getByText('Brint')).toBeInTheDocument();
-    expect(screen.getByText('Calyx')).toBeInTheDocument();
+    expect(screen.getByText("Aethon")).toBeInTheDocument();
+    expect(screen.getByText("Brint")).toBeInTheDocument();
+    expect(screen.getByText("Calyx")).toBeInTheDocument();
   });
 
-  it('filters members by search text', async () => {
+  it("filters members by search text", async () => {
     const user = userEvent.setup();
     setupDefaultHandlers(makeBoard(), makeSiege(), members);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     const searchInput = screen.getByPlaceholderText(/search/i);
-    await user.type(searchInput, 'Aeth');
+    await user.type(searchInput, "Aeth");
 
-    expect(screen.getByText('Aethon')).toBeInTheDocument();
-    expect(screen.queryByText('Brint')).not.toBeInTheDocument();
-    expect(screen.queryByText('Calyx')).not.toBeInTheDocument();
+    expect(screen.getByText("Aethon")).toBeInTheDocument();
+    expect(screen.queryByText("Brint")).not.toBeInTheDocument();
+    expect(screen.queryByText("Calyx")).not.toBeInTheDocument();
   });
 
   it('shows "No members" when search matches nothing', async () => {
     const user = userEvent.setup();
     setupDefaultHandlers(makeBoard(), makeSiege(), members);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     const searchInput = screen.getByPlaceholderText(/search/i);
-    await user.type(searchInput, 'zzz');
+    await user.type(searchInput, "zzz");
 
-    expect(screen.getByText('No members')).toBeInTheDocument();
+    expect(screen.getByText("No members")).toBeInTheDocument();
   });
 
-  it('filters members by role via the role select', async () => {
+  it("filters members by role via the role select", async () => {
     const user = userEvent.setup();
     setupDefaultHandlers(makeBoard(), makeSiege(), members);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // MemberBucket uses a plain <select>, not a shadcn Select component
     const roleSelect = screen
-      .getAllByRole('combobox')
-      .find((el) => el.tagName === 'SELECT')!;
-    await user.selectOptions(roleSelect, 'novice');
+      .getAllByRole("combobox")
+      .find((el) => el.tagName === "SELECT")!;
+    await user.selectOptions(roleSelect, "novice");
 
-    expect(screen.getByText('Brint')).toBeInTheDocument();
-    expect(screen.queryByText('Aethon')).not.toBeInTheDocument();
-    expect(screen.queryByText('Calyx')).not.toBeInTheDocument();
+    expect(screen.getByText("Brint")).toBeInTheDocument();
+    expect(screen.queryByText("Aethon")).not.toBeInTheDocument();
+    expect(screen.queryByText("Calyx")).not.toBeInTheDocument();
   });
 
-  it('shows role abbreviation badge next to each member', async () => {
+  it("shows role abbreviation badge next to each member", async () => {
     setupDefaultHandlers(makeBoard(), makeSiege(), [
-      makeSiegeMember({ member_id: 1, member_name: 'Aethon', member_role: 'heavy_hitter' }),
+      makeSiegeMember({
+        member_id: 1,
+        member_name: "Aethon",
+        member_role: "heavy_hitter",
+      }),
     ]);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // heavy_hitter → "HH" abbreviation badge
-    expect(screen.getByText('HH')).toBeInTheDocument();
+    expect(screen.getByText("HH")).toBeInTheDocument();
   });
 
-  it('shows assignment count badge for each member', async () => {
+  it("shows assignment count badge for each member", async () => {
     // Aethon is assigned to two positions
     const positions = [
-      makePosition({ id: 1, position_number: 1, member_id: 1, member_name: 'Aethon' }),
-      makePosition({ id: 2, position_number: 2, member_id: 1, member_name: 'Aethon' }),
+      makePosition({
+        id: 1,
+        position_number: 1,
+        member_id: 1,
+        member_name: "Aethon",
+      }),
+      makePosition({
+        id: 2,
+        position_number: 2,
+        member_id: 1,
+        member_name: "Aethon",
+      }),
     ];
     setupDefaultHandlers(makeBoard(positions), makeSiege(), [
-      makeSiegeMember({ member_id: 1, member_name: 'Aethon', member_role: 'heavy_hitter' }),
+      makeSiegeMember({
+        member_id: 1,
+        member_name: "Aethon",
+        member_role: "heavy_hitter",
+      }),
     ]);
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // The count badge "2" should appear in the member bucket next to Aethon
     // Note: the MemberBucket is in the same DOM tree as the board, so scope to Aethon's row
-    const memberRows = screen.getAllByText('Aethon');
+    const memberRows = screen.getAllByText("Aethon");
     // First match is the bucket row; find the "2" count badge inside its parent
-    const bucketRow = memberRows[0].closest('div[class*="flex"]') as HTMLElement;
-    expect(within(bucketRow).getByText('2')).toBeInTheDocument();
+    const bucketRow = memberRows[0].closest(
+      'div[class*="flex"]'
+    ) as HTMLElement;
+    expect(within(bucketRow).getByText("2")).toBeInTheDocument();
   });
 });
 
 // ─── Action buttons ────────────────────────────────────────────────────────
 
-describe('BoardPage — action buttons', () => {
-  it('renders Validate and Preview Auto-fill buttons', async () => {
+describe("BoardPage — action buttons", () => {
+  it("renders Validate and Preview Auto-fill buttons", async () => {
     setupDefaultHandlers();
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    expect(screen.getByRole('button', { name: /validate/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /preview auto-fill/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /validate/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /preview auto-fill/i })
+    ).toBeInTheDocument();
   });
 
-  it('renders Buildings and Posts tab buttons', async () => {
+  it("renders Buildings and Posts tab buttons", async () => {
     setupDefaultHandlers();
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
-    expect(screen.getByRole('button', { name: /buildings/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /posts/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /buildings/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /posts/i })).toBeInTheDocument();
   });
 
-  it('shows the Buildings tab content by default (Stronghold section header visible)', async () => {
+  it("shows the Buildings tab content by default (Stronghold section header visible)", async () => {
     const positions = [makePosition({ id: 1, position_number: 1 })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // BuildingTypeSection renders the type label via BUILDING_LABELS; CSS uppercase doesn't change DOM text
-    expect(screen.getByText('Stronghold')).toBeInTheDocument();
+    expect(screen.getByText("Stronghold")).toBeInTheDocument();
   });
 });
 
 // ─── Building section collapse ─────────────────────────────────────────────
 
-describe('BoardPage — building section collapse/expand', () => {
-  it('collapses a building section when its header is clicked', async () => {
+describe("BoardPage — building section collapse/expand", () => {
+  it("collapses a building section when its header is clicked", async () => {
     const user = userEvent.setup();
     const positions = [makePosition({ id: 1, position_number: 1 })];
     setupDefaultHandlers(makeBoard(positions));
     renderBoard();
-    await waitFor(() => expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
 
     // Position cell placeholder is visible in the expanded (default) state
-    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
 
     // Click the section header to collapse
     const sectionHeader = screen
-      .getByText('Stronghold')
+      .getByText("Stronghold")
       .closest('div[class*="cursor-pointer"]')!;
     await user.click(sectionHeader);
 
     // After collapse the position placeholder should not be rendered
-    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/test/pages/LoginPage.test.tsx
+++ b/frontend/src/test/pages/LoginPage.test.tsx
@@ -1,0 +1,52 @@
+import { screen, waitFor } from "@testing-library/react";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import LoginPage from "../../pages/LoginPage";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("LoginPage", () => {
+  it("renders the sign-in button and privacy disclosure", async () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /sign in with discord/i })
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/username and avatar/i)).toBeInTheDocument();
+  });
+
+  it("shows unauthorized error message", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=unauthorized"],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/not authorized to access this app/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows service unavailable error message", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=service_unavailable"],
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error for unknown error codes", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=invalid_state"],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/not authorized to access this app/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/pages/MembersPage.test.tsx
+++ b/frontend/src/test/pages/MembersPage.test.tsx
@@ -1,102 +1,104 @@
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { server } from '../server';
-import { renderWithProviders } from '../utils';
-import MembersPage from '../../pages/MembersPage';
-import type { Member } from '../../api/types';
+import { screen, waitForElementToBeRemoved } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import MembersPage from "../../pages/MembersPage";
+import type { Member } from "../../api/types";
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('MembersPage', () => {
-  it('renders the page heading', () => {
+describe("MembersPage", () => {
+  it("renders the page heading", () => {
     renderWithProviders(<MembersPage />);
-    expect(screen.getByRole('heading', { name: 'Members' })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Members" })
+    ).toBeInTheDocument();
   });
 
-  it('has an Add Member button', () => {
+  it("has an Add Member button", () => {
     renderWithProviders(<MembersPage />);
-    expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /add member/i })
+    ).toBeInTheDocument();
   });
 
-  it('renders the role filter select', () => {
+  it("renders the role filter select", () => {
     renderWithProviders(<MembersPage />);
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it('renders the Active only checkbox', () => {
+  it("renders the Active only checkbox", () => {
     renderWithProviders(<MembersPage />);
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
-    expect(screen.getByText('Active only')).toBeInTheDocument();
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(screen.getByText("Active only")).toBeInTheDocument();
   });
 
-  it('shows loading state while fetching', () => {
+  it("shows loading state while fetching", () => {
     server.use(
-      http.get('/api/members', async () => {
+      http.get("/api/members", async () => {
         await new Promise(() => {});
-      }),
+      })
     );
     renderWithProviders(<MembersPage />);
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
-  it('shows empty state when API returns no members', async () => {
+  it("shows empty state when API returns no members", async () => {
     renderWithProviders(<MembersPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(/no members found/i)).toBeInTheDocument();
   });
 
-  it('shows table column headers after loading', async () => {
+  it("shows table column headers after loading", async () => {
     renderWithProviders(<MembersPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
-    expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Role')).toBeInTheDocument();
-    expect(screen.getByText('Power')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    expect(screen.getByText("Power")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
   });
 
-  it('renders member rows when API returns data', async () => {
+  it("renders member rows when API returns data", async () => {
     const members: Member[] = [
       {
         id: 1,
-        name: 'Aethon',
-        discord_username: 'aethon#1234',
-        role: 'heavy_hitter',
-        power_level: 'gt_25m',
+        name: "Aethon",
+        discord_username: "aethon#1234",
+        role: "heavy_hitter",
+        power_level: "gt_25m",
         is_active: true,
       },
       {
         id: 2,
-        name: 'Brint',
+        name: "Brint",
         discord_username: null,
-        role: 'novice',
-        power_level: 'lt_10m',
+        role: "novice",
+        power_level: "lt_10m",
         is_active: false,
       },
     ];
-    server.use(http.get('/api/members', () => HttpResponse.json(members)));
+    server.use(http.get("/api/members", () => HttpResponse.json(members)));
 
     renderWithProviders(<MembersPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
-    expect(screen.getByText('Aethon')).toBeInTheDocument();
-    expect(screen.getByText('Brint')).toBeInTheDocument();
-    expect(screen.getByText('Heavy Hitter')).toBeInTheDocument();
-    expect(screen.getByText('Novice')).toBeInTheDocument();
-    expect(screen.getByText('> 25M')).toBeInTheDocument();
-    expect(screen.getByText('< 10M')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Inactive')).toBeInTheDocument();
+    expect(screen.getByText("Aethon")).toBeInTheDocument();
+    expect(screen.getByText("Brint")).toBeInTheDocument();
+    expect(screen.getByText("Heavy Hitter")).toBeInTheDocument();
+    expect(screen.getByText("Novice")).toBeInTheDocument();
+    expect(screen.getByText("> 25M")).toBeInTheDocument();
+    expect(screen.getByText("< 10M")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
   });
 
-  it('shows error message when the API call fails', async () => {
-    server.use(
-      http.get('/api/members', () => HttpResponse.error()),
-    );
+  it("shows error message when the API call fails", async () => {
+    server.use(http.get("/api/members", () => HttpResponse.error()));
     renderWithProviders(<MembersPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(/failed to load members/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/pages/SiegeSettingsPage.test.tsx
+++ b/frontend/src/test/pages/SiegeSettingsPage.test.tsx
@@ -16,25 +16,33 @@
  *  - "Post to Discord" button disabled when siege is complete
  */
 
-import { screen, waitFor, within, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect, vi } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
-import { server } from '../server';
-import SiegeSettingsPage from '../../pages/SiegeSettingsPage';
+import { screen, waitFor, within, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  it,
+  expect,
+  vi,
+} from "vitest";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { server } from "../server";
+import SiegeSettingsPage from "../../pages/SiegeSettingsPage";
 import type {
   Siege,
   NotifyResponse,
   NotificationBatchResponse,
   NotificationResultItem,
-} from '../../api/types';
+} from "../../api/types";
 
 // ─── Server lifecycle ──────────────────────────────────────────────────────────
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => {
   server.resetHandlers();
   vi.useRealTimers();
@@ -46,30 +54,34 @@ afterAll(() => server.close());
 function makeSiege(overrides: Partial<Siege> = {}): Siege {
   return {
     id: 42,
-    date: '2026-03-22',
-    status: 'active',
+    date: "2026-03-22",
+    status: "active",
     defense_scroll_count: 0,
     computed_scroll_count: 0,
-    created_at: '2026-03-19T00:00:00Z',
-    updated_at: '2026-03-19T00:00:00Z',
+    created_at: "2026-03-19T00:00:00Z",
+    updated_at: "2026-03-19T00:00:00Z",
     ...overrides,
   };
 }
 
-function makeNotifyResponse(overrides: Partial<NotifyResponse> = {}): NotifyResponse {
+function makeNotifyResponse(
+  overrides: Partial<NotifyResponse> = {}
+): NotifyResponse {
   return {
     batch_id: 101,
-    status: 'pending',
+    status: "pending",
     member_count: 2,
     ...overrides,
   };
 }
 
-function makeResult(overrides: Partial<NotificationResultItem> = {}): NotificationResultItem {
+function makeResult(
+  overrides: Partial<NotificationResultItem> = {}
+): NotificationResultItem {
   return {
     member_id: 1,
-    member_name: 'Aethon',
-    discord_username: 'aethon#0001',
+    member_name: "Aethon",
+    discord_username: "aethon#0001",
     success: null,
     error: null,
     sent_at: null,
@@ -79,7 +91,7 @@ function makeResult(overrides: Partial<NotificationResultItem> = {}): Notificati
 
 function makeBatchResponse(
   status: string,
-  results: NotificationResultItem[],
+  results: NotificationResultItem[]
 ): NotificationBatchResponse {
   return { batch_id: 101, status, results };
 }
@@ -93,9 +105,9 @@ function makeBatchResponse(
 
 function renderPage(siege: Siege = makeSiege()) {
   server.use(
-    http.get('/api/sieges/42', () => HttpResponse.json(siege)),
-    http.get('/api/sieges/42/buildings', () => HttpResponse.json([])),
-    http.get('/api/sieges/42/members', () => HttpResponse.json([])),
+    http.get("/api/sieges/42", () => HttpResponse.json(siege)),
+    http.get("/api/sieges/42/buildings", () => HttpResponse.json([])),
+    http.get("/api/sieges/42/members", () => HttpResponse.json([]))
   );
 
   const queryClient = new QueryClient({
@@ -105,452 +117,501 @@ function renderPage(siege: Siege = makeSiege()) {
   });
 
   return render(
-    <MemoryRouter initialEntries={['/sieges/42']}>
+    <MemoryRouter initialEntries={["/sieges/42"]}>
       <QueryClientProvider client={queryClient}>
         <Routes>
           <Route path="/sieges/:id" element={<SiegeSettingsPage />} />
         </Routes>
       </QueryClientProvider>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
 // Helper: wait for the page loading state to resolve
 async function waitForPageLoad() {
-  await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+  await waitFor(() =>
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+  );
 }
 
 // ─── Notify Members button ─────────────────────────────────────────────────
 
-describe('SiegeSettingsPage — Notify Members button', () => {
-  it('renders the Notify Members button', async () => {
+describe("SiegeSettingsPage — Notify Members button", () => {
+  it("renders the Notify Members button", async () => {
     renderPage();
     await waitForPageLoad();
-    expect(screen.getByRole('button', { name: /notify members/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /notify members/i })
+    ).toBeInTheDocument();
   });
 
-  it('is disabled when siege status is complete', async () => {
-    renderPage(makeSiege({ status: 'complete' }));
+  it("is disabled when siege status is complete", async () => {
+    renderPage(makeSiege({ status: "complete" }));
     await waitForPageLoad();
-    expect(screen.getByRole('button', { name: /notify members/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /notify members/i })
+    ).toBeDisabled();
   });
 
-  it('opens a confirmation dialog when the button is clicked', async () => {
+  it("opens a confirmation dialog when the button is clicked", async () => {
     const user = userEvent.setup();
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     // Check the dialog heading specifically (button and heading both contain "Notify Members")
     expect(within(dialog).getByText(/notify members/i)).toBeInTheDocument();
   });
 
-  it('disables Notify Members button and shows spinner while batch is in-progress', async () => {
+  it("disables Notify Members button and shows spinner while batch is in-progress", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('in_progress', [
+          makeBatchResponse("in_progress", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // Wait for batch panel to appear (POST returned)
-    await waitFor(() => expect(screen.getByText(/batch #101/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/batch #101/i)).toBeInTheDocument()
+    );
 
     // Button should be disabled while batch is in-progress
-    const notifyBtn = screen.getByRole('button', { name: /notify members/i });
+    const notifyBtn = screen.getByRole("button", { name: /notify members/i });
     expect(notifyBtn).toBeDisabled();
 
     // Button should show a spinner (animate-spin) while batch is in-progress
-    expect(notifyBtn.querySelector('.animate-spin')).not.toBeNull();
+    expect(notifyBtn.querySelector(".animate-spin")).not.toBeNull();
   });
 
-  it('re-enables Notify Members button after batch completes', async () => {
+  it("re-enables Notify Members button after batch completes", async () => {
     const user = userEvent.setup();
 
     let callCount = 0;
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () => {
+      http.get("/api/sieges/42/notify/101", () => {
         callCount += 1;
         if (callCount === 1) {
           return HttpResponse.json(
-            makeBatchResponse('in_progress', [
-              makeResult({ member_id: 1, member_name: 'Aethon', success: null }),
-            ]),
+            makeBatchResponse("in_progress", [
+              makeResult({
+                member_id: 1,
+                member_name: "Aethon",
+                success: null,
+              }),
+            ])
           );
         }
         return HttpResponse.json(
-          makeBatchResponse('completed', [
+          makeBatchResponse("completed", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: true,
-              sent_at: '2026-03-22T10:00:00Z',
+              sent_at: "2026-03-22T10:00:00Z",
             }),
-          ]),
+          ])
         );
-      }),
+      })
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // Wait for batch to complete
     await waitFor(
       () => {
-        const statusEl = screen.queryByText('completed');
+        const statusEl = screen.queryByText("completed");
         return expect(statusEl).not.toBeNull();
       },
-      { timeout: 10000 },
+      { timeout: 10000 }
     );
 
     // After completion, button should no longer be disabled (except for normal conditions)
-    const notifyBtn = screen.getByRole('button', { name: /notify members/i });
+    const notifyBtn = screen.getByRole("button", { name: /notify members/i });
     expect(notifyBtn).not.toBeDisabled();
 
     // No spinner should be showing on the button
-    expect(notifyBtn.querySelector('.animate-spin')).toBeNull();
+    expect(notifyBtn.querySelector(".animate-spin")).toBeNull();
   });
 });
 
 // ─── Notification batch panel ─────────────────────────────────────────────
 
-describe('SiegeSettingsPage — notification batch panel', () => {
+describe("SiegeSettingsPage — notification batch panel", () => {
   /**
    * Click "Notify Members" → confirm → verify the batch summary panel appears.
    * The confirm button inside the dialog is "Send Notifications".
    */
-  it('shows the batch panel after confirming, displaying batch id and member count', async () => {
+  it("shows the batch panel after confirming, displaying batch id and member count", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse({ batch_id: 101, member_count: 2 })),
-      ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.post("/api/sieges/42/notify", () =>
         HttpResponse.json(
-          makeBatchResponse('in_progress', [
-            makeResult({ member_id: 1, member_name: 'Aethon', success: null }),
+          makeNotifyResponse({ batch_id: 101, member_count: 2 })
+        )
+      ),
+      http.get("/api/sieges/42/notify/101", () =>
+        HttpResponse.json(
+          makeBatchResponse("in_progress", [
+            makeResult({ member_id: 1, member_name: "Aethon", success: null }),
             makeResult({
               member_id: 2,
-              member_name: 'Brint',
+              member_name: "Brint",
               discord_username: null,
               success: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
-    await waitFor(() => expect(screen.getByText(/batch #101/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/batch #101/i)).toBeInTheDocument()
+    );
     expect(screen.getByText(/2 members/i)).toBeInTheDocument();
   });
 
-  it('shows a spinner for a pending member who has a discord username', async () => {
+  it("shows a spinner for a pending member who has a discord username", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('in_progress', [
+          makeBatchResponse("in_progress", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // Wait for the member row to appear
-    await waitFor(() => expect(screen.getByText('Aethon')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Aethon")).toBeInTheDocument());
 
     // The Lucide Loader2 svg has the animate-spin class
-    const memberRow = screen.getByText('Aethon').closest('li')!;
-    expect(memberRow.querySelector('.animate-spin')).not.toBeNull();
+    const memberRow = screen.getByText("Aethon").closest("li")!;
+    expect(memberRow.querySelector(".animate-spin")).not.toBeNull();
   });
 
   it('shows a warning and "No Discord username" for a member without a discord username', async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('in_progress', [
+          makeBatchResponse("in_progress", [
             makeResult({
               member_id: 2,
-              member_name: 'Brint',
+              member_name: "Brint",
               discord_username: null,
               success: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // member_name and "— No Discord username" are in the same span, so use the combined text
-    await waitFor(() => expect(screen.getByText(/no discord username/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/no discord username/i)).toBeInTheDocument()
+    );
     // The warning icon has text-yellow-500
-    const memberRow = screen.getByText(/no discord username/i).closest('li')!;
-    expect(memberRow.querySelector('.text-yellow-500')).not.toBeNull();
+    const memberRow = screen.getByText(/no discord username/i).closest("li")!;
+    expect(memberRow.querySelector(".text-yellow-500")).not.toBeNull();
   });
 
-  it('shows a green check icon for a successfully notified member', async () => {
+  it("shows a green check icon for a successfully notified member", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('completed', [
+          makeBatchResponse("completed", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: true,
-              sent_at: '2026-03-22T10:00:00Z',
+              sent_at: "2026-03-22T10:00:00Z",
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
-    await waitFor(() => expect(screen.getByText('Aethon')).toBeInTheDocument());
-    const memberRow = screen.getByText('Aethon').closest('li')!;
+    await waitFor(() => expect(screen.getByText("Aethon")).toBeInTheDocument());
+    const memberRow = screen.getByText("Aethon").closest("li")!;
     // Lucide Check rendered with text-green-600
-    expect(memberRow.querySelector('.text-green-600')).not.toBeNull();
+    expect(memberRow.querySelector(".text-green-600")).not.toBeNull();
   });
 
-  it('shows a red X icon and error message for a failed member', async () => {
+  it("shows a red X icon and error message for a failed member", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('completed', [
+          makeBatchResponse("completed", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: false,
-              error: 'User not found',
+              error: "User not found",
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
-    await waitFor(() => expect(screen.getByText(/user not found/i)).toBeInTheDocument());
-    const memberRow = screen.getByText(/aethon/i).closest('li')!;
+    await waitFor(() =>
+      expect(screen.getByText(/user not found/i)).toBeInTheDocument()
+    );
+    const memberRow = screen.getByText(/aethon/i).closest("li")!;
     // Lucide X rendered with text-red-600
-    expect(memberRow.querySelector('.text-red-600')).not.toBeNull();
+    expect(memberRow.querySelector(".text-red-600")).not.toBeNull();
   });
 
-  it('shows error icon (not spinner) for a pending member when batch is completed', async () => {
+  it("shows error icon (not spinner) for a pending member when batch is completed", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
       // Batch is completed but member still has success=null (DB write failed)
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('completed', [
+          makeBatchResponse("completed", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: null,
               error: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
-    await waitFor(() => expect(screen.getByText(/status unknown/i)).toBeInTheDocument(), {
-      timeout: 5000,
-    });
+    await waitFor(
+      () => expect(screen.getByText(/status unknown/i)).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      }
+    );
 
-    const memberRow = screen.getByText(/status unknown/i).closest('li')!;
+    const memberRow = screen.getByText(/status unknown/i).closest("li")!;
 
     // Must NOT show a spinning loader
-    expect(memberRow.querySelector('.animate-spin')).toBeNull();
+    expect(memberRow.querySelector(".animate-spin")).toBeNull();
   });
 
-  it('shows spinner for a pending member when batch is still in-progress', async () => {
+  it("shows spinner for a pending member when batch is still in-progress", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () =>
+      http.get("/api/sieges/42/notify/101", () =>
         HttpResponse.json(
-          makeBatchResponse('pending', [
+          makeBatchResponse("pending", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: null,
             }),
-          ]),
-        ),
-      ),
+          ])
+        )
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
-    await waitFor(() => expect(screen.getByText('Aethon')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Aethon")).toBeInTheDocument());
 
-    const memberRow = screen.getByText('Aethon').closest('li')!;
+    const memberRow = screen.getByText("Aethon").closest("li")!;
     // Should show spinner while batch is still running
-    expect(memberRow.querySelector('.animate-spin')).not.toBeNull();
+    expect(memberRow.querySelector(".animate-spin")).not.toBeNull();
   });
 });
 
 // ─── Polling state transitions ─────────────────────────────────────────────
 
-describe('SiegeSettingsPage — notification polling state transitions', () => {
+describe("SiegeSettingsPage — notification polling state transitions", () => {
   /**
    * batchDone returns false on the first poll (in_progress, success=null) so React Query
    * uses a 3-second refetchInterval. The second poll returns completed, causing batchDone
    * to return false (stopping further polling). We verify the text and its green styling.
    */
-  it('transitions status text from in_progress to completed and applies green styling', async () => {
+  it("transitions status text from in_progress to completed and applies green styling", async () => {
     const user = userEvent.setup();
 
     let callCount = 0;
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () => {
+      http.get("/api/sieges/42/notify/101", () => {
         callCount += 1;
         if (callCount === 1) {
           // First poll: still processing
           return HttpResponse.json(
-            makeBatchResponse('in_progress', [
-              makeResult({ member_id: 1, member_name: 'Aethon', success: null }),
-            ]),
+            makeBatchResponse("in_progress", [
+              makeResult({
+                member_id: 1,
+                member_name: "Aethon",
+                success: null,
+              }),
+            ])
           );
         }
         // Subsequent polls: done
         return HttpResponse.json(
-          makeBatchResponse('completed', [
+          makeBatchResponse("completed", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: true,
-              sent_at: '2026-03-22T10:00:00Z',
+              sent_at: "2026-03-22T10:00:00Z",
             }),
-          ]),
+          ])
         );
-      }),
+      })
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // Wait for the batch panel
-    await waitFor(() => expect(screen.getByText(/batch #101/i)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/batch #101/i)).toBeInTheDocument()
+    );
 
     // React Query will refetch because batchDone=false on first result.
     // When the second response arrives, "completed" should appear with the green class.
     await waitFor(
       () => {
-        const statusEl = screen.getByText('completed');
+        const statusEl = screen.getByText("completed");
         expect(statusEl).toBeInTheDocument();
-        expect(statusEl).toHaveClass('text-green-600');
+        expect(statusEl).toHaveClass("text-green-600");
       },
-      { timeout: 10000 },
+      { timeout: 10000 }
     );
   });
 
@@ -558,42 +619,47 @@ describe('SiegeSettingsPage — notification polling state transitions', () => {
    * When all results already have success !== null, batchDone returns true on the very
    * first poll and refetchInterval returns false — no further fetches should occur.
    */
-  it('stops polling once all results have success !== null (batchDone=true)', async () => {
+  it("stops polling once all results have success !== null (batchDone=true)", async () => {
     const user = userEvent.setup();
 
     let callCount = 0;
     server.use(
-      http.post('/api/sieges/42/notify', () =>
-        HttpResponse.json(makeNotifyResponse()),
+      http.post("/api/sieges/42/notify", () =>
+        HttpResponse.json(makeNotifyResponse())
       ),
-      http.get('/api/sieges/42/notify/101', () => {
+      http.get("/api/sieges/42/notify/101", () => {
         callCount += 1;
         // Every response has success=true, so batchDone=true immediately
         return HttpResponse.json(
-          makeBatchResponse('in_progress', [
+          makeBatchResponse("in_progress", [
             makeResult({
               member_id: 1,
-              member_name: 'Aethon',
-              discord_username: 'aethon#0001',
+              member_name: "Aethon",
+              discord_username: "aethon#0001",
               success: true,
-              sent_at: '2026-03-22T10:00:00Z',
+              sent_at: "2026-03-22T10:00:00Z",
             }),
-          ]),
+          ])
         );
-      }),
+      })
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /notify members/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /send notifications/i }));
+    await user.click(screen.getByRole("button", { name: /notify members/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: /send notifications/i })
+    );
 
     // Wait for the first poll to resolve and member row to appear
-    await waitFor(() => expect(screen.getByText('Aethon')).toBeInTheDocument(), {
-      timeout: 5000,
-    });
+    await waitFor(
+      () => expect(screen.getByText("Aethon")).toBeInTheDocument(),
+      {
+        timeout: 5000,
+      }
+    );
 
     const countAfterFirstRender = callCount;
 
@@ -608,51 +674,53 @@ describe('SiegeSettingsPage — notification polling state transitions', () => {
 
 // ─── Post to Discord ───────────────────────────────────────────────────────
 
-describe('SiegeSettingsPage — Post to Discord', () => {
+describe("SiegeSettingsPage — Post to Discord", () => {
   it('shows "Posted successfully." after a successful post', async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/post-to-channel', () =>
-        HttpResponse.json({ status: 'ok' }),
-      ),
+      http.post("/api/sieges/42/post-to-channel", () =>
+        HttpResponse.json({ status: "ok" })
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /post to discord/i }));
-    const dialog = screen.getByRole('dialog');
+    await user.click(screen.getByRole("button", { name: /post to discord/i }));
+    const dialog = screen.getByRole("dialog");
     // Confirm button inside the Post to Discord dialog is "Post"
-    await user.click(within(dialog).getByRole('button', { name: /^post$/i }));
+    await user.click(within(dialog).getByRole("button", { name: /^post$/i }));
 
     await waitFor(() =>
-      expect(screen.getByText(/posted successfully/i)).toBeInTheDocument(),
+      expect(screen.getByText(/posted successfully/i)).toBeInTheDocument()
     );
   });
 
-  it('shows the error detail when post to channel returns a 4xx', async () => {
+  it("shows the error detail when post to channel returns a 4xx", async () => {
     const user = userEvent.setup();
     server.use(
-      http.post('/api/sieges/42/post-to-channel', () =>
-        HttpResponse.json({ detail: 'Channel not found' }, { status: 400 }),
-      ),
+      http.post("/api/sieges/42/post-to-channel", () =>
+        HttpResponse.json({ detail: "Channel not found" }, { status: 400 })
+      )
     );
 
     renderPage();
     await waitForPageLoad();
 
-    await user.click(screen.getByRole('button', { name: /post to discord/i }));
-    const dialog = screen.getByRole('dialog');
-    await user.click(within(dialog).getByRole('button', { name: /^post$/i }));
+    await user.click(screen.getByRole("button", { name: /post to discord/i }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /^post$/i }));
 
     await waitFor(() =>
-      expect(screen.getByText(/channel not found/i)).toBeInTheDocument(),
+      expect(screen.getByText(/channel not found/i)).toBeInTheDocument()
     );
   });
 
-  it('disables Post to Discord button when siege is complete', async () => {
-    renderPage(makeSiege({ status: 'complete' }));
+  it("disables Post to Discord button when siege is complete", async () => {
+    renderPage(makeSiege({ status: "complete" }));
     await waitForPageLoad();
-    expect(screen.getByRole('button', { name: /post to discord/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /post to discord/i })
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/test/pages/SiegesPage.test.tsx
+++ b/frontend/src/test/pages/SiegesPage.test.tsx
@@ -1,88 +1,88 @@
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
-import { http, HttpResponse } from 'msw';
-import { beforeAll, afterAll, afterEach, describe, it, expect } from 'vitest';
-import { server } from '../server';
-import { renderWithProviders } from '../utils';
-import SiegesPage from '../../pages/SiegesPage';
-import type { Siege } from '../../api/types';
+import { screen, waitForElementToBeRemoved } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import SiegesPage from "../../pages/SiegesPage";
+import type { Siege } from "../../api/types";
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('SiegesPage', () => {
-  it('renders the page heading', () => {
+describe("SiegesPage", () => {
+  it("renders the page heading", () => {
     renderWithProviders(<SiegesPage />);
-    expect(screen.getByRole('heading', { name: 'Sieges' })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Sieges" })).toBeInTheDocument();
   });
 
-  it('has a New Siege button', () => {
+  it("has a New Siege button", () => {
     renderWithProviders(<SiegesPage />);
-    expect(screen.getByRole('button', { name: /new siege/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /new siege/i })
+    ).toBeInTheDocument();
   });
 
-  it('shows loading state while fetching', () => {
+  it("shows loading state while fetching", () => {
     server.use(
-      http.get('/api/sieges', async () => {
+      http.get("/api/sieges", async () => {
         await new Promise(() => {}); // never resolves
-      }),
+      })
     );
     renderWithProviders(<SiegesPage />);
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
-  it('shows empty state when there are no sieges', async () => {
+  it("shows empty state when there are no sieges", async () => {
     renderWithProviders(<SiegesPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(/no sieges yet/i)).toBeInTheDocument();
   });
 
-  it('shows table column headers after loading', async () => {
+  it("shows table column headers after loading", async () => {
     renderWithProviders(<SiegesPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
-    expect(screen.getByText('Date')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Links')).toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Links")).toBeInTheDocument();
   });
 
-  it('renders siege rows when API returns data', async () => {
+  it("renders siege rows when API returns data", async () => {
     const sieges: Siege[] = [
       {
         id: 1,
-        date: '2026-03-22',
-        status: 'planning',
+        date: "2026-03-22",
+        status: "planning",
         defense_scroll_count: 0,
         computed_scroll_count: 0,
-        created_at: '2026-03-19T00:00:00Z',
-        updated_at: '2026-03-19T00:00:00Z',
+        created_at: "2026-03-19T00:00:00Z",
+        updated_at: "2026-03-19T00:00:00Z",
       },
       {
         id: 2,
-        date: '2026-03-29',
-        status: 'active',
+        date: "2026-03-29",
+        status: "active",
         defense_scroll_count: 2,
         computed_scroll_count: 2,
-        created_at: '2026-03-19T00:00:00Z',
-        updated_at: '2026-03-19T00:00:00Z',
+        created_at: "2026-03-19T00:00:00Z",
+        updated_at: "2026-03-19T00:00:00Z",
       },
     ];
-    server.use(http.get('/api/sieges', () => HttpResponse.json(sieges)));
+    server.use(http.get("/api/sieges", () => HttpResponse.json(sieges)));
 
     renderWithProviders(<SiegesPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
 
-    expect(screen.getByText('2026-03-22')).toBeInTheDocument();
-    expect(screen.getByText('2026-03-29')).toBeInTheDocument();
-    expect(screen.getByText('Planning')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText("2026-03-22")).toBeInTheDocument();
+    expect(screen.getByText("2026-03-29")).toBeInTheDocument();
+    expect(screen.getByText("Planning")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
-  it('shows error message when the API call fails', async () => {
-    server.use(
-      http.get('/api/sieges', () => HttpResponse.error()),
-    );
+  it("shows error message when the API call fails", async () => {
+    server.use(http.get("/api/sieges", () => HttpResponse.error()));
     renderWithProviders(<SiegesPage />);
-    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(/failed to load sieges/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/server.ts
+++ b/frontend/src/test/server.ts
@@ -1,4 +1,4 @@
-import { setupServer } from 'msw/node';
-import { handlers } from './handlers';
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
 
 export const server = setupServer(...handlers);

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/vitest';
+import "@testing-library/jest-dom/vitest";

--- a/frontend/src/test/utils.tsx
+++ b/frontend/src/test/utils.tsx
@@ -1,15 +1,16 @@
-import { type ReactNode } from 'react';
-import { render, type RenderOptions } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, type MemoryRouterProps } from 'react-router-dom';
+import { type ReactNode } from "react";
+import { render, type RenderOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, type MemoryRouterProps } from "react-router-dom";
+import { AuthProvider } from "../context/AuthContext";
 
-interface TestRenderOptions extends Omit<RenderOptions, 'wrapper'> {
-  initialEntries?: MemoryRouterProps['initialEntries'];
+interface TestRenderOptions extends Omit<RenderOptions, "wrapper"> {
+  initialEntries?: MemoryRouterProps["initialEntries"];
 }
 
 export function renderWithProviders(
   ui: ReactNode,
-  { initialEntries = ['/'], ...renderOptions }: TestRenderOptions = {},
+  { initialEntries = ["/"], ...renderOptions }: TestRenderOptions = {}
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -23,7 +24,9 @@ export function renderWithProviders(
   function Wrapper({ children }: { children: ReactNode }) {
     return (
       <MemoryRouter initialEntries={initialEntries}>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>{children}</AuthProvider>
+        </QueryClientProvider>
       </MemoryRouter>
     );
   }
@@ -31,4 +34,4 @@ export function renderWithProviders(
   return render(ui, { wrapper: Wrapper, ...renderOptions });
 }
 
-export * from '@testing-library/react';
+export * from "@testing-library/react";


### PR DESCRIPTION
## Summary

- Add Discord OAuth2 login (Authorization Code Grant, `identify` scope only) so only verified guild members can access the app
- Backend: `get_current_user` middleware protects all routes (dev bypass → Bearer service token → JWT session cookie → 401), auth endpoints (login, callback, logout, me)
- Frontend: `AuthContext` + `RequireAuth` wrapper + LoginPage with Discord button + 401 interceptor + user display in nav
- Guild membership verified via bot sidecar (existing endpoint), member matched by `discord_id` only (no username fallback)
- 24-hour JWT in HttpOnly/Secure/SameSite=Lax cookie

Closes #144 closes #145 closes #146 closes #147 closes #148 closes #149 closes #150 closes #151

## Changes

### Backend (new files)
- `backend/app/dependencies/auth.py` — `AuthenticatedUser` dataclass + `get_current_user` dependency
- `backend/app/api/auth.py` — OAuth2 endpoints (login, callback, logout, me)
- `backend/tests/test_auth.py` — 18 auth tests

### Backend (modified)
- `backend/app/services/bot_client.py` — `get_member()` method (raises on failure, unlike other methods)
- `backend/app/main.py` — auth router registered; all protected routers get `Depends(get_current_user)`
- `backend/tests/conftest.py` — autouse fixture sets `auth_disabled=True` for existing tests

### Frontend (new files)
- `frontend/src/context/AuthContext.tsx` — auth state management + `useAuth()` hook
- `frontend/src/pages/LoginPage.tsx` — Discord sign-in with error messages
- `frontend/src/components/RequireAuth.tsx` — route guard

### Frontend (modified)
- `frontend/src/api/client.ts` — 401 → `/login` interceptor
- `frontend/src/App.tsx` — `/login` route outside RequireAuth, all others inside
- `frontend/src/components/Layout.tsx` — username + sign-out button in nav
- `frontend/src/main.tsx` — `AuthProvider` wraps app root

## Test plan

- [ ] Backend: `pytest --ignore=tests/test_schema.py` — 250 pass (1 pre-existing failure)
- [ ] Frontend: `vitest run` — new auth tests pass (6 pre-existing vitest globals failures)
- [ ] Dev bypass: `AUTH_DISABLED=true` + `ENVIRONMENT=development` → all routes accessible
- [ ] Startup guard: `AUTH_DISABLED=true` + `ENVIRONMENT=staging` → backend refuses to start
- [ ] Login flow: Discord consent → callback → session cookie → redirect to `/sieges`
- [ ] Not in guild: → "You are not authorized to access this app."
- [ ] Bot down: → "Login is temporarily unavailable."
- [ ] Sign out: cookie cleared → redirect to `/login`

## Pre-launch checklist (before enabling auth)

1. Run Discord sync: `POST /api/members/discord-sync/apply`
2. Verify zero unsynced: `SELECT COUNT(*) FROM member WHERE discord_id IS NULL` = 0
3. Register Discord app at discord.com/developers/applications
4. Set `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `SESSION_SECRET`

**Spec:** `docs/superpowers/plans/discord-auth-plan.md`
**Plan:** `docs/superpowers/plans/2026-04-08-discord-auth-implementation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)