### PR TITLE
infra: promote DISCORD_REDIRECT_URI from KV secret to plain env var

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -20,9 +20,9 @@ name: Infra Deploy
 #
 # New secrets required per environment (add under Settings → Environments):
 #   Secrets  : POSTGRES_ADMIN_PASSWORD, DISCORD_TOKEN, BOT_API_KEY,
-#              SESSION_SECRET, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET,
-#              DISCORD_REDIRECT_URI
-#   Variables: DISCORD_GUILD_ID
+#              SESSION_SECRET, DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET
+#   Variables: DISCORD_GUILD_ID, DISCORD_REDIRECT_URI
+#              (redirect URI is a public URL, not a secret — use a variable)
 #
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -121,7 +121,7 @@ jobs:
             --parameters sessionSecret="${{ secrets.SESSION_SECRET }}" \
             --parameters discordClientId="${{ secrets.DISCORD_CLIENT_ID }}" \
             --parameters discordClientSecret="${{ secrets.DISCORD_CLIENT_SECRET }}" \
-            --parameters discordRedirectUri="${{ secrets.DISCORD_REDIRECT_URI }}" \
+            --parameters discordRedirectUri="${{ vars.DISCORD_REDIRECT_URI }}" \
             --parameters imageTag="${{ env.IMAGE_TAG }}"
 
 # ── Deploy (prod) ────────────────────────────────────────────────────────────
@@ -176,5 +176,5 @@ jobs:
             --parameters sessionSecret="${{ secrets.SESSION_SECRET }}" \
             --parameters discordClientId="${{ secrets.DISCORD_CLIENT_ID }}" \
             --parameters discordClientSecret="${{ secrets.DISCORD_CLIENT_SECRET }}" \
-            --parameters discordRedirectUri="${{ secrets.DISCORD_REDIRECT_URI }}" \
+            --parameters discordRedirectUri="${{ vars.DISCORD_REDIRECT_URI }}" \
             --parameters imageTag="${{ env.IMAGE_TAG }}"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -179,7 +179,6 @@ module keyVault 'modules/keyvault.bicep' = {
     sessionSecret: sessionSecret
     discordClientId: discordClientId
     discordClientSecret: discordClientSecret
-    discordRedirectUri: discordRedirectUri
     softDeleteRetentionDays: kvSoftDeleteRetentionDays
   }
 }
@@ -220,6 +219,7 @@ module containerApps 'modules/container-apps.bicep' = {
     imageTag: imageTag
     keyVaultUri: keyVault.outputs.vaultUri
     discordGuildId: discordGuildId
+    discordRedirectUri: discordRedirectUri
     acrUsername: registry.outputs.acrUsername
     acrPassword: registry.outputs.acrPassword
     appInsightsConnectionString: appInsights.outputs.connectionString

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -15,8 +15,8 @@ using 'main.bicep'
 //     --parameters discordGuildId="$DISCORD_GUILD_ID" \
 //     --parameters sessionSecret="$SESSION_SECRET" \
 //     --parameters discordClientId="$DISCORD_CLIENT_ID" \
-//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET" \
-//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
+//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"
+//     --parameters discordRedirectUri="https://dev.example.com/api/auth/callback"  # plain config, not a secret
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or CLI --parameters flags.
@@ -70,7 +70,11 @@ param botApiKey = ''
 param sessionSecret = ''
 param discordClientId = ''
 param discordClientSecret = ''
-param discordRedirectUri = ''
+
+// ── OAuth2 config (non-secret) ────────────────────────────────────────────────
+// The redirect URI is a public URL (visible in the browser address bar during
+// the OAuth flow). It is config, not a secret — supply inline or via vars.*.
+param discordRedirectUri = 'https://siegeweb-dev.example.com/api/auth/callback'
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 7-day soft-delete retention is the minimum allowed by Azure and enables fast

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -16,7 +16,7 @@ using 'main.bicep'
 //     --parameters sessionSecret="$SESSION_SECRET" \
 //     --parameters discordClientId="$DISCORD_CLIENT_ID" \
 //     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"
-//     --parameters discordRedirectUri="https://dev.example.com/api/auth/callback"  # plain config, not a secret
+//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or CLI --parameters flags.
@@ -74,7 +74,7 @@ param discordClientSecret = ''
 // ── OAuth2 config (non-secret) ────────────────────────────────────────────────
 // The redirect URI is a public URL (visible in the browser address bar during
 // the OAuth flow). It is config, not a secret — supply inline or via vars.*.
-param discordRedirectUri = 'https://siegeweb-dev.example.com/api/auth/callback'
+param discordRedirectUri = ''
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 7-day soft-delete retention is the minimum allowed by Azure and enables fast

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -15,8 +15,8 @@ using 'main.bicep'
 //     --parameters discordGuildId="$DISCORD_GUILD_ID" \
 //     --parameters sessionSecret="$SESSION_SECRET" \
 //     --parameters discordClientId="$DISCORD_CLIENT_ID" \
-//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET" \
-//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
+//     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"
+//     --parameters discordRedirectUri="https://prod.example.com/api/auth/callback"  # plain config, not a secret
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or a CI/CD secret store.
@@ -69,7 +69,11 @@ param botApiKey = ''
 param sessionSecret = ''
 param discordClientId = ''
 param discordClientSecret = ''
-param discordRedirectUri = ''
+
+// ── OAuth2 config (non-secret) ────────────────────────────────────────────────
+// The redirect URI is a public URL (visible in the browser address bar during
+// the OAuth flow). It is config, not a secret — supply inline or via vars.*.
+param discordRedirectUri = 'https://siegeweb-prod.example.com/api/auth/callback'
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 90-day soft-delete retention gives the maximum recovery window for secrets

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -16,7 +16,7 @@ using 'main.bicep'
 //     --parameters sessionSecret="$SESSION_SECRET" \
 //     --parameters discordClientId="$DISCORD_CLIENT_ID" \
 //     --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"
-//     --parameters discordRedirectUri="https://prod.example.com/api/auth/callback"  # plain config, not a secret
+//     --parameters discordRedirectUri="$DISCORD_REDIRECT_URI"
 //
 // NEVER commit real secrets here. All @secure() params must be supplied at
 // deploy time via environment variables or a CI/CD secret store.
@@ -73,7 +73,7 @@ param discordClientSecret = ''
 // ── OAuth2 config (non-secret) ────────────────────────────────────────────────
 // The redirect URI is a public URL (visible in the browser address bar during
 // the OAuth flow). It is config, not a secret — supply inline or via vars.*.
-param discordRedirectUri = 'https://siegeweb-prod.example.com/api/auth/callback'
+param discordRedirectUri = ''
 
 // ── Key Vault ─────────────────────────────────────────────────────────────────
 // 90-day soft-delete retention gives the maximum recovery window for secrets

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -22,6 +22,9 @@ param keyVaultUri string
 @description('Discord guild ID (non-secret)')
 param discordGuildId string
 
+@description('Discord OAuth2 redirect URI (non-secret; public URL visible in browser address bar)')
+param discordRedirectUri string
+
 @description('ACR admin username for image pull authentication')
 param acrUsername string
 
@@ -138,11 +141,6 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
           keyVaultUrl: '${keyVaultUri}secrets/discord-client-secret'
           identity: 'system'
         }
-        {
-          name: 'discord-redirect-uri'
-          keyVaultUrl: '${keyVaultUri}secrets/discord-redirect-uri'
-          identity: 'system'
-        }
       ]
     }
     template: {
@@ -164,7 +162,7 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
               { name: 'SESSION_SECRET', secretRef: 'session-secret' }
               { name: 'DISCORD_CLIENT_ID', secretRef: 'discord-client-id' }
               { name: 'DISCORD_CLIENT_SECRET', secretRef: 'discord-client-secret' }
-              { name: 'DISCORD_REDIRECT_URI', secretRef: 'discord-redirect-uri' }
+              { name: 'DISCORD_REDIRECT_URI', value: discordRedirectUri }
               { name: 'BOT_SERVICE_TOKEN', secretRef: 'discord-bot-api-key' }
             ],
             // Only inject the Application Insights connection string when one

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -38,9 +38,6 @@ param discordClientId string
 @secure()
 param discordClientSecret string
 
-@description('Discord OAuth2 redirect URI')
-param discordRedirectUri string
-
 // Soft-delete retention: minimum is 7 days; Azure default (and recommended for
 // prod) is 90 days. This means a deleted vault or secret can be recovered for
 // up to retentionDays before it is permanently purged. Use 7 for dev (fast
@@ -120,12 +117,6 @@ resource secretDiscordClientSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01
   parent: keyVault
   name: 'discord-client-secret'
   properties: { value: discordClientSecret }
-}
-
-resource secretDiscordRedirectUri 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
-  parent: keyVault
-  name: 'discord-redirect-uri'
-  properties: { value: discordRedirectUri }
 }
 
 output vaultId string = keyVault.id


### PR DESCRIPTION
## Summary

- Removes the `discord-redirect-uri` secret from Key Vault — it was storing a public URL that is visible in the browser address bar during OAuth, which is not sensitive data
- Adds a plain `discordRedirectUri` param to `container-apps.bicep` and wires `DISCORD_REDIRECT_URI` as a regular `value:` env var (identical to how `DISCORD_GUILD_ID` is handled)
- Threads the value through `main.bicep` → `containerApps` module (no longer routed through `keyVault` module)
- Switches the deploy workflow from `secrets.DISCORD_REDIRECT_URI` to `vars.DISCORD_REDIRECT_URI` — GitHub Environment variables are the right store for non-sensitive, environment-specific config
- Updates `.bicepparam` files to reflect that `discordRedirectUri` is config, not a secret

## Why

`DISCORD_REDIRECT_URI` is the OAuth2 callback URL (e.g. `https://myapp.example.com/api/auth/callback`). It must be registered in the Discord Developer Portal and is transmitted in plain text in browser redirects — it has no secrecy requirement. Treating it as a KV secret means one extra secret to provision, rotate, and manage for zero security benefit. The `discordGuildId` precedent already establishes the right pattern for non-sensitive Discord config.

## Files changed

| File | Change |
|---|---|
| `infra/modules/keyvault.bicep` | Remove `discordRedirectUri` param and `discord-redirect-uri` secret resource |
| `infra/modules/container-apps.bicep` | Add plain `discordRedirectUri` param; switch env var from `secretRef` to `value:` |
| `infra/main.bicep` | Stop passing `discordRedirectUri` to `keyVault` module; pass to `containerApps` module |
| `infra/main.dev.bicepparam` | Move `discordRedirectUri` to a plain config section; update deploy comment |
| `infra/main.prod.bicepparam` | Same as dev param file |
| `.github/workflows/infra-deploy.yml` | Switch `secrets.DISCORD_REDIRECT_URI` → `vars.DISCORD_REDIRECT_URI`; update header comment |

## Test plan

- [ ] Infra CI passes: Bicep lint → build → ARM preflight validate → what-if all green
- [ ] What-if output shows the `discord-redirect-uri` KV secret as **Delete** — confirm this is expected and safe (the running Container App reads the value from its plain env var after redeployment, not from KV)
- [ ] No other KV secrets appear as unexpected deletes in what-if output
- [ ] Verify `vars.DISCORD_REDIRECT_URI` is set under Settings → Environments → dev and Settings → Environments → prod before running a real deploy
- [ ] After deploy, confirm `DISCORD_REDIRECT_URI` env var is visible on the API Container App (Azure Portal → Container App → Environment variables) and matches the expected callback URL

closes #157

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)