### PR TITLE
ci(infra): migrate infra-ci.yml from GH_PAT to App token

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -95,7 +95,8 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          # Use App token on PRs (enables @claude triggering); fall back to GITHUB_TOKEN on other events
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -136,7 +137,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -195,7 +196,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -261,7 +262,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const fs = require('fs');
             const output = fs.readFileSync('/tmp/what-if.txt', 'utf8');
@@ -277,7 +278,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -67,6 +67,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -87,7 +95,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,6 +115,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -120,7 +136,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -143,6 +159,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -171,7 +195,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -199,6 +223,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -229,7 +261,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const output = fs.readFileSync('/tmp/what-if.txt', 'utf8');
@@ -245,7 +277,7 @@ jobs:
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- Replaces the long-lived `secrets.GH_PAT` with short-lived GitHub App installation tokens minted once per job via `actions/create-github-app-token@v1`
- Uses the existing `APP_ID` / `APP_PRIVATE_KEY` repo secrets — no new secrets required
- Token is minted only on `pull_request` events (the only trigger that consumes it); non-PR runs skip the step cleanly
- Script bodies, `if:` conditions, and the top-level `permissions:` block are all untouched

## What changed

| Change | Count |
|---|---|
| New "Mint GitHub App token" steps added (one per job) | 4 |
| `github-token: ${{ secrets.GH_PAT }}` replaced with `${{ steps.app-token.outputs.token }}` | 5 |

Jobs affected: `infra-lint`, `infra-build`, `infra-validate-dev`, `infra-what-if-dev`

## Why App token instead of PAT rotation

- **No expiry treadmill** — installation tokens are minted fresh each run and expire after 1 hour; no calendar reminder to rotate a PAT
- **Least-privilege** — token carries only the permissions granted to the App's installation (`pull-requests: write`), not the full scope of a personal PAT
- **Preserves `@claude` trigger** — comments posted by the App (rather than `GITHUB_TOKEN`) can trigger downstream workflows that listen for PR comments, which is the exact behavior these steps rely on for the `@claude` auto-trigger described in #156

## Scope note

`ci.yml` line 143 still references `GH_PAT` via the shared `claude-lint-fix@v1` action. That migration requires an upstream shared-action update and is tracked separately in #161. `GH_PAT` must not be deleted until #161 is resolved.

## Test plan

- [ ] Infra CI workflow runs successfully on this PR (gates 1–4 all pass)
- [ ] The what-if comment posts to this PR from the App identity (visible sign that the token is minting correctly)
- [ ] If any gate fails, the failure comment also posts successfully via the App token

closes #156

---

Generated with [Claude Code](https://claude.com/claude-code)