### PR TITLE
infra: wire OAuth2 secrets through Bicep and deploy workflow

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -161,7 +161,11 @@ jobs:
             --parameters discordToken="ci-placeholder-value" \
             --parameters discordBotApiKey="ci-placeholder-value" \
             --parameters botApiKey="ci-placeholder-value" \
-            --parameters discordGuildId="000000000000000000"
+            --parameters discordGuildId="000000000000000000" \
+            --parameters sessionSecret="ci-placeholder-value" \
+            --parameters discordClientId="ci-placeholder-value" \
+            --parameters discordClientSecret="ci-placeholder-value" \
+            --parameters discordRedirectUri="https://placeholder.example.com/api/auth/callback"
 
       - name: Post failure comment
         if: failure() && github.event_name == 'pull_request'
@@ -214,6 +218,10 @@ jobs:
             --parameters discordBotApiKey="ci-placeholder-value" \
             --parameters botApiKey="ci-placeholder-value" \
             --parameters discordGuildId="000000000000000000" \
+            --parameters sessionSecret="ci-placeholder-value" \
+            --parameters discordClientId="ci-placeholder-value" \
+            --parameters discordClientSecret="ci-placeholder-value" \
+            --parameters discordRedirectUri="https://placeholder.example.com/api/auth/callback" \
             --result-format ResourceIdOnly \
             2>&1 | tee /tmp/what-if.txt; exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -19,7 +19,9 @@ name: Infra Deploy
 # the rationale.
 #
 # New secrets required per environment (add under Settings → Environments):
-#   Secrets  : POSTGRES_ADMIN_PASSWORD, DISCORD_TOKEN, BOT_API_KEY
+#   Secrets  : POSTGRES_ADMIN_PASSWORD, DISCORD_TOKEN, BOT_API_KEY,
+#              SESSION_SECRET, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET,
+#              DISCORD_REDIRECT_URI
 #   Variables: DISCORD_GUILD_ID
 #
 # ──────────────────────────────────────────────────────────────────────────────
@@ -116,6 +118,10 @@ jobs:
             --parameters discordBotApiKey="${{ secrets.BOT_API_KEY }}" \
             --parameters botApiKey="${{ secrets.BOT_API_KEY }}" \
             --parameters discordGuildId="${{ vars.DISCORD_GUILD_ID }}" \
+            --parameters sessionSecret="${{ secrets.SESSION_SECRET }}" \
+            --parameters discordClientId="${{ secrets.DISCORD_CLIENT_ID }}" \
+            --parameters discordClientSecret="${{ secrets.DISCORD_CLIENT_SECRET }}" \
+            --parameters discordRedirectUri="${{ secrets.DISCORD_REDIRECT_URI }}" \
             --parameters imageTag="${{ env.IMAGE_TAG }}"
 
 # ── Deploy (prod) ────────────────────────────────────────────────────────────
@@ -167,4 +173,8 @@ jobs:
             --parameters discordBotApiKey="${{ secrets.BOT_API_KEY }}" \
             --parameters botApiKey="${{ secrets.BOT_API_KEY }}" \
             --parameters discordGuildId="${{ vars.DISCORD_GUILD_ID }}" \
+            --parameters sessionSecret="${{ secrets.SESSION_SECRET }}" \
+            --parameters discordClientId="${{ secrets.DISCORD_CLIENT_ID }}" \
+            --parameters discordClientSecret="${{ secrets.DISCORD_CLIENT_SECRET }}" \
+            --parameters discordRedirectUri="${{ secrets.DISCORD_REDIRECT_URI }}" \
             --parameters imageTag="${{ env.IMAGE_TAG }}"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -44,6 +44,7 @@ param botApiKey string
 param sessionSecret string
 
 @description('Discord OAuth2 application client ID')
+@secure()
 param discordClientId string
 
 @description('Discord OAuth2 application client secret')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -39,6 +39,20 @@ param discordBotApiKey string
 @secure()
 param botApiKey string
 
+@description('Secret key for signing JWT session cookies')
+@secure()
+param sessionSecret string
+
+@description('Discord OAuth2 application client ID')
+param discordClientId string
+
+@description('Discord OAuth2 application client secret')
+@secure()
+param discordClientSecret string
+
+@description('Discord OAuth2 redirect URI (full callback URL)')
+param discordRedirectUri string
+
 @description('Enable geo-redundant PostgreSQL backup (set true for prod)')
 param postgresGeoRedundantBackup bool = false
 
@@ -161,6 +175,10 @@ module keyVault 'modules/keyvault.bicep' = {
     discordGuildId: discordGuildId
     discordBotApiKey: discordBotApiKey
     botApiKey: botApiKey
+    sessionSecret: sessionSecret
+    discordClientId: discordClientId
+    discordClientSecret: discordClientSecret
+    discordRedirectUri: discordRedirectUri
     softDeleteRetentionDays: kvSoftDeleteRetentionDays
   }
 }

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -12,7 +12,11 @@ using 'main.bicep'
 //     --parameters discordToken="$DISCORD_TOKEN" \
 //     --parameters discordBotApiKey="$DISCORD_BOT_API_KEY" \
 //     --parameters botApiKey="$BOT_API_KEY" \
-//     --parameters discordGuildId="$DISCORD_GUILD_ID"
+//     --parameters discordGuildId="$DISCORD_GUILD_ID" \
+//     --parameters sessionSecret="$SESSION_SECRET" \
+//     --parameters discordClientId="$DISCORD_CLIENT_ID" \
+//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET" \
+//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or CLI --parameters flags.
@@ -60,6 +64,13 @@ param discordGuildId = '' // Your Discord server ID (non-secret; ok to fill in)
 param discordToken = ''
 param discordBotApiKey = ''
 param botApiKey = ''
+
+// ── OAuth2 secrets ────────────────────────────────────────────────────────────
+// Supply at deploy time:
+param sessionSecret = ''
+param discordClientId = ''
+param discordClientSecret = ''
+param discordRedirectUri = ''
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 7-day soft-delete retention is the minimum allowed by Azure and enables fast

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -12,7 +12,11 @@ using 'main.bicep'
 //     --parameters discordToken="$DISCORD_TOKEN" \
 //     --parameters discordBotApiKey="$DISCORD_BOT_API_KEY" \
 //     --parameters botApiKey="$BOT_API_KEY" \
-//     --parameters discordGuildId="$DISCORD_GUILD_ID"
+//     --parameters discordGuildId="$DISCORD_GUILD_ID" \
+//     --parameters sessionSecret="$SESSION_SECRET" \
+//     --parameters discordClientId="$DISCORD_CLIENT_ID" \
+//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET" \
+//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or a CI/CD secret store.
@@ -59,6 +63,13 @@ param discordGuildId = '' // Your Discord server ID (non-secret; ok to fill in)
 param discordToken = ''
 param discordBotApiKey = ''
 param botApiKey = ''
+
+// ── OAuth2 secrets ────────────────────────────────────────────────────────────
+// Supply at deploy time:
+param sessionSecret = ''
+param discordClientId = ''
+param discordClientSecret = ''
+param discordRedirectUri = ''
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 90-day soft-delete retention gives the maximum recovery window for secrets

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -123,6 +123,26 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
           keyVaultUrl: '${keyVaultUri}secrets/discord-bot-api-key'
           identity: 'system'
         }
+        {
+          name: 'session-secret'
+          keyVaultUrl: '${keyVaultUri}secrets/session-secret'
+          identity: 'system'
+        }
+        {
+          name: 'discord-client-id'
+          keyVaultUrl: '${keyVaultUri}secrets/discord-client-id'
+          identity: 'system'
+        }
+        {
+          name: 'discord-client-secret'
+          keyVaultUrl: '${keyVaultUri}secrets/discord-client-secret'
+          identity: 'system'
+        }
+        {
+          name: 'discord-redirect-uri'
+          keyVaultUrl: '${keyVaultUri}secrets/discord-redirect-uri'
+          identity: 'system'
+        }
       ]
     }
     template: {
@@ -141,6 +161,11 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
               { name: 'DISCORD_BOT_API_URL', value: 'http://${botAppName}' }
               { name: 'DISCORD_GUILD_ID', value: discordGuildId }
               { name: 'ENVIRONMENT', value: environment }
+              { name: 'SESSION_SECRET', secretRef: 'session-secret' }
+              { name: 'DISCORD_CLIENT_ID', secretRef: 'discord-client-id' }
+              { name: 'DISCORD_CLIENT_SECRET', secretRef: 'discord-client-secret' }
+              { name: 'DISCORD_REDIRECT_URI', secretRef: 'discord-redirect-uri' }
+              { name: 'BOT_SERVICE_TOKEN', secretRef: 'discord-bot-api-key' }
             ],
             // Only inject the Application Insights connection string when one
             // has been provided — keeps dev deployments lightweight.

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -31,6 +31,7 @@ param botApiKey string
 param sessionSecret string
 
 @description('Discord OAuth2 application client ID')
+@secure()
 param discordClientId string
 
 @description('Discord OAuth2 application client secret')

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -26,6 +26,20 @@ param discordBotApiKey string
 @secure()
 param botApiKey string
 
+@description('Secret key for signing JWT session cookies')
+@secure()
+param sessionSecret string
+
+@description('Discord OAuth2 application client ID')
+param discordClientId string
+
+@description('Discord OAuth2 application client secret')
+@secure()
+param discordClientSecret string
+
+@description('Discord OAuth2 redirect URI')
+param discordRedirectUri string
+
 // Soft-delete retention: minimum is 7 days; Azure default (and recommended for
 // prod) is 90 days. This means a deleted vault or secret can be recovered for
 // up to retentionDays before it is permanently purged. Use 7 for dev (fast
@@ -87,6 +101,30 @@ resource secretBotApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: keyVault
   name: 'bot-api-key'
   properties: { value: botApiKey }
+}
+
+resource secretSessionSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'session-secret'
+  properties: { value: sessionSecret }
+}
+
+resource secretDiscordClientId 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'discord-client-id'
+  properties: { value: discordClientId }
+}
+
+resource secretDiscordClientSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'discord-client-secret'
+  properties: { value: discordClientSecret }
+}
+
+resource secretDiscordRedirectUri 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: keyVault
+  name: 'discord-redirect-uri'
+  properties: { value: discordRedirectUri }
 }
 
 output vaultId string = keyVault.id


### PR DESCRIPTION
## Summary

- Add `SESSION_SECRET`, `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI` to the full secret chain: Bicep params → Key Vault → Container Apps env vars
- Add `BOT_SERVICE_TOKEN` env var to the API container (reuses existing `discord-bot-api-key` KV secret — the backend startup guard requires this in non-dev environments)
- Update `infra-deploy.yml` to pass new secrets from GitHub Actions to Bicep
- Update `infra-ci.yml` with placeholder values for validation/what-if gates
- Update `.bicepparam` files with placeholder entries and updated deploy command docs

## Why

PR #152 added Discord OAuth2 auth with startup guards that crash the API container if `SESSION_SECRET` and `BOT_SERVICE_TOKEN` are missing. The GitHub secrets are already configured — this PR wires them through the infrastructure layer.

## Files changed (7)

| File | Change |
|---|---|
| `infra/main.bicep` | 4 new params, passed to keyVault module |
| `infra/modules/keyvault.bicep` | 4 new params, 4 new KV secret resources |
| `infra/modules/container-apps.bicep` | 4 new KV secret refs + 5 new env vars on API container |
| `.github/workflows/infra-deploy.yml` | Pass 4 new secrets in both dev and prod deploy jobs |
| `.github/workflows/infra-ci.yml` | Add CI placeholders for validate and what-if gates |
| `infra/main.dev.bicepparam` | Placeholder entries + updated deploy command |
| `infra/main.prod.bicepparam` | Placeholder entries + updated deploy command |

## Test plan

- [ ] Infra CI passes (lint → build → validate → what-if)
- [ ] After merge, run Infra Deploy workflow for dev environment
- [ ] Verify API container starts successfully (no more startup crash)
- [ ] Verify `/api/auth/login` returns a Discord OAuth URL

fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)