### PR TITLE
docs: commit landing-page plan and mockups

### DIFF
--- a/docs/mockups/README.md
+++ b/docs/mockups/README.md
@@ -1,0 +1,1 @@
+Throwaway mockups for the public-launch landing page and login polish. Open either HTML file directly in a browser. No build step required. These are not production artifacts and should be deleted once the real React components land.

--- a/docs/mockups/mockup-landing.html
+++ b/docs/mockups/mockup-landing.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Siege Assignments — open-source Raid: Shadow Legends clan tool</title>
+  <meta name="description" content="A fully open-source web app for managing Raid: Shadow Legends siege assignments. Built for Master's Of Magicka. Deploy your own instance anywhere Docker runs." />
+  <meta property="og:title" content="Siege Assignments" />
+  <meta property="og:description" content="Open-source siege assignment tool for Raid: Shadow Legends clans. Self-host anywhere." />
+  <meta property="og:type" content="website" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui'] }
+        }
+      }
+    }
+  </script>
+  <style>
+    /* Faint dot-grid decorative background for hero */
+    .hero-bg {
+      background-color: #ffffff;
+      background-image: radial-gradient(circle at 60% 20%, rgba(124, 58, 237, 0.06) 0%, transparent 60%),
+                        radial-gradient(#e2e8f0 1px, transparent 1px);
+      background-size: 100% 100%, 24px 24px;
+    }
+  </style>
+</head>
+<body class="font-sans antialiased text-slate-900">
+
+  <!-- ============================================================
+       STICKY NAV
+  ============================================================ -->
+  <nav id="main-nav" class="sticky top-0 z-50 bg-white/95 backdrop-blur border-b border-slate-200 transition-all duration-200">
+    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+      <!-- Left: logo + wordmark -->
+      <a href="/" class="flex items-center gap-2 text-slate-900 hover:text-violet-700 transition-colors">
+        <!-- Lucide Shield SVG -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none"
+             stroke="#7c3aed" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        </svg>
+        <span class="font-semibold text-base tracking-tight">Siege Assignments</span>
+      </a>
+      <!-- Right: GitHub + Sign in -->
+      <div class="flex items-center gap-3">
+        <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener noreferrer"
+           class="text-slate-500 hover:text-slate-900 transition-colors p-1.5 rounded-md hover:bg-slate-100"
+           aria-label="View on GitHub">
+          <!-- Lucide Github SVG -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/>
+            <path d="M9 18c-4.51 2-5-2-7-2"/>
+          </svg>
+        </a>
+        <a href="/login"
+           class="px-4 py-1.5 rounded-md text-white text-sm font-medium transition-opacity hover:opacity-90"
+           style="background-color: #5865F2;">
+          Sign in
+        </a>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+
+    <!-- ============================================================
+         HERO
+    ============================================================ -->
+    <section class="hero-bg min-h-[82vh] flex items-center">
+      <div class="max-w-4xl mx-auto px-6 py-24 text-center">
+        <p class="text-xs font-semibold uppercase tracking-widest text-slate-500 mb-5">
+          A portfolio project by higgsbp
+        </p>
+        <h1 class="text-4xl sm:text-5xl font-bold text-slate-900 leading-tight tracking-tight mb-4">
+          A siege assignment tool I built<br class="hidden sm:block" /> for my Raid: Shadow Legends clan.
+        </h1>
+        <p class="text-sm text-slate-500 mb-6 tracking-wide">
+          FastAPI · React · PostgreSQL · Azure Container Apps · Discord bot
+        </p>
+        <!-- PROVISIONAL COPY — subject to redlines -->
+        <p class="text-lg text-slate-700 max-w-2xl mx-auto mb-10 leading-relaxed">
+          Fully open source. I built it for my own clan, but everything you need to run it for yours is in the repo.
+        </p>
+        <!-- PROVISIONAL COPY — subject to redlines -->
+        <a href="#self-host"
+           class="inline-block px-8 py-3.5 rounded-lg bg-violet-600 text-white font-semibold text-base hover:bg-violet-700 transition-colors shadow-sm"
+           id="hero-cta">
+          Set it up for your clan ↓
+        </a>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         WHAT IT DOES
+    ============================================================ -->
+    <section id="features" class="py-24 bg-slate-50">
+      <div class="max-w-6xl mx-auto px-6">
+        <h2 class="text-3xl font-bold text-slate-900 mb-12">What it does</h2>
+        <div class="grid md:grid-cols-2 gap-10 items-start">
+          <!-- Left: screenshot placeholder -->
+          <div class="h-96 rounded-lg border-2 border-dashed border-slate-300 flex items-center justify-center text-slate-400 text-sm bg-white">
+            Master's Of Magicka board screenshot
+          </div>
+          <!-- Right: feature bullets -->
+          <ul class="space-y-4">
+            <!-- Check icon inline SVG (Lucide Check) -->
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">Auto-fill algorithm that respects pin state and attack-day thresholds</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">16 validation rules enforced live as you edit</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">Drag-and-drop member bucket per building</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">Generated PNG boards posted to Discord automatically</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">Per-member DM notifications with delivery tracking</span>
+            </li>
+            <li class="flex items-start gap-3">
+              <svg class="mt-0.5 shrink-0 text-violet-600" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
+                   fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+              <span class="text-slate-700">Side-by-side siege comparison for planning</span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- ========================================================
+             FEATURE SLIDESHOW — "See the workflow"
+        ======================================================== -->
+        <div class="mt-16">
+          <h3 class="text-xl font-semibold text-slate-800 mb-2">See the workflow</h3>
+          <p class="text-slate-500 text-sm mb-6">Six screens that cover the full workflow — from assignment to notification.</p>
+
+          <!-- Slideshow viewport -->
+          <div class="relative max-w-2xl mx-auto overflow-hidden rounded-xl bg-white border border-slate-200 shadow-sm">
+
+            <!-- Track: all 6 cards side by side, shifted via transform -->
+            <div id="slideshow-track" class="flex" style="transition: transform 500ms ease-out;">
+
+              <!-- Card 1: Assignment board -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Assignment board</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Assignment board</p>
+                  <p class="text-sm text-slate-500">Drag-and-drop member buckets per building</p>
+                </div>
+              </div>
+
+              <!-- Card 2: Auto-fill preview -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Auto-fill preview</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Auto-fill preview</p>
+                  <p class="text-sm text-slate-500">Algorithm output before committing</p>
+                </div>
+              </div>
+
+              <!-- Card 3: Validation errors -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Validation errors</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Validation errors</p>
+                  <p class="text-sm text-slate-500">16 rules enforced live as you edit</p>
+                </div>
+              </div>
+
+              <!-- Card 4: Siege comparison -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Siege comparison</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Siege comparison</p>
+                  <p class="text-sm text-slate-500">Side-by-side planning view</p>
+                </div>
+              </div>
+
+              <!-- Card 5: Generated Discord image -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Generated Discord image</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Generated Discord image</p>
+                  <p class="text-sm text-slate-500">The PNG posted to your channel</p>
+                </div>
+              </div>
+
+              <!-- Card 6: Notification tracking -->
+              <div class="shrink-0 w-full flex flex-col overflow-hidden">
+                <div class="h-[28rem] border-b-2 border-dashed border-slate-300 bg-slate-50 flex items-center justify-center">
+                  <span class="font-semibold text-slate-400 text-sm text-center px-4">Notification tracking</span>
+                </div>
+                <div class="px-6 py-4 border-t border-slate-100">
+                  <p class="font-medium text-slate-700 text-sm mb-0.5">Notification tracking</p>
+                  <p class="text-sm text-slate-500">DM batch delivery status</p>
+                </div>
+              </div>
+
+            </div><!-- /track -->
+
+            <!-- Prev arrow -->
+            <button type="button" id="slideshow-prev" aria-label="Previous slide"
+                    class="absolute left-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/90 shadow-md border border-slate-200 text-slate-700 hover:bg-white hover:text-violet-600 transition-colors flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="15 18 9 12 15 6"/>
+              </svg>
+            </button>
+
+            <!-- Next arrow -->
+            <button type="button" id="slideshow-next" aria-label="Next slide"
+                    class="absolute right-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/90 shadow-md border border-slate-200 text-slate-700 hover:bg-white hover:text-violet-600 transition-colors flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="9 18 15 12 9 6"/>
+              </svg>
+            </button>
+
+          </div><!-- /viewport -->
+
+          <!-- Dot pagination -->
+          <div id="slideshow-dots" class="flex items-center justify-center gap-2 mt-6">
+            <button type="button" aria-label="Go to slide 1" class="w-2 h-2 rounded-full bg-violet-600 transition-colors"></button>
+            <button type="button" aria-label="Go to slide 2" class="w-2 h-2 rounded-full bg-slate-300 transition-colors"></button>
+            <button type="button" aria-label="Go to slide 3" class="w-2 h-2 rounded-full bg-slate-300 transition-colors"></button>
+            <button type="button" aria-label="Go to slide 4" class="w-2 h-2 rounded-full bg-slate-300 transition-colors"></button>
+            <button type="button" aria-label="Go to slide 5" class="w-2 h-2 rounded-full bg-slate-300 transition-colors"></button>
+            <button type="button" aria-label="Go to slide 6" class="w-2 h-2 rounded-full bg-slate-300 transition-colors"></button>
+          </div>
+
+        </div>
+
+      </div>
+    </section>
+
+    <!-- ============================================================
+         UNDER THE HOOD
+    ============================================================ -->
+    <section id="architecture" class="py-24 bg-white">
+      <div class="max-w-6xl mx-auto px-6">
+        <h2 class="text-3xl font-bold text-slate-900 mb-4">Under the hood</h2>
+        <p class="text-slate-600 max-w-2xl mb-12 leading-relaxed">
+          Three containerized services deployed via Bicep infrastructure-as-code, with CI/CD through GitHub Actions.
+          Cloud-agnostic by design — the whole stack runs anywhere Docker runs.
+        </p>
+        <!-- Service cards -->
+        <div class="grid md:grid-cols-3 gap-6 mb-8">
+          <div class="rounded-lg border border-slate-200 p-6 shadow-sm hover:shadow-md transition-shadow">
+            <p class="font-mono text-sm font-semibold text-violet-700 mb-2">siege-api</p>
+            <p class="text-slate-600 text-sm leading-relaxed">FastAPI · SQLAlchemy async · Playwright for image generation</p>
+          </div>
+          <div class="rounded-lg border border-slate-200 p-6 shadow-sm hover:shadow-md transition-shadow">
+            <p class="font-mono text-sm font-semibold text-violet-700 mb-2">siege-frontend</p>
+            <p class="text-slate-600 text-sm leading-relaxed">React 18 · Vite · TypeScript · Tailwind · shadcn/ui</p>
+          </div>
+          <div class="rounded-lg border border-slate-200 p-6 shadow-sm hover:shadow-md transition-shadow">
+            <p class="font-mono text-sm font-semibold text-violet-700 mb-2">siege-bot</p>
+            <p class="text-slate-600 text-sm leading-relaxed">discord.py client + FastAPI HTTP sidecar</p>
+          </div>
+        </div>
+        <!-- Azure backing services -->
+        <p class="text-center text-slate-500 text-sm mb-4">
+          PostgreSQL · Key Vault · Application Insights · Log Analytics
+        </p>
+        <div class="text-center">
+          <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener noreferrer"
+             class="inline-flex items-center gap-1.5 text-sm text-slate-600 hover:text-slate-900 transition-colors border border-slate-300 rounded-md px-4 py-2 hover:bg-slate-50">
+            View architecture on GitHub
+            <!-- Lucide ExternalLink SVG -->
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+              <polyline points="15 3 21 3 21 9"/>
+              <line x1="10" y1="14" x2="21" y2="3"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         SELF-HOST
+    ============================================================ -->
+    <section id="self-host" class="py-24 bg-slate-50">
+      <div class="max-w-6xl mx-auto px-6">
+        <h2 class="text-3xl font-bold text-slate-900 mb-4">Run it for your own clan</h2>
+        <p class="text-slate-600 max-w-2xl mb-12 leading-relaxed">
+          Siege Assignments is fully open source and deliberately cloud-agnostic. Three paths — pick the one that fits your setup.
+        </p>
+        <div class="grid lg:grid-cols-3 gap-6 mb-8">
+
+          <!-- Card 1: Try locally -->
+          <div class="rounded-xl border border-slate-200 bg-white p-6 hover:shadow-md transition-shadow flex flex-col">
+            <div class="text-3xl mb-3">👀</div>
+            <h3 class="font-semibold text-slate-900 mb-0.5">Try it locally</h3>
+            <p class="text-xs text-slate-400 mb-3 font-medium">~5 minutes</p>
+            <p class="text-slate-600 text-sm leading-relaxed mb-6 flex-1">
+              Docker Compose + auth disabled + seed data. Click around the UI with zero Discord setup.
+            </p>
+            <!-- TODO: link to docs/self-host/*.md once written -->
+            <a href="#"
+               class="inline-block text-center px-4 py-2 rounded-md border border-slate-300 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors">
+              Try it ↗
+            </a>
+          </div>
+
+          <!-- Card 2: Self-host (recommended) -->
+          <div class="rounded-xl border-2 border-violet-400 bg-white p-6 hover:shadow-md transition-shadow flex flex-col ring-2 ring-violet-100">
+            <div class="text-3xl mb-3">🏠</div>
+            <div class="flex items-center gap-2 mb-0.5">
+              <h3 class="font-semibold text-slate-900">Self-host anywhere</h3>
+              <span class="text-xs font-semibold px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">Recommended</span>
+            </div>
+            <p class="text-xs text-slate-400 mb-3 font-medium">~30 minutes</p>
+            <p class="text-slate-600 text-sm leading-relaxed mb-6 flex-1">
+              VPS or home server + Docker. Works on any box that runs containers. No cloud bill.
+            </p>
+            <!-- TODO: link to docs/self-host/*.md once written -->
+            <a href="#"
+               class="inline-block text-center px-4 py-2 rounded-md border border-violet-400 text-sm font-medium text-violet-700 hover:bg-violet-50 transition-colors">
+              Self-host guide ↗
+            </a>
+          </div>
+
+          <!-- Card 3: Azure -->
+          <div class="rounded-xl border border-slate-200 bg-white p-6 hover:shadow-md transition-shadow flex flex-col">
+            <div class="text-3xl mb-3">☁</div>
+            <h3 class="font-semibold text-slate-900 mb-0.5">Deploy to Azure</h3>
+            <p class="text-xs text-slate-400 mb-3 font-medium">~1–2 hours</p>
+            <p class="text-slate-600 text-sm leading-relaxed mb-6 flex-1">
+              Bicep templates, Container Apps, Key Vault, CI/CD. Managed hands-off infrastructure.
+            </p>
+            <!-- TODO: link to docs/self-host/*.md once written -->
+            <a href="#"
+               class="inline-block text-center px-4 py-2 rounded-md border border-slate-300 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors">
+              Azure guide ↗
+            </a>
+          </div>
+
+        </div>
+        <p class="text-center text-slate-500 text-sm">
+          All three use the same stack. Start small, graduate later if you ever want to.
+        </p>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         CONTACT + FOOTER
+    ============================================================ -->
+    <section id="contact" class="py-24 bg-white">
+      <div class="max-w-6xl mx-auto px-6">
+        <h2 class="text-3xl font-bold text-slate-900 mb-8">Contact</h2>
+        <div class="space-y-3 mb-8">
+          <p class="text-slate-700">
+            <span class="text-slate-400 font-medium w-20 inline-block">Discord</span>
+            higgsbp
+          </p>
+          <p class="text-slate-700">
+            <span class="text-slate-400 font-medium w-20 inline-block">GitHub</span>
+            <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener noreferrer"
+               class="text-violet-600 hover:underline">
+              github.com/cbeaulieu-gt/siege-web
+            </a>
+          </p>
+        </div>
+        <p class="text-sm text-amber-800 bg-amber-50 rounded-md px-4 py-3 mb-10 inline-block">
+          ⚠ The app itself isn't optimized for mobile. For the best experience, use a desktop browser.
+        </p>
+        <div class="border-t border-slate-200 pt-6">
+          <p class="text-sm text-slate-400">© 2026 higgsbp · Built as a portfolio project</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <script>
+    // Smooth-scroll for hero CTA
+    document.getElementById('hero-cta').addEventListener('click', function(e) {
+      e.preventDefault();
+      document.getElementById('self-host').scrollIntoView({ behavior: 'smooth' });
+    });
+
+    // Sticky nav shrink on scroll
+    window.addEventListener('scroll', function() {
+      var nav = document.getElementById('main-nav');
+      if (window.scrollY > 20) {
+        nav.classList.add('shadow-sm');
+      } else {
+        nav.classList.remove('shadow-sm');
+      }
+    });
+  </script>
+
+  <script>
+    // Slideshow
+    var track = document.getElementById('slideshow-track');
+    var dots = document.getElementById('slideshow-dots').querySelectorAll('button');
+    var totalSlides = 6;
+    var currentIndex = 0;
+
+    function goToSlide(index) {
+      currentIndex = (index + totalSlides) % totalSlides;
+      track.style.transform = 'translateX(-' + (currentIndex * 100) + '%)';
+      dots.forEach(function(d, i) {
+        d.style.backgroundColor = i === currentIndex ? '#7c3aed' : '#cbd5e1';
+      });
+    }
+
+    document.getElementById('slideshow-prev').onclick = function() { goToSlide(currentIndex - 1); };
+    document.getElementById('slideshow-next').onclick = function() { goToSlide(currentIndex + 1); };
+    dots.forEach(function(d, i) { d.onclick = function() { goToSlide(i); }; });
+
+    // Keyboard support: left/right arrows when slideshow is near viewport
+    window.addEventListener('keydown', function(e) {
+      var rect = track.closest('.relative').getBoundingClientRect();
+      var inView = rect.top < window.innerHeight && rect.bottom > 0;
+      if (!inView) return;
+      if (e.key === 'ArrowLeft') goToSlide(currentIndex - 1);
+      if (e.key === 'ArrowRight') goToSlide(currentIndex + 1);
+    });
+  </script>
+
+</body>
+</html>

--- a/docs/mockups/mockup-login.html
+++ b/docs/mockups/mockup-login.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign in — Siege Assignments</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui'] }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="font-sans antialiased bg-slate-50 min-h-screen flex flex-col">
+
+  <!-- ============================================================
+       MINIMAL TOP NAV (not sticky)
+  ============================================================ -->
+  <nav class="px-6 py-4">
+    <a href="/" class="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-800 transition-colors">
+      <!-- Lucide ArrowLeft SVG -->
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="19" y1="12" x2="5" y2="12"/>
+        <polyline points="12 19 5 12 12 5"/>
+      </svg>
+      Back
+    </a>
+  </nav>
+
+  <!-- ============================================================
+       CENTERED CARD
+  ============================================================ -->
+  <main class="flex-1 flex items-center justify-center px-4 py-12">
+    <div class="w-full max-w-sm bg-white rounded-lg border border-slate-200 shadow-sm p-8">
+
+      <!-- Logo -->
+      <div class="flex justify-center mb-4">
+        <!-- Lucide Shield SVG -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none"
+             stroke="#7c3aed" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        </svg>
+      </div>
+
+      <!-- Title -->
+      <h1 class="text-center text-xl font-semibold text-slate-900 mb-2">Siege Assignments</h1>
+
+      <!-- Caption -->
+      <p class="text-center text-sm text-slate-500 mb-6 leading-relaxed">
+        Sign in with Discord to manage your clan's siege assignments.
+      </p>
+
+      <!-- Error banner (shown active in mockup; in prod only renders when ?error=... is present) -->
+      <!-- In production this only renders when ?error=... is present -->
+      <div class="bg-red-50 border border-red-200 rounded-md px-4 py-3 mb-5">
+        <p class="text-sm text-red-700 leading-snug">
+          <!-- PROVISIONAL COPY — subject to redlines -->
+          This instance is private to Master's Of Magicka. Sign-in is limited to clan members.
+        </p>
+      </div>
+
+      <!-- Discord sign-in button -->
+      <!-- PROVISIONAL COPY — subject to redlines -->
+      <button
+        disabled
+        class="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-md text-white font-medium text-sm cursor-not-allowed opacity-80 transition-opacity"
+        style="background-color: #5865F2;"
+        title="Disabled in mockup">
+        <!-- Discord logo SVG (simplified) -->
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="white">
+          <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/>
+        </svg>
+        Sign in with Discord
+      </button>
+
+      <!-- Divider -->
+      <div class="relative flex items-center my-5">
+        <div class="flex-1 h-px bg-slate-200"></div>
+        <span class="mx-3 text-xs text-slate-400">or</span>
+        <div class="flex-1 h-px bg-slate-200"></div>
+      </div>
+
+      <!-- Self-host secondary link -->
+      <div class="text-center mb-5">
+        <a href="/#self-host"
+           class="text-sm text-slate-600 hover:text-slate-900 transition-colors">
+          Run Siege Assignments for your own clan ↗
+        </a>
+      </div>
+
+      <!-- Mobile warning (always visible in mockup; in prod: <768px only) -->
+      <div class="bg-amber-50 border border-amber-200 rounded-md px-4 py-3 mb-5">
+        <p class="text-xs text-amber-800 leading-snug">
+          ⚠ This app is built for desktop. On mobile you may see layout issues.
+        </p>
+      </div>
+
+      <!-- Privacy footer -->
+      <p class="text-xs text-slate-500 text-center leading-snug">
+        We only request your Discord username and avatar. Guild membership is verified privately through our bot.
+      </p>
+
+    </div>
+  </main>
+
+</body>
+</html>

--- a/docs/plans/public-launch-self-hostable-and-landing-page.md
+++ b/docs/plans/public-launch-self-hostable-and-landing-page.md
@@ -1,0 +1,241 @@
+# Public launch: self-hostable + landing page
+
+**Milestone:** `Public launch: self-hostable + landing page`
+**Status:** Planning — not yet filed as issues
+**Supersedes:** The previously-planned `UX Polish` milestone. The scope grew beyond polish once the three-audience framing landed, so the milestone is being renamed rather than UX-polish work being added onto an existing milestone. No other plan docs conflict with this one.
+
+---
+
+## Pre-flight findings (read these first)
+
+A quick sweep of the repo surfaced a few things worth calling out before the work starts:
+
+- **`frontend/src/pages/HomePage.tsx` is confirmed dead code.** It's only referenced by its own file — nothing in `App.tsx` imports it. The current `/` route is a `<Navigate to="/sieges" replace />` living *inside* the `RequireAuth` layout, which means an unauthenticated visitor to `/` is bounced to `/login`, not to a landing page. Issue 4 needs to move `/` *out* of `RequireAuth` so the public landing page can live at `/`, and the authenticated-user redirect to `/sieges` needs to be re-homed (easiest: do it inside the landing page component if `user` is present, or keep a separate authenticated-only redirect route).
+- **`.env.example` has `AUTH_DISABLED=true` commented out at the bottom with a scary warning.** It is not the "happy path" the README implies. It also has `SESSION_SECRET=changeme-...` sitting in the middle of the file with no indication that the backend won't start without it, and no grouping that distinguishes "required for any run" from "required only for real OAuth" from "Azure-only." Issue 1 fixes all three of these at once.
+- **There is no seed script anywhere in `backend/`.** A fresh clone + `docker-compose up` produces an empty database and a UI with nothing to click, which silently undermines the "clone it and see what it does" portfolio story. Issue 1 must introduce seed data.
+- **`docs/plans/` did not exist before this doc.** I created it as part of writing this.
+- **No existing competing plan.** `docs/IMPLEMENTATION_PLAN.md` covers the original app build (phases 0–9) and does not speak to public launch. `docs/STATUS.md` is a running status file, not a plan. Nothing needs to be superseded other than the `UX Polish` milestone rename.
+
+---
+
+## 1. Overview
+
+This initiative turns Siege Assignments from "higgsbp's clan's internal tool that happens to be open source" into a public-facing, credibly self-hostable project. The work has three halves that stay in sync: (a) make the local dev experience so smooth that a stranger who clones the repo is clicking around a populated demo UI inside five minutes, (b) write cloud-agnostic self-host docs so other clan leaders can realistically run it on a $5 VPS without touching Azure, and (c) ship a landing page at `/` that reframes the project as both a portfolio artifact and a tool other people can pick up.
+
+## 2. Goals
+
+- **Portfolio advertisement.** The deployed instance at `higgsbp`'s URL presents the project well enough to recruiters and other developers that it reads as a finished product, not a work-in-progress.
+- **Credible self-host story.** A Raid clan leader who finds the repo can stand up their own instance — on a VPS, a home server, or Azure — without asking a single question of the maintainer and without any cloud-specific lock-in.
+- **Clan member sign-in that still feels like home.** Existing Master's Of Magicka members sign in on the canonical instance with the same Discord OAuth flow they already know, and the landing page makes it obvious which button is theirs.
+- **Low-friction local evaluation.** Anyone — recruiter, clan leader, curious developer — can evaluate the tool in under five minutes with zero external account setup.
+
+## 3. Non-goals
+
+- **Mobile-optimizing the main application.** The board, post list, and member management screens remain desktop-first. The login page gets a mobile warning banner (Issue 5); that's the extent of mobile work in this milestone.
+- **Kubernetes / Helm / Nomad / ECS / Fly.io / Render deploy paths.** Only two host profiles are documented: generic Docker Compose (Issue 2) and Azure Container Apps (Issue 3). Other runtimes can be added later if demand appears.
+- **Multi-tenant hosting.** Each self-hosted instance is a single clan. No work toward tenant isolation, per-clan subdomains, or a hosted "sign up and get a clan" SaaS mode.
+- **i18n.** English-only.
+- **Landing page A/B testing, analytics, or email capture.** Ship a static marketing page, not a growth funnel.
+- **Rewriting the Discord OAuth flow.** Issue 5 is a polish pass on the login page, not a redesign of the auth mechanism.
+- **Blog, changelog, or docs site.** Markdown in `docs/` remains the only documentation surface.
+
+## 4. Work breakdown
+
+### Issue 1 — Local dev onboarding polish
+
+**Summary.** Make `git clone && cp .env.example .env && docker-compose up` produce a working, populated demo UI inside five minutes with zero Discord setup. This is the foundation for every other issue in the milestone — the landing page, the self-host docs, and the login polish all assume a dev can get to a running instance fast.
+
+**Acceptance criteria.**
+- [ ] `.env.example` has `AUTH_DISABLED=true` uncommented as the default for the dev profile, with a short inline comment explaining that this is the demo/dev mode and that real deployments must set it to `false` (or remove it).
+- [ ] `.env.example` is reorganized into three clearly-labeled tiers: (1) required for any run (DB URL, session secret, auth flag), (2) required only when running with real Discord OAuth (client ID/secret/redirect, bot token, guild ID, channels), (3) Azure/deploy-only (anything used by Bicep or the deploy workflow).
+- [ ] `SESSION_SECRET` has an inline comment stating that the backend refuses to start without it and giving a one-line command to generate a secure value.
+- [ ] A backend seed script exists (e.g. `backend/scripts/seed_demo.py`) that idempotently creates a demo clan's worth of members, one demo siege with members assigned to most building positions, and a handful of post priority examples. Running it twice does not create duplicates.
+- [ ] The seed script runs automatically on `docker-compose up` for the default dev profile — either via an entrypoint hook, a dedicated one-shot service in the compose file, or an `alembic upgrade head && python scripts/seed_demo.py` chain. Decide which during implementation.
+- [ ] Frontend shows a persistent "Demo mode — authentication disabled" banner (non-dismissible, small, top-of-viewport or in the nav) whenever the backend reports `AUTH_DISABLED=true`. Backend exposes this via an existing or new config endpoint.
+- [ ] README Quick Start section rewritten to reflect reality: clone, copy env, compose up, open browser, click around. No mention of Discord setup in Quick Start — that moves to the self-host docs.
+- [ ] A new dev following *only* the rewritten Quick Start on a clean machine reaches a populated UI in under 5 minutes. Owner validates this on a fresh VM or a teammate's machine before closing.
+
+**Dependencies.** None. Must land before Issues 2, 4, and 5 begin (Issue 3 can technically start in parallel since it's just docs consolidation, but sequencing it after 1 is cleaner).
+
+**Effort.** M. Seed script is the biggest chunk of real code; everything else is configuration and docs.
+
+**Risks / open questions.**
+- *Seed data realism.* How close should demo members mirror real clan data? Recommend: fully fictional names ("Demo Member 01"…"Demo Member 25") so there's no implication that real MoM members are being exposed in a public demo.
+- *Where does the seed script run in the compose flow?* Entrypoint hook vs. dedicated one-shot service. Pick during implementation; document the choice in the issue.
+- *Banner styling.* Needs to be visible without being obnoxious. A thin amber strip with text is probably enough — avoid a modal.
+
+---
+
+### Issue 2 — Cloud-agnostic self-host documentation (`docs/self-host/anywhere.md`)
+
+**Summary.** A single doc that takes a developer from "I have a $5 VPS and a domain" to "I have a working Siege Assignments instance my clan can sign in to" in under 60 minutes, without ever mentioning Azure.
+
+**Acceptance criteria.**
+- [ ] `docs/self-host/anywhere.md` exists and is linked from the root README's "Run it yourself" section and from the landing page's self-host card (Issue 4).
+- [ ] Doc covers: prerequisites (Docker + Docker Compose, a domain, a Discord app registered at discord.com/developers), Discord app registration walkthrough with callback URL guidance, `.env.production` variables (explicitly calling out what differs from `.env.example`), production compose overlay usage, Caddy sidecar for HTTPS termination with a minimal working `Caddyfile`, first-run steps (migrations, optionally running the seed script for testing then wiping it), and smoke-test checklist.
+- [ ] A production compose overlay exists — either `docker-compose.prod.yml` applied via `-f docker-compose.yml -f docker-compose.prod.yml`, or a standalone `docker-compose.production.yml`. Decide during implementation and document the choice. The overlay differs from dev in at least: no source bind-mounts, env loaded from `.env.production`, `ENVIRONMENT=prod`, `AUTH_DISABLED` unset/false, `restart: unless-stopped` on every service, and sane resource limits (`mem_limit` or deploy resource reservations).
+- [ ] Tunnel-tool alternative section documents the Cloudflare Tunnel path as the recommended alternative for someone who can't or won't open ports, including the exact `cloudflared` config needed to route to the backend on localhost and where to set the OAuth redirect URI. Tailscale Funnel and ngrok are mentioned in one paragraph each as additional options with links to their docs rather than full walkthroughs.
+- [ ] Troubleshooting section covers the three most likely failure modes: Discord OAuth redirect URI mismatch, Postgres volume permission issues, and backend failing to start because `SESSION_SECRET` is missing.
+- [ ] Doc explicitly states "no Azure account required" in the opening paragraph.
+- [ ] Owner (or a willing stand-in) walks through the doc on a fresh $5 VPS before the issue is closed. Timing it is optional but encouraged — the 60-minute claim only goes in the doc if the walkthrough actually hits it.
+
+**Dependencies.** Issue 1 (so the env var story is sane before it's documented).
+
+**Effort.** L. This is a full end-to-end production hosting guide, and the Caddy + Cloudflare Tunnel sections need to be actually tested, not just written from memory.
+
+**Risks / open questions.**
+- *Caddy vs. Traefik vs. "bring your own reverse proxy."* Recommend Caddy for the worked example because its config is shortest and automatic HTTPS is the default. Mention the others only in passing.
+- *Compose overlay shape.* `docker-compose.prod.yml` as an overlay is the more idiomatic Compose v2 pattern; a standalone file is easier to reason about for someone new to Compose. Slight preference for the overlay, but defer to whoever writes the issue.
+- *Does the bot need to be exposed publicly?* No — only the backend's `/api/auth/callback` needs to be reachable. Make this explicit in the doc so self-hosters don't over-expose.
+
+---
+
+### Issue 3 — Azure self-host documentation consolidation (`docs/self-host/azure.md`)
+
+**Summary.** Take the existing deploy workflow, Bicep modules, and Key Vault story and collapse them into one narrative doc at `docs/self-host/azure.md`, clearly framed as the "managed hands-off path" — one of several options, not the only option.
+
+**Acceptance criteria.**
+- [ ] `docs/self-host/azure.md` exists and is linked from the root README and the landing page's self-host card.
+- [ ] Doc is a single narrative a reader can follow top-to-bottom: prerequisites (Azure subscription, `az` CLI), one-time resource-group setup, `az deployment group create` invocation with the Bicep entry point, secret population in Key Vault, first deploy via the GitHub Actions workflow (or a manual alternative), DNS and custom domain setup, and smoke test.
+- [ ] Opening paragraph states explicitly: "This is the managed, hands-off path. If you don't want an Azure subscription, see [anywhere.md](./anywhere.md) instead."
+- [ ] Any existing deploy instructions scattered across `infra/` READMEs and `.github/workflows/` comments are either moved into this doc or replaced with a one-line pointer to this doc. Goal: one canonical Azure doc, not three.
+- [ ] All Azure-specific env vars are listed with their source (Key Vault secret name, Bicep output, manually set, etc.).
+- [ ] A fresh read-through by someone who hasn't touched the infra before reaches a successful first deploy without clicking into workflow YAML or Bicep to figure out missing steps.
+
+**Dependencies.** None. Can run fully in parallel with Issue 2.
+
+**Effort.** M. Almost entirely a documentation-consolidation exercise — the infra already exists and works.
+
+**Risks / open questions.**
+- *Should this doc assume the reader has already forked the repo and will use their own GitHub Actions, or should it document a manual `az` deploy path too?* Recommend: lead with the "fork + GitHub Actions" path (matches current reality) and include a short "manual deploy" appendix for readers who want to deploy from their laptop.
+
+---
+
+### Issue 4 — Public landing page at `/`
+
+**Summary.** Ship a public marketing page at `/` that sells the project to three audiences (recruiters, clan leaders, curious developers) and routes each one where they need to go. Delete the orphaned `HomePage.tsx`. Keep `/sieges` as the destination for authenticated users.
+
+**Acceptance criteria.**
+- [ ] The `/` route is moved *out* of the `RequireAuth` layout in `App.tsx` and renders a new `LandingPage` component. Authenticated users hitting `/` are redirected to `/sieges` — either via a guard inside the landing page component or via a sibling authenticated-only route. Pick one approach during implementation and document it.
+- [ ] `frontend/src/pages/HomePage.tsx` is deleted. (Confirmed dead: only self-referenced.)
+- [ ] Landing page has a top nav with a prominent "Sign in" button in the upper right that links to `/login`.
+- [ ] Hero section: portfolio framing headline, open-source tagline, and a "Set it up for your clan ↓" CTA that smooth-scrolls to the self-host section.
+- [ ] "What it does" section: 4–6 feature bullets (assignments, validation rules, auto-fill, Discord notifications, comparison view, image generation) plus at least one board screenshot. Screenshots live under `docs/assets/landing/` or `frontend/public/landing/` — pick one and stay consistent.
+- [ ] "Under the hood" section: brief three-service architecture blurb (FastAPI + React + Discord bot), with no marketing fluff — this is the section recruiters read.
+- [ ] "Run it for your own clan" section: three cards side-by-side (or stacked on narrow viewports) linking to (a) the README Quick Start for local dev, (b) `docs/self-host/anywhere.md`, (c) `docs/self-host/azure.md`. Each card has a one-line "best for …" subtitle.
+- [ ] "Contact" section: Discord `higgsbp` and a GitHub repo link.
+- [ ] SEO: page has a proper `<title>`, `<meta name="description">`, canonical link, and Open Graph (`og:title`, `og:description`, `og:image`) and Twitter card tags. An OG image lives in the repo and is referenced by absolute URL.
+- [ ] Landing page is indexable by search engines — verified by a Lighthouse SEO audit scoring ≥90 and a manual check that meta tags show up in the built HTML (not only after hydration).
+- [ ] The authenticated `/sieges` redirect behavior is unchanged from the user's perspective: a logged-in user visiting `/` lands on `/sieges`, exactly as today.
+- [ ] Login flow unaffected: clicking "Sign in" from the landing page goes to `/login`, which works as it does today.
+
+**Dependencies.** Depends on Issues 1, 2, and 3 — the landing page links to artifacts those issues produce (Quick Start section in README, the two self-host docs). It can begin drafting in parallel with 2 and 3 as long as it doesn't merge until those land.
+
+**Effort.** L. Not because any single piece is hard, but because the SEO decision, the screenshots, the OG image, and the route restructuring each have their own rabbit holes.
+
+**Risks / open questions.**
+- *SEO rendering approach.* Covered in section 6 — needs a decision before implementation starts.
+- *Screenshot freshness.* Screenshots in the landing page will drift from the real UI over time. Accept this for now; add a "refresh landing page screenshots" note to the project backlog for the next UX change that touches the board.
+- *Route guarding after the move.* Easy to accidentally break the authenticated `/` → `/sieges` redirect while pulling `/` out of `RequireAuth`. Cover with a component test or a manual checklist in the PR description.
+
+---
+
+### Issue 5 — Login page polish
+
+**Summary.** Polish the existing login page so (a) mobile visitors see a clear "use a desktop" warning and (b) the rejection / unauthorized state reframes "you're not in this clan" as "here's how to run your own instance" instead of dead-ending the visitor.
+
+**Acceptance criteria.**
+- [ ] A mobile warning banner appears at viewport widths < 768px on the login page, with copy explaining that Siege Assignments is desktop-first and the sign-in will work but the app is not mobile-optimized. Banner does not block the sign-in button.
+- [ ] The authorization-failure / rejection state (e.g. user is Discord-authenticated but not a member of the configured guild) shows copy that acknowledges this instance is for one specific clan *and* points the visitor at the landing page's self-host section with a clear call to action ("Run it for your own clan →").
+- [ ] The happy-path sign-in flow is byte-identical from the user's perspective — same Discord icon, same button copy, same layout, same redirect behavior. This issue is a polish pass, not a rewrite.
+- [ ] Existing login-related tests still pass. New test (unit or component) covers the mobile-viewport banner render condition.
+- [ ] Visual review by the owner before close.
+
+**Dependencies.** Depends on Issue 4 (the rejection-state copy links into a section of the landing page that doesn't exist yet), and logically on Issue 1 (the login page is easier to test end-to-end when local dev is smooth). Can be drafted in parallel with 4 but must not merge before 4.
+
+**Effort.** S. Small surface area — two pieces of new copy, one banner, one test.
+
+**Risks / open questions.**
+- *What exactly constitutes "rejection"?* The current auth flow — does it return a distinct error state for "authenticated but not in guild" vs. "OAuth cancelled"? Confirm during implementation; the copy may need to fork based on the error type.
+- *Banner reappearance on narrow desktop windows.* A 1024-wide browser with devtools open can be < 768. Accept — this is a signal not a lock.
+
+## 5. Sequencing
+
+```
+         Issue 1: Local dev onboarding polish
+                        │
+           ┌────────────┴────────────┐
+           ▼                         ▼
+   Issue 2: Anywhere docs    Issue 3: Azure docs
+           │                         │
+           └────────────┬────────────┘
+                        ▼
+           ┌────────────┴────────────┐
+           ▼                         ▼
+    Issue 4: Landing page     Issue 5: Login polish
+```
+
+- **Issue 1 is strictly first.** Everything else assumes a sane local dev experience. Don't start another issue until 1 is merged.
+- **Issues 2 and 3 run in parallel** after 1 lands. They touch different files and have no shared code.
+- **Issues 4 and 5 run in parallel** after 2 and 3 land. They both consume the self-host docs and both touch the frontend, but in non-overlapping files (landing page vs. login page). Coordinate on nav links and shared copy if needed.
+
+## 6. Technical decisions to make before Issue 4 starts
+
+These do not need to be resolved in this plan doc, but they must be resolved before the landing page issue begins implementation.
+
+### Decision 6.1 — SEO rendering approach
+
+**Context.** The app is a React Router SPA served by Vite + Nginx behind Azure Easy Auth. The landing page needs to be crawlable by Google, with correct `<title>`, meta description, and OG tags present in the initial HTML response (not only after hydration) for reliable indexing.
+
+**Options.**
+1. **`vite-plugin-react-ssg` (prerender plugin).** Build-time prerender for a specific list of routes. Uses `@unhead/react` hooks (`useSeoMeta`, `useHead`) inside the page components for per-page meta tags. Non-prerendered routes fall back to normal CSR automatically. Minimal configuration, no change to the dev server workflow, no impact on authenticated routes.
+2. **`vite-react-ssg` (full SSG framework).** More feature-complete — supports loaders, data fetching at build time, per-page head management. Bigger footprint: changes how routing is defined, may affect CSR routes, needs care around the `RequireAuth` boundary.
+3. **`react-helmet` / `react-helmet-async` (runtime meta tags only).** No build-time HTML generation. Google *does* execute JS during indexing, but runtime-only meta tags are noticeably less reliable than server-rendered ones, and Lighthouse SEO audits ding them. Works, but it's the weakest option for a page whose whole job is to get indexed.
+4. **Vite's built-in `transformIndexHtml` with a static HTML template for `/`.** Hand-write the landing page's HTML and meta tags into a custom `index.html` that's served for `/`, with the SPA's own `index.html` serving everything else. Zero new dependencies, but now there are two HTML entry points to maintain.
+
+**Recommendation.** **Option 1 — `vite-plugin-react-ssg`.** It's a drop-in prerender plugin that targets exactly this case (existing Vite + React Router SPAs that need a few static routes prerendered for SEO), the authenticated routes gracefully fall back to CSR without any code changes, and `@unhead/react`'s `useSeoMeta` hook is the cleanest per-page meta-tag API on offer. Options 2 is overkill, option 3 is the weakest for indexing, and option 4 introduces a second HTML entry point that will rot. Flag this recommendation for developer confirmation before Issue 4 starts — the landing page is the only prerendered route for now and the plugin's footprint should stay tiny.
+
+### Decision 6.2 — Where to home the `/` → `/sieges` redirect for authenticated users
+
+**Context.** Currently `/` is inside `RequireAuth` and `Navigate`s to `/sieges`. Pulling `/` out of `RequireAuth` to make it public means that redirect logic has to move somewhere.
+
+**Options.**
+1. **Guard inside the new `LandingPage` component.** On mount, if the auth context says the user is logged in, `Navigate` to `/sieges`. Downside: a brief flash of the landing page during auth hydration.
+2. **Two separate routes outside/inside `RequireAuth` with the same path.** React Router doesn't love this; order matters and it's error-prone.
+3. **A thin wrapper component `LandingOrSieges` at `/` that renders either the landing page or a redirect based on auth state.** Same as option 1 but factored out so the landing page itself stays pure. Slightly cleaner for testing.
+
+**Recommendation.** **Option 3 — a `LandingOrSieges` wrapper.** Keeps the landing page component pure (easy to test, easy for the prerender plugin to handle), puts the auth decision in one small place, and makes it obvious to the next reader what's happening.
+
+### Decision 6.3 — Where landing-page assets live
+
+**Context.** Screenshots and the OG image need to be served as static assets from the frontend bundle.
+
+**Options.**
+1. `frontend/public/landing/` — served from the root of the frontend at `/landing/…` paths. Simplest.
+2. `frontend/src/assets/landing/` — imported by components, hashed in the build. Good for components, wrong for OG images (OG consumers need a stable URL).
+3. `docs/assets/landing/` — checked in but not served. Won't work for OG images.
+
+**Recommendation.** **Option 1 — `frontend/public/landing/`.** OG consumers need stable absolute URLs, and `public/` gives you exactly that with no hashing.
+
+### Decision 6.4 — Production compose overlay file shape
+
+**Context.** Issue 2 needs a production compose definition that differs from dev.
+
+**Options.**
+1. **Overlay (`docker-compose.prod.yml` + `-f docker-compose.yml -f docker-compose.prod.yml`).** Idiomatic, small, composable. Harder for compose-first-timers to reason about.
+2. **Standalone (`docker-compose.production.yml`).** Self-contained, easier to read. Duplicates a lot of the base compose.
+
+**Recommendation.** **Option 1 — overlay.** Smaller maintenance burden over time. The self-host doc can show the exact `-f … -f …` command so readers don't have to know the Compose override mechanism by heart.
+
+## 7. Success criteria
+
+The milestone is done when all of the following are observable:
+
+- A cold-cache `git clone && cp .env.example .env && docker-compose up` on a fresh machine reaches a populated UI — with visible demo data — in under 5 minutes, with the dev-mode banner showing.
+- A developer with no prior context on this project can follow `docs/self-host/anywhere.md` top-to-bottom and end up with a working Siege Assignments instance on their own infrastructure in under 60 minutes, without opening the Azure docs once.
+- A developer with an Azure subscription can follow `docs/self-host/azure.md` top-to-bottom to a successful `az deployment group create` without needing to cross-reference the infra README, the GitHub Actions workflow YAML, or this plan doc.
+- The public landing page renders at `/` for unauthenticated visitors, redirects authenticated users to `/sieges`, and scores ≥90 on a Lighthouse SEO audit with correct `<title>`, meta description, and OG tags present in the initial HTML response.
+- The login page shows a mobile-warning banner at < 768px and, on the authorization-failure state, points rejected visitors at the landing page's self-host section instead of dead-ending them.
+- `frontend/src/pages/HomePage.tsx` is deleted from the repo.
+- The README Quick Start, when read cold by a stranger, requires zero follow-up questions to get to a running instance.
+- (Stretch, not required for milestone close) The landing page is indexed by Google for queries like "raid shadow legends siege tool" within 90 days of ship. Not a blocker — the milestone closes on indexability, not on actual rankings.


### PR DESCRIPTION
Commits the four untracked files that define the v1.0 landing-page and self-host spec:

- \`docs/plans/public-launch-self-hostable-and-landing-page.md\`
- \`docs/mockups/README.md\`
- \`docs/mockups/mockup-landing.html\`
- \`docs/mockups/mockup-login.html\`

Referenced by #163, #164, #165, #166, #167 as canonical spec — they were blocking anyone else from picking up v1.0 critical-path work because the files only existed on one local checkout. No content changes.

closes #177

---
_Prepared with Claude Code._