### PR TITLE
fix(frontend): swap comparison page before/after order

### DIFF
--- a/backend/app/api/comparison.py
+++ b/backend/app/api/comparison.py
@@ -23,6 +23,7 @@ async def compare_with_most_recent(
     if other is None:
         raise HTTPException(status_code=404, detail="No completed siege found to compare against")
 
+    # siege_a = compare-to (old), siege_b = current (new)
     return await comparison_service.compare_sieges(db, other.id, siege_id)
 
 
@@ -39,4 +40,5 @@ async def compare_with_specific(
     if other_id not in found_ids:
         raise HTTPException(status_code=404, detail="Other siege not found")
 
-    return await comparison_service.compare_sieges(db, siege_id, other_id)
+    # siege_a = compare-to (old), siege_b = current (new)
+    return await comparison_service.compare_sieges(db, other_id, siege_id)

--- a/backend/app/api/comparison.py
+++ b/backend/app/api/comparison.py
@@ -23,7 +23,7 @@ async def compare_with_most_recent(
     if other is None:
         raise HTTPException(status_code=404, detail="No completed siege found to compare against")
 
-    return await comparison_service.compare_sieges(db, siege_id, other.id)
+    return await comparison_service.compare_sieges(db, other.id, siege_id)
 
 
 @router.get("/sieges/{siege_id}/compare/{other_id}", response_model=ComparisonResult)

--- a/backend/tests/test_comparison.py
+++ b/backend/tests/test_comparison.py
@@ -107,6 +107,10 @@ async def test_compare_with_specific_endpoint_200(client):
     assert data["siege_a_id"] == 1
     assert data["siege_b_id"] == 2
     assert len(data["members"]) == 1
+    # Verify parameter order: compare-to siege (other_id=2) is siege_a, current siege (siege_id=1) is siege_b
+    call_args = mock_compare.call_args
+    assert call_args.args[1] == 2, "other_id should be passed as siege_a (compare-to / old)"
+    assert call_args.args[2] == 1, "siege_id should be passed as siege_b (current / new)"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_comparison.py
+++ b/backend/tests/test_comparison.py
@@ -107,7 +107,8 @@ async def test_compare_with_specific_endpoint_200(client):
     assert data["siege_a_id"] == 1
     assert data["siege_b_id"] == 2
     assert len(data["members"]) == 1
-    # Verify parameter order: compare-to siege (other_id=2) is siege_a, current siege (siege_id=1) is siege_b
+    # Verify parameter order: compare-to siege (other_id=2) is siege_a,
+    # current siege (siege_id=1) is siege_b
     call_args = mock_compare.call_args
     assert call_args.args[1] == 2, "other_id should be passed as siege_a (compare-to / old)"
     assert call_args.args[2] == 1, "siege_id should be passed as siege_b (current / new)"

--- a/frontend/src/pages/ComparisonPage.tsx
+++ b/frontend/src/pages/ComparisonPage.tsx
@@ -88,7 +88,7 @@ export default function ComparisonPage() {
     queryKey: ["comparison", siegeId, compareToId],
     queryFn: () =>
       isSpecific && specificId != null
-        ? compareSiegesSpecific(siegeId, specificId)
+        ? compareSiegesSpecific(specificId, siegeId)
         : compareSieges(siegeId),
     enabled: true,
   });


### PR DESCRIPTION
## Summary

- Fixes the Comparison page showing "Old" and "New" positions reversed — the current siege was labeled as "Old Positions" and the compare-to siege as "New Positions"
- Swaps parameter order in both the frontend API call (specific comparison) and backend endpoint handler (default/most-recent comparison) so `siege_a` = compare-to (old) and `siege_b` = current (new)

Fixes #198

## Test plan

- [ ] Open a siege → Compare → select an older siege from dropdown → verify "Old Positions" shows the selected siege and "New Positions" shows the current siege
- [ ] Open a siege → Compare (default/most-recent) → verify same correct ordering
- [ ] Verify added/removed/unchanged member diffs make sense relative to the labels
- [ ] Backend comparison tests pass (10/10)
- [ ] Frontend builds cleanly with no type errors

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*