### PR TITLE
feat(observability): wire Application Insights SDK into backend and bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ BOT_SERVICE_TOKEN=changeme-use-a-long-random-string-in-production
 
 # Dev auth bypass — backend WILL NOT START if this is set outside development environment
 # AUTH_DISABLED=true
+
+# Azure Application Insights (optional; telemetry SDK is a no-op when unset)
+# APPLICATIONINSIGHTS_CONNECTION_STRING=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Copy `.env.example` to `.env`. Required:
 | `DISCORD_SIEGE_CHANNEL` | backend (channel to post images) |
 | `DISCORD_SIEGE_IMAGES_CHANNEL` | backend (channel to post image CDN links) |
 | `ENVIRONMENT` | all (controls debug/docs) |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | backend, bot (optional; telemetry no-op when unset) |
 
 ## Domain Reference
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,12 +28,12 @@ from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
 from app.telemetry import configure_telemetry
 
-configure_telemetry()
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
+
+configure_telemetry()
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,9 @@ from app.api.version import router as version_router
 from app.config import settings
 from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
+from app.telemetry import configure_telemetry
+
+configure_telemetry()
 
 logging.basicConfig(
     level=logging.INFO,

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -1,0 +1,45 @@
+"""
+Application Insights / OpenTelemetry initialisation for the backend.
+
+Call ``configure_telemetry()`` once at process start, before the ASGI app
+begins accepting requests.  If ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is
+not set the function is a no-op so local development is unaffected.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def configure_telemetry() -> None:
+    """Initialise Azure Monitor OpenTelemetry if the connection string is present.
+
+    The ``azure-monitor-opentelemetry`` distro reads
+    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment automatically
+    when ``configure_azure_monitor()`` is called without an explicit
+    ``connection_string`` argument.  We guard the call so that a missing env var
+    is a silent no-op rather than an import-time or startup error.
+    """
+    connection_string = os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
+    ).strip()
+    if not connection_string:
+        logger.debug(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled."
+        )
+        return
+
+    try:
+        from azure.monitor.opentelemetry import configure_azure_monitor
+
+        configure_azure_monitor(
+            logger_name="app",  # collect logs from the 'app' namespace and children
+        )
+        logger.info("Azure Monitor OpenTelemetry configured for backend.")
+    except (
+        Exception
+    ):  # pragma: no cover — unexpected SDK failure must not crash the app
+        logger.exception(
+            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
+        )

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -21,13 +21,9 @@ def configure_telemetry() -> None:
     ``connection_string`` argument.  We guard the call so that a missing env var
     is a silent no-op rather than an import-time or startup error.
     """
-    connection_string = os.environ.get(
-        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
-    ).strip()
+    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug(
-            "APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled."
-        )
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
         return
 
     try:
@@ -37,9 +33,11 @@ def configure_telemetry() -> None:
             logger_name="app",  # collect logs from the 'app' namespace and children
         )
         logger.info("Azure Monitor OpenTelemetry configured for backend.")
-    except (
-        Exception
-    ):  # pragma: no cover — unexpected SDK failure must not crash the app
+    # Catch-all: telemetry init failures must never crash the app.
+    # Azure SDK init can raise ValueError (bad connection string),
+    # ConnectionError (network), or ImportError (missing optional deps).
+    # A failure here is always logged at ERROR and then swallowed.
+    except Exception:  # pragma: no cover
         logger.exception(
             "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ httpx>=0.27
 playwright>=1.49
 PyJWT>=2.9
 cryptography>=43
+azure-monitor-opentelemetry>=1.6

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -29,11 +29,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -52,11 +48,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -75,11 +67,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -89,7 +77,8 @@ class TestConfigureTelemetryNoop:
 class TestConfigureTelemetryActive:
     """When env var is set, configure_azure_monitor() must be called."""
 
-    # A syntactically valid-format connection string (fake values; no real App Insights).
+    # Fake connection string — intentionally invalid; the SDK accepts any
+    # syntactically-valid string at configure time and only fails on export.
     _FAKE_CS = (
         "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
         "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
@@ -110,9 +99,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -132,7 +119,5 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise — the function catches and logs the exception.
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()  # no exception expected

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -1,0 +1,138 @@
+"""
+Tests for backend/app/telemetry.py.
+
+Verifies:
+- configure_telemetry() is a no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset
+- configure_telemetry() calls configure_azure_monitor() when the env var is set
+- An unexpected exception from configure_azure_monitor() is swallowed (no crash)
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestConfigureTelemetryNoop:
+    """When APPLICATIONINSIGHTS_CONNECTION_STRING is absent, nothing should happen."""
+
+    def test_noop_when_env_var_missing(self, monkeypatch):
+        """No exception and configure_azure_monitor is never imported or called."""
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+
+        # Reload the module so the function runs fresh without cached state.
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        # Patch the azure.monitor.opentelemetry namespace so an accidental import
+        # would be detectable — if it's called the mock records the call.
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+    def test_noop_when_env_var_empty_string(self, monkeypatch):
+        """An explicitly empty string also results in a no-op."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+    def test_noop_when_env_var_whitespace_only(self, monkeypatch):
+        """A whitespace-only string is treated the same as empty."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "   ")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+
+class TestConfigureTelemetryActive:
+    """When env var is set, configure_azure_monitor() must be called."""
+
+    # A syntactically valid-format connection string (fake values; no real App Insights).
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_calls_configure_azure_monitor_when_env_var_set(self, monkeypatch):
+        """configure_azure_monitor() is called exactly once with logger_name='app'."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_called_once_with(logger_name="app")
+
+    def test_sdk_exception_does_not_propagate(self, monkeypatch):
+        """If configure_azure_monitor raises, the exception is swallowed."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock(side_effect=RuntimeError("SDK exploded"))
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+
+        # Should not raise — the function catches and logs the exception.
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
+            telemetry_module.configure_telemetry()  # no exception expected

--- a/bot/app/main.py
+++ b/bot/app/main.py
@@ -10,6 +10,7 @@ from app.config import settings
 from app.discord_client import SiegeBot
 from app.http_api import app as http_app
 from app.http_api import set_bot
+from app.telemetry import configure_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -46,4 +47,5 @@ async def main() -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
+    configure_telemetry()
     asyncio.run(main())

--- a/bot/app/telemetry.py
+++ b/bot/app/telemetry.py
@@ -22,13 +22,9 @@ def configure_telemetry() -> None:
     ``connection_string`` argument.  We guard the call so that a missing env var
     is a silent no-op rather than an import-time or startup error.
     """
-    connection_string = os.environ.get(
-        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
-    ).strip()
+    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug(
-            "APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled."
-        )
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
         return
 
     try:
@@ -38,9 +34,11 @@ def configure_telemetry() -> None:
             logger_name="app",  # collect logs from the 'app' namespace and children
         )
         logger.info("Azure Monitor OpenTelemetry configured for bot.")
-    except (
-        Exception
-    ):  # pragma: no cover — unexpected SDK failure must not crash the app
+    # Catch-all: telemetry init failures must never crash the app.
+    # Azure SDK init can raise ValueError (bad connection string),
+    # ConnectionError (network), or ImportError (missing optional deps).
+    # A failure here is always logged at ERROR and then swallowed.
+    except Exception:  # pragma: no cover
         logger.exception(
             "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
         )

--- a/bot/app/telemetry.py
+++ b/bot/app/telemetry.py
@@ -1,0 +1,46 @@
+"""
+Application Insights / OpenTelemetry initialisation for the bot service.
+
+Call ``configure_telemetry()`` once at process start, before the asyncio
+TaskGroup spins up the Discord client and HTTP sidecar.  If
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the function is a no-op
+so local development is unaffected.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def configure_telemetry() -> None:
+    """Initialise Azure Monitor OpenTelemetry if the connection string is present.
+
+    The ``azure-monitor-opentelemetry`` distro reads
+    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment automatically
+    when ``configure_azure_monitor()`` is called without an explicit
+    ``connection_string`` argument.  We guard the call so that a missing env var
+    is a silent no-op rather than an import-time or startup error.
+    """
+    connection_string = os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
+    ).strip()
+    if not connection_string:
+        logger.debug(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled."
+        )
+        return
+
+    try:
+        from azure.monitor.opentelemetry import configure_azure_monitor
+
+        configure_azure_monitor(
+            logger_name="app",  # collect logs from the 'app' namespace and children
+        )
+        logger.info("Azure Monitor OpenTelemetry configured for bot.")
+    except (
+        Exception
+    ):  # pragma: no cover — unexpected SDK failure must not crash the app
+        logger.exception(
+            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
+        )

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -4,3 +4,4 @@ discord.py==2.4.0
 pydantic-settings==2.6.1
 httpx==0.27.2
 python-multipart==0.0.20
+azure-monitor-opentelemetry>=1.6

--- a/bot/tests/test_telemetry.py
+++ b/bot/tests/test_telemetry.py
@@ -1,0 +1,131 @@
+"""
+Tests for bot/app/telemetry.py.
+
+Verifies:
+- configure_telemetry() is a no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset
+- configure_telemetry() calls configure_azure_monitor() when the env var is set
+- An unexpected exception from configure_azure_monitor() is swallowed (no crash)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestConfigureTelemetryNoop:
+    """When APPLICATIONINSIGHTS_CONNECTION_STRING is absent, nothing should happen."""
+
+    def test_noop_when_env_var_missing(self, monkeypatch):
+        """No exception and configure_azure_monitor is never imported or called."""
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+
+        import importlib
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+    def test_noop_when_env_var_empty_string(self, monkeypatch):
+        """An explicitly empty string also results in a no-op."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
+
+        import importlib
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+    def test_noop_when_env_var_whitespace_only(self, monkeypatch):
+        """A whitespace-only string is treated the same as empty."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "   ")
+
+        import importlib
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_not_called()
+
+
+class TestConfigureTelemetryActive:
+    """When APPLICATIONINSIGHTS_CONNECTION_STRING is set, configure_azure_monitor() must be called."""
+
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_calls_configure_azure_monitor_when_env_var_set(self, monkeypatch):
+        """configure_azure_monitor() is called exactly once with logger_name='app'."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_configure.assert_called_once_with(logger_name="app")
+
+    def test_sdk_exception_does_not_propagate(self, monkeypatch):
+        """If configure_azure_monitor raises, the exception is swallowed."""
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock(side_effect=RuntimeError("SDK exploded"))
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+
+        # Should not raise.
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
+            telemetry_module.configure_telemetry()  # no exception expected

--- a/bot/tests/test_telemetry.py
+++ b/bot/tests/test_telemetry.py
@@ -9,8 +9,6 @@ Verifies:
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestConfigureTelemetryNoop:
     """When APPLICATIONINSIGHTS_CONNECTION_STRING is absent, nothing should happen."""
@@ -27,11 +25,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -49,11 +43,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -71,11 +61,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -85,6 +71,8 @@ class TestConfigureTelemetryNoop:
 class TestConfigureTelemetryActive:
     """When APPLICATIONINSIGHTS_CONNECTION_STRING is set, configure_azure_monitor() must be called."""
 
+    # Fake connection string — intentionally invalid; the SDK accepts any
+    # syntactically-valid string at configure time and only fails on export.
     _FAKE_CS = (
         "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
         "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
@@ -104,9 +92,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -125,7 +111,5 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise.
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()  # no exception expected


### PR DESCRIPTION
## Summary

- Adds `azure-monitor-opentelemetry>=1.6` to `backend/requirements.txt` and `bot/requirements.txt`
- Creates `backend/app/telemetry.py` and `bot/app/telemetry.py` with a `configure_telemetry()` function that calls `configure_azure_monitor(logger_name='app')` when `APPLICATIONINSIGHTS_CONNECTION_STRING` is set, and is a silent no-op when unset (local dev safe)
- Wires `configure_telemetry()` into `backend/app/main.py` (called at module load before ASGI startup) and `bot/app/main.py` (called in `__main__` before `asyncio.run()`)
- Adds 5 unit tests per service (10 total) covering: no-op on missing/empty/whitespace env var, call with correct args when set, SDK exception swallowed

## Test plan

- [ ] `pytest backend/tests/test_telemetry.py` — 5/5 pass (verified locally)
- [ ] `pytest bot/tests/test_telemetry.py` — 5/5 pass (verified locally)
- [ ] `black --check` clean on all changed files
- [ ] `ruff check` clean on all backend changed files
- [ ] Deploy to dev and confirm traces appear in App Insights within 5 minutes of a request

## Context7 lookups

Queried `/azure-samples/azure-monitor-opentelemetry-python` and `/microsoftdocs/azure-monitor-docs` — confirmed `configure_azure_monitor()` signature, that it reads `APPLICATIONINSIGHTS_CONNECTION_STRING` automatically from env, and that `logger_name` scopes stdlib log forwarding.

closes #171

---
_Prepared with Claude Code._