### PR TITLE
feat(auth): polish login page with mobile banner and self-host reframe

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,16 +3,42 @@ import { useSearchParams } from "react-router-dom";
 import apiClient from "../api/client";
 import { Shield } from "lucide-react";
 
+// Errors that map to a specific transient/technical message (not membership denial).
 const ERROR_MESSAGES: Record<string, string> = {
   service_unavailable:
     "Login is temporarily unavailable. Please try again in a moment.",
 };
-const DEFAULT_ERROR = "You are not authorized to access this app.";
+
+// Errors that indicate guild membership denial — trigger the soft-handoff reframe.
+const MEMBERSHIP_ERRORS = new Set(["unauthorized"]);
+
+// TODO: extract into a shared MobileBanner component when LandingPage grows one.
+function MobileBanner() {
+  const isMobile =
+    typeof window !== "undefined" && window.innerWidth < 768;
+  if (!isMobile) return null;
+  return (
+    <div
+      className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3"
+      data-testid="mobile-banner"
+    >
+      <p className="text-xs leading-snug text-amber-800">
+        ⚠ Desktop recommended — the board UI is built for larger screens
+      </p>
+    </div>
+  );
+}
 
 export default function LoginPage() {
   const [searchParams] = useSearchParams();
   const error = searchParams.get("error");
   const [isLoading, setIsLoading] = useState(false);
+
+  // Determine whether this error is a membership denial (soft-handoff) or a
+  // technical error (generic message). No error → happy path, no banner.
+  const isMembershipDenied = error !== null && MEMBERSHIP_ERRORS.has(error);
+  const isTechnicalError =
+    error !== null && !isMembershipDenied;
 
   const handleLogin = async () => {
     setIsLoading(true);
@@ -26,18 +52,34 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50">
-      <div className="w-full max-w-sm space-y-6 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+      <div className="w-full max-w-sm space-y-4 rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
+        {/* Logo + title */}
         <div className="flex flex-col items-center gap-2">
           <Shield className="h-8 w-8 text-violet-600" />
           <h1 className="text-xl font-semibold text-slate-900">
             Siege Assignments
           </h1>
         </div>
-        {error && (
-          <div className="rounded-md bg-red-50 p-3 text-center text-sm text-red-700">
-            {ERROR_MESSAGES[error] ?? DEFAULT_ERROR}
+
+        {/* Membership-denial reframe — soft handoff to self-host */}
+        {isMembershipDenied && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3">
+            <p className="text-sm leading-snug text-red-700">
+              This instance is private to Master&rsquo;s Of Magicka. Sign-in is
+              limited to clan members.
+            </p>
           </div>
         )}
+
+        {/* Technical / transient error */}
+        {isTechnicalError && (
+          <div className="rounded-md bg-red-50 p-3 text-center text-sm text-red-700">
+            {ERROR_MESSAGES[error!] ??
+              "You are not authorized to access this app."}
+          </div>
+        )}
+
+        {/* Sign-in button — happy path, byte-identical behaviour */}
         <div className="space-y-4">
           <button
             onClick={handleLogin}
@@ -47,6 +89,24 @@ export default function LoginPage() {
           >
             {isLoading ? "Signing in..." : "Sign in with Discord"}
           </button>
+
+          {/* Always-visible self-host link */}
+          <div className="text-center">
+            <a
+              href="/#self-host"
+              className="text-sm text-slate-600 transition-colors hover:text-slate-900"
+              data-testid="self-host-link"
+            >
+              {isMembershipDenied
+                ? "Run Siege Assignments for your own clan →"
+                : "Run Siege Assignments for your own clan ↗"}
+            </a>
+          </div>
+
+          {/* Mobile warning — only at <768px */}
+          <MobileBanner />
+
+          {/* Privacy footer — preserved exactly */}
           <p className="text-center text-xs text-slate-500">
             We only request access to your Discord username and avatar. Guild
             membership is verified privately using our bot.

--- a/frontend/src/test/pages/LoginPage.test.tsx
+++ b/frontend/src/test/pages/LoginPage.test.tsx
@@ -1,5 +1,13 @@
 import { screen, waitFor } from "@testing-library/react";
-import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  it,
+  expect,
+  vi,
+} from "vitest";
 import { server } from "../server";
 import { renderWithProviders } from "../utils";
 import LoginPage from "../../pages/LoginPage";
@@ -19,13 +27,14 @@ describe("LoginPage", () => {
     expect(screen.getByText(/username and avatar/i)).toBeInTheDocument();
   });
 
-  it("shows unauthorized error message", async () => {
+  it("shows membership-denial reframe for ?error=unauthorized", async () => {
     renderWithProviders(<LoginPage />, {
       initialEntries: ["/login?error=unauthorized"],
     });
     await waitFor(() => {
+      // unauthorized is now routed to the soft-handoff banner, not the generic error
       expect(
-        screen.getByText(/not authorized to access this app/i)
+        screen.getByText(/private to Master/i)
       ).toBeInTheDocument();
     });
   });
@@ -46,6 +55,71 @@ describe("LoginPage", () => {
     await waitFor(() => {
       expect(
         screen.getByText(/not authorized to access this app/i)
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mobile banner
+// ---------------------------------------------------------------------------
+
+describe("LoginPage — mobile banner", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the mobile warning banner when innerWidth < 768", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(375);
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Desktop recommended/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not render the mobile warning banner when innerWidth >= 768", async () => {
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1280);
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    // Give the component a chance to render; the banner must be absent.
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Desktop recommended/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection reframe
+// ---------------------------------------------------------------------------
+
+describe("LoginPage — rejection reframe", () => {
+  it("shows the private-instance message and self-host link on ?error=unauthorized", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=unauthorized"],
+    });
+    await waitFor(() => {
+      // Match on unambiguous fragment to avoid apostrophe/rsquo encoding differences
+      expect(
+        screen.getByText(/private to Master/i)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("link", {
+        name: /Run Siege Assignments for your own clan/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the always-visible self-host link on the happy path too", async () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", {
+          name: /Run Siege Assignments for your own clan/i,
+        })
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

- Add mobile warning banner (amber, `<768px` only) matching the landing page's inline amber style
- Reframe `?error=unauthorized` as a soft handoff: private-instance notice + self-host link instead of a generic denial message
- Always render a "Run Siege Assignments for your own clan" link below the sign-in button on all states
- Preserve the happy-path sign-in flow byte-identical (same button, same `/api/auth/login` call, same loading state)

## Test plan

- [ ] `LoginPage — mobile banner`: mock `window.innerWidth < 768` → banner renders; mock `>= 768` → banner absent
- [ ] `LoginPage — rejection reframe`: render with `?error=unauthorized` → private-instance copy present, self-host link present
- [ ] `LoginPage — always-visible self-host link`: happy path → self-host link present
- [ ] All 108 existing + new tests pass (`npm run test`)
- [ ] `npm run lint` → 0 errors (pre-existing warnings only)
- [ ] `npm run build` → clean build

closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)