### PR TITLE
docs: correct auth description to Discord OAuth2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Monorepo with three independently containerized services:
 - **`frontend/`** — React 18 + TypeScript, Vite, React Router v6, React Query, Tailwind CSS, shadcn/ui
 - **`bot/`** — discord.py client + FastAPI HTTP sidecar (port 8001); backend calls the bot's HTTP API to send DMs / post images
 
-Data flow: Azure AD → Easy Auth → frontend (Nginx) → `/api/*` proxy → backend → PostgreSQL. Backend calls bot HTTP API for Discord notifications. Backend generates images via Playwright (headless HTML/CSS → PNG); the bot receives the finished PNG and posts it.
+Data flow: user hits frontend → unauthenticated users redirected to `/login` → `/api/auth/login` → Discord OAuth2 → `/api/auth/callback` → JWT session cookie → frontend calls `/api/*` with cookie → backend validates via `get_current_user` dependency → PostgreSQL. Backend calls bot HTTP API for Discord notifications. Backend generates images via Playwright (headless HTML/CSS → PNG); the bot receives the finished PNG and posts it. See `docs/superpowers/plans/discord-auth-plan.md` for the canonical auth spec.
 
  - Keep `docs/STATUS.md` with a high level summary of the state of the project and the anticipated next steps. Frequently update it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,13 @@ Monorepo with three independently containerized services:
 - **`frontend/`** — React 18 + TypeScript, Vite, React Router v6, React Query, Tailwind CSS, shadcn/ui
 - **`bot/`** — discord.py client + FastAPI HTTP sidecar (port 8001); backend calls the bot's HTTP API to send DMs / post images
 
-Data flow: user hits frontend → unauthenticated users redirected to `/login` → `/api/auth/login` → Discord OAuth2 → `/api/auth/callback` → JWT session cookie → frontend calls `/api/*` with cookie → backend validates via `get_current_user` dependency → PostgreSQL. Backend calls bot HTTP API for Discord notifications. Backend generates images via Playwright (headless HTML/CSS → PNG); the bot receives the finished PNG and posts it. See `docs/superpowers/plans/discord-auth-plan.md` for the canonical auth spec.
+Data flow:
+- Unauthenticated users hit `/login` → `/api/auth/login` → Discord OAuth2 → `/api/auth/callback` → JWT session cookie
+- Frontend calls `/api/*` with cookie → backend validates via `get_current_user` dependency → PostgreSQL
+- Backend calls bot HTTP API for Discord notifications
+- Backend generates images via Playwright (headless HTML/CSS → PNG); bot receives the PNG and posts it
+
+See `docs/superpowers/plans/discord-auth-plan.md` for the canonical auth spec.
 
  - Keep `docs/STATUS.md` with a high level summary of the state of the project and the anticipated next steps. Frequently update it.
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -9,7 +9,7 @@ All open questions from the initial planning session have been resolved. These d
 | Database | Azure Database for PostgreSQL (Flexible Server) |
 | Hosting | Azure Container Apps + Azure Container Registry (ACR) |
 | CI/CD | GitHub Actions → Docker build → push to ACR → deploy to Container Apps |
-| Authentication | Azure Easy Auth (Azure AD) — no custom auth code |
+| Authentication | Discord OAuth2 with JWT session cookies — guild membership is the authorization boundary (see `docs/superpowers/plans/discord-auth-plan.md`) |
 | Discord Bot | Full rewrite: discord.py + FastAPI HTTP sidecar, deployed as its own container |
 | Board API response shape | Nested hierarchy (buildings → groups → positions) |
 | Validation Rule 10 (RESERVE balance) | Warn on any slot that is empty, not disabled, and not marked RESERVE |
@@ -82,7 +82,7 @@ Phase 8 (Excel Import Script) ── can run any time after Phase 3; defer post-
    - Azure Container Apps environment
    - Azure Database for PostgreSQL Flexible Server (dev instance)
    - Azure Key Vault for secrets
-10. Configure Azure Easy Auth on the Container Apps environment (Azure AD)
+10. Configure Discord OAuth2 app credentials and JWT session cookie settings (see `docs/superpowers/plans/discord-auth-plan.md`)
 11. Write a minimal FastAPI app with `GET /health` that confirms DB connectivity
 12. Write a minimal React app that fetches and displays the health endpoint
 13. Validate the full local stack starts with one command (`docker compose up`)
@@ -485,8 +485,8 @@ Three containers, each deployed as a separate Azure Container App:
 
 | Container | Contents | Exposes |
 |---|---|---|
-| `siege-api` | FastAPI backend, Playwright (for image gen) | Port 8000 (internal + Easy Auth) |
-| `siege-frontend` | React SPA served by Nginx | Port 80 (public via Easy Auth) |
+| `siege-api` | FastAPI backend, Playwright (for image gen) | Port 8000 (internal) |
+| `siege-frontend` | React SPA served by Nginx | Port 80 (public) |
 | `siege-bot` | discord.py + FastAPI HTTP sidecar | Port 8001 (internal only) |
 
 The frontend container's Nginx config proxies `/api/*` to the `siege-api` container. The bot container is only reachable from `siege-api` — it is not exposed publicly.
@@ -504,7 +504,7 @@ The frontend container's Nginx config proxies `/api/*` to the `siege-api` contai
 | Image Generation | Playwright (headless Chromium) |
 | Hosting | Azure Container Apps |
 | Container Registry | Azure Container Registry (ACR) |
-| Authentication | Azure Easy Auth (Azure AD) |
+| Authentication | Discord OAuth2 with JWT session cookies |
 | Secrets | Azure Key Vault |
 | Monitoring | Azure Application Insights |
 | CI/CD | GitHub Actions |

--- a/docs/plans/public-launch-self-hostable-and-landing-page.md
+++ b/docs/plans/public-launch-self-hostable-and-landing-page.md
@@ -185,7 +185,7 @@ These do not need to be resolved in this plan doc, but they must be resolved bef
 
 ### Decision 6.1 — SEO rendering approach
 
-**Context.** The app is a React Router SPA served by Vite + Nginx behind Azure Easy Auth. The landing page needs to be crawlable by Google, with correct `<title>`, meta description, and OG tags present in the initial HTML response (not only after hydration) for reliable indexing.
+**Context.** The app is a React Router SPA served by Vite + Nginx with Discord OAuth2 authentication. The landing page needs to be crawlable by Google, with correct `<title>`, meta description, and OG tags present in the initial HTML response (not only after hydration) for reliable indexing.
 
 **Options.**
 1. **`vite-plugin-react-ssg` (prerender plugin).** Build-time prerender for a specific list of routes. Uses `@unhead/react` hooks (`useSeoMeta`, `useHead`) inside the page components for per-page meta tags. Non-prerendered routes fall back to normal CSR automatically. Minimal configuration, no change to the dev server workflow, no impact on authenticated routes.


### PR DESCRIPTION
## Summary

- Replace all "Azure Easy Auth (Azure AD)" references in `CLAUDE.md` and `docs/IMPLEMENTATION_PLAN.md` with the shipped Discord OAuth2 + JWT session cookie flow
- Update the data flow line in `CLAUDE.md` to describe the real auth path (`/api/auth/login` → Discord OAuth2 → `/api/auth/callback` → JWT cookie → `get_current_user`)
- Cross-reference `docs/superpowers/plans/discord-auth-plan.md` as the canonical auth spec in both files

closes #168

## Test plan

- [ ] `grep -r "Easy Auth\|Azure AD" CLAUDE.md docs/IMPLEMENTATION_PLAN.md` returns zero matches
- [ ] `grep "discord-auth-plan\.md" CLAUDE.md docs/IMPLEMENTATION_PLAN.md` returns at least one match in each file
- [ ] Cross-reference link to `docs/superpowers/plans/discord-auth-plan.md` resolves in rendered GitHub markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)