### PR TITLE
docs: add community health files (LICENSE, CoC, CONTRIBUTING, SUPPORT, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report something that is broken or behaving unexpectedly
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Reproduction steps
+
+1. Go to '...'
+2. Click on '...'
+3. Observe '...'
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include any error messages or console output.
+
+## Environment
+
+- **Install type**: Docker Compose / native
+- **OS**: (e.g. Windows 11, Ubuntu 22.04)
+- **Browser** (if frontend): (e.g. Chrome 124, Firefox 125)
+- **Backend version / commit hash**: (run `git rev-parse --short HEAD`)
+
+## Logs / screenshots
+
+Paste relevant log output here, or attach a screenshot. If the backend is involved, include the container logs (`docker-compose logs backend`).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/cbeaulieu-gt/siege-web/issues/new?labels=question
+    about: For questions (not bugs), open an Issue with the Question label. GitHub Discussions is not currently enabled on this repository.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What are you trying to do? What is currently painful or missing?
+
+## Proposed solution
+
+A clear description of what you would like to happen.
+
+## Alternatives considered
+
+Any other approaches you thought of and why you ruled them out.
+
+## Additional context
+
+Screenshots, mockups, links to related issues, or anything else that helps explain the request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- <!-- What does this PR do? 1–3 bullets. -->
+
+## Linked issue
+
+fixes #
+
+## Test plan
+
+<!-- How did you verify this change? What did you run? -->
+
+- [ ] Tests pass locally (`pytest` / `npm run build`)
+- [ ] Linters pass (`black` + `ruff` / `npm run lint`)
+
+## Checklist
+
+- [ ] README updated if setup, build, or run instructions changed
+- [ ] New behavior has test coverage
+- [ ] CI is green

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at cbeaulieu-gt@users.noreply.github.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Siege Assignment Web App
+
+Outside contributions are welcome. This document covers how to set up a local environment, the project's branching and commit conventions, how to run tests and linters, and what to expect from the review process.
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+---
+
+## Setting up a local environment
+
+Follow the **Quick Start** and **Dev Mode** sections in [README.md](README.md). Those sections are the authoritative reference for getting a working local stack — this file does not duplicate them.
+
+---
+
+## Branching conventions
+
+- **Never commit directly to `main`.**
+- All work goes on a feature branch: `feat/<name>`, `fix/<name>`, `docs/<name>`, `ci/<name>`, etc.
+- Open a PR against `main` when the work is ready for review.
+- For large features that span multiple work streams, cut a primary feature branch off `main` and use sub-branches (e.g. `feature-ux`, `feature-ux-api`, `feature-ux-frontend`). Sub-branch PRs merge into the primary branch; the primary branch PR merges into `main`.
+
+---
+
+## Commit message style
+
+This repo uses a Conventional-Commits-adjacent style. Match the format in `git log --oneline`:
+
+```
+feat(scope): short imperative description
+fix(scope): short imperative description
+docs: short description
+ci: short description
+refactor(scope): short description
+```
+
+- **Type** is required: `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`.
+- **Scope** is optional but helpful for service-specific changes: `(auth)`, `(frontend)`, `(bot)`, etc.
+- Subject line is lowercase, no trailing period, 72 characters or fewer.
+- Body is optional; use it to explain *why*, not *what*.
+
+---
+
+## Running tests
+
+### Backend
+
+```bash
+cd backend
+pip install -r requirements-dev.txt
+pytest --ignore=tests/test_schema.py -v
+```
+
+`test_schema.py` requires a live database and is excluded from the standard run.
+
+### Frontend
+
+```bash
+cd frontend
+npm ci
+npm run build
+```
+
+There is currently no separate `npm test` command — the build serves as the integration check. Type errors and lint failures fail the build.
+
+### Bot
+
+```bash
+cd bot
+pip install -r requirements-dev.txt
+pytest
+```
+
+---
+
+## Running linters
+
+### Backend
+
+```bash
+cd backend
+black .
+ruff check .
+ruff check . --fix   # auto-fix where possible
+```
+
+### Frontend
+
+```bash
+cd frontend
+npx eslint src/
+npx prettier --write src/
+```
+
+Or use the npm script shorthand:
+
+```bash
+cd frontend
+npm run lint
+```
+
+---
+
+## Opening a pull request
+
+1. Fork or branch from `main` (pull the latest first).
+2. Make your changes on a feature branch.
+3. Ensure all tests pass and linters report no errors.
+4. Open a PR against `main`. The PR template will prompt for a summary, linked issue, and test plan — fill it in.
+5. CI runs automatically: black + ruff + pytest (backend) and eslint + build (frontend). A green CI run is required before merge.
+
+**What reviewers look for:**
+
+- Tests for any new behavior or bug fix. Modified code without tests will not be merged.
+- README updates if the change affects how the project is run, built, or configured.
+- Commit messages that follow the style above.
+- No unrelated changes bundled into the PR.
+
+---
+
+## Questions
+
+If you are unsure whether something is in scope, open an issue and ask before writing code. See [SUPPORT.md](SUPPORT.md) for where to ask questions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Christopher Beaulieu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -162,3 +162,11 @@ Copy `.env.deploy.example` to both files and fill in the values.
 ```bash
 python -c "import secrets; print(secrets.token_hex(32))"
 ```
+
+## License
+
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for the full text.
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before opening a PR.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+## Where to ask
+
+**Bugs and unexpected behavior** — open a [GitHub Issue](https://github.com/cbeaulieu-gt/siege-web/issues/new/choose) using the bug report template. Include reproduction steps, your environment, and any relevant logs.
+
+**Questions and how-to** — open a GitHub Issue with the `question` label. GitHub Discussions is not currently enabled on this repository; Issues are the right place for Q&A until it is.
+
+**In-game / clan coordination** — use your clan's Discord server directly. This tool is a planning aid; in-game questions belong in-game.
+
+---
+
+## Expected response time
+
+Best effort, evenings and weekends. This is a hobby project maintained by one person; please be patient. There is no SLA or guaranteed response window.
+
+---
+
+## What NOT to file as issues
+
+- **In-game bugs** — crashes, balance issues, or anything that belongs to Plarium. Those go through Plarium's support channels.
+- **General Raid Shadow Legends questions** — hero builds, farming routes, meta guides. This project is scoped to siege planning only.
+- **Feature requests unrelated to the siege-planning domain** — requests to track other game modes, guild war, etc. are out of scope.
+- **Duplicate issues** — search open and closed issues before filing. If yours is a duplicate, add a comment to the existing issue instead.


### PR DESCRIPTION
## Summary

Adds the standard open-source community health files. **LICENSE is launch-blocking for v1.0** — the README positions this as open-source and self-hostable, so we can't ship without one.

All decisions locked per #188:
- MIT license, copyright `Christopher Beaulieu`, year 2026
- Contributor Covenant v2.1, contact `cbeaulieu-gt@users.noreply.github.com`
- Fully open contribution posture

## Files added

- `LICENSE` — MIT, verbatim from choosealicense.com
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1, verbatim
- `CONTRIBUTING.md` — dev setup, test/lint commands per service, PR guidance
- `SUPPORT.md` — where to ask, expected response cadence
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues disabled
- `.github/pull_request_template.md`
- `README.md` — added License and Contributing sections

## Out of scope (deferred)

- `SECURITY.md`
- `.github/CODEOWNERS`
- `.github/FUNDING.yml`

Can be filed separately post-launch if wanted.

## Test plan

- [ ] CI passes (markdown/config-only changes, no code)
- [ ] README renders correctly with new sections
- [ ] Issue templates appear in the New Issue dropdown after merge
- [ ] PR template auto-populates on new PRs after merge
- [ ] Community Standards checklist at `Insights → Community Standards` hits 100% after merge (verify post-merge)

fixes #188

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*