### PR TITLE
fix: clone siege uses PostPriorityConfig instead of copying source priority

### DIFF
--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -8,6 +8,7 @@ from app.models.building_group import BuildingGroup
 from app.models.enums import BuildingType, SiegeStatus
 from app.models.position import Position
 from app.models.post import Post
+from app.models.post_priority_config import PostPriorityConfig
 from app.models.siege import Siege
 from app.models.siege_member import SiegeMember
 from app.services import validation as validation_service
@@ -206,10 +207,19 @@ async def clone_siege(session: AsyncSession, siege_id: int) -> Siege:
         # 2c. Copy post if building type is post
         if src_building.building_type == BuildingType.post and src_building.post is not None:
             src_post = src_building.post
+            # Look up priority from config by post_number rather than copying the source
+            # priority verbatim — the source siege may predate PostPriorityConfig seeds and
+            # carry stale priority=0 values that would otherwise propagate to every clone.
+            ppc_result = await session.execute(
+                select(PostPriorityConfig).where(
+                    PostPriorityConfig.post_number == src_building.building_number
+                )
+            )
+            ppc = ppc_result.scalar_one_or_none()
             new_post = Post(
                 siege_id=new_siege.id,
                 building_id=new_building.id,
-                priority=src_post.priority,
+                priority=ppc.priority if ppc else 2,
                 description=src_post.description,
                 # active_conditions intentionally NOT copied — game assigns new conditions
             )

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -2,14 +2,15 @@
 
 import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
-from app.models.enums import SiegeStatus
+from app.models.enums import BuildingType, SiegeStatus
+from app.services import lifecycle as lifecycle_service
 
 
 def _make_siege(
@@ -141,3 +142,148 @@ async def test_clone_siege_returns_201(client):
     assert data["id"] == 99
     assert data["status"] == "planning"
     assert data["date"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. clone_siege uses PostPriorityConfig priority, not the source post priority
+#    Regression test for bug #194: cloning a siege whose posts have priority=0
+#    (predating PostPriorityConfig seeds) must not propagate that stale value.
+# ---------------------------------------------------------------------------
+
+
+def _make_post_ns(priority: int, description: str | None = None):
+    return SimpleNamespace(
+        priority=priority,
+        description=description,
+        active_conditions=[],
+    )
+
+
+def _make_post_priority_config_ns(post_number: int, priority: int):
+    return SimpleNamespace(post_number=post_number, priority=priority)
+
+
+def _make_src_position_ns(position_number=1, member_id=None, member=None, is_reserve=False):
+    return SimpleNamespace(
+        position_number=position_number,
+        member_id=member_id,
+        member=member,
+        is_reserve=is_reserve,
+        is_disabled=False,
+    )
+
+
+def _make_src_group_ns(group_number=1, slot_count=1, positions=None):
+    return SimpleNamespace(
+        group_number=group_number,
+        slot_count=slot_count,
+        positions=positions or [],
+    )
+
+
+def _make_src_building_ns(building_type, building_number, groups=None, post=None):
+    return SimpleNamespace(
+        building_type=building_type,
+        building_number=building_number,
+        level=1,
+        is_broken=False,
+        groups=groups or [],
+        post=post,
+    )
+
+
+@pytest.mark.asyncio
+async def test_clone_uses_post_priority_config_not_source_priority():
+    """Cloning a siege with stale priority=0 posts must use PostPriorityConfig.priority.
+
+    Regression for bug #194: clone_siege was copying src_post.priority verbatim.
+    Sieges created before PostPriorityConfig seeds had priority=0, so every clone
+    perpetuated the stale value. The fix queries PostPriorityConfig by post_number,
+    matching the behavior of create_siege.
+    """
+    # Source siege: one post building whose post carries the stale priority=0
+    stale_post = _make_post_ns(priority=0, description="Old post")
+    src_group = _make_src_group_ns(
+        group_number=1,
+        slot_count=1,
+        positions=[_make_src_position_ns(position_number=1)],
+    )
+    src_building = _make_src_building_ns(
+        building_type=BuildingType.post,
+        building_number=3,
+        groups=[src_group],
+        post=stale_post,
+    )
+    source_siege = SimpleNamespace(
+        id=1,
+        date=datetime.date(2025, 1, 1),
+        status=SiegeStatus.complete,
+        defense_scroll_count=5,
+        buildings=[src_building],
+        siege_members=[],
+    )
+
+    # PostPriorityConfig seed says post 3 has priority=4 (not 0)
+    ppc = _make_post_priority_config_ns(post_number=3, priority=4)
+
+    # The session mock drives clone_siege through its execute calls.
+    # clone_siege makes these execute calls in order:
+    #   call 0 — SELECT Siege (load source, with selectinload options)
+    #   call 1 — SELECT PostPriorityConfig WHERE post_number == 3
+    # All ORM constructors (Siege, Building, BuildingGroup, Position, Post) run for real;
+    # only session.flush is stubbed so we can inject .id values on the new objects.
+    added_objects: list = []
+    execute_call_count = 0
+    flush_call_count = 0
+
+    # IDs assigned during flush, in the order flush is called:
+    # flush 0 → new Siege gets id=99
+    # flush 1 → new Building gets id=10
+    # flush 2 → new BuildingGroup gets id=20
+    flush_id_map = {0: ("siege", 99), 1: ("building", 10), 2: ("group", 20)}
+    pending_objects: list = []  # tracks the most recently add()ed object per flush slot
+
+    async def fake_execute(stmt):
+        nonlocal execute_call_count
+        result = MagicMock()
+        if execute_call_count == 0:
+            result.scalar_one_or_none.return_value = source_siege
+        else:
+            # PostPriorityConfig lookup
+            result.scalar_one_or_none.return_value = ppc
+        execute_call_count += 1
+        return result
+
+    async def fake_flush():
+        nonlocal flush_call_count
+        if flush_call_count < len(flush_id_map):
+            # Assign the id to the last object that was session.add()-ed
+            if added_objects:
+                added_objects[-1].id = flush_id_map[flush_call_count][1]
+        flush_call_count += 1
+
+    session = AsyncMock()
+    session.execute = fake_execute
+    session.flush = fake_flush
+    session.commit = AsyncMock()
+    session.add = lambda obj: added_objects.append(obj)
+    session.refresh = AsyncMock()
+
+    await lifecycle_service.clone_siege(session, 1)
+
+    # Find all Post instances that were added to the session
+    from app.models.post import Post as PostModel
+
+    posts_added = [obj for obj in added_objects if isinstance(obj, PostModel)]
+
+    assert len(posts_added) == 1, f"Expected exactly 1 Post to be cloned, got {len(posts_added)}"
+
+    cloned_post = posts_added[0]
+
+    # Core assertion: priority must come from PostPriorityConfig (4), not the stale source (0)
+    assert cloned_post.priority == 4, (
+        f"Expected priority=4 from PostPriorityConfig, got priority={cloned_post.priority}. "
+        "Bug #194: clone_siege was copying src_post.priority (0) instead of querying config."
+    )
+    # Description is still copied from the source post, not from config
+    assert cloned_post.description == "Old post"

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -241,6 +241,7 @@ async def test_clone_uses_post_priority_config_not_source_priority():
     # flush 1 → new Building gets id=10
     # flush 2 → new BuildingGroup gets id=20
     flush_id_map = {0: ("siege", 99), 1: ("building", 10), 2: ("group", 20)}
+
     async def fake_execute(stmt):
         nonlocal execute_call_count
         result = MagicMock()

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -241,8 +241,6 @@ async def test_clone_uses_post_priority_config_not_source_priority():
     # flush 1 → new Building gets id=10
     # flush 2 → new BuildingGroup gets id=20
     flush_id_map = {0: ("siege", 99), 1: ("building", 10), 2: ("group", 20)}
-    pending_objects: list = []  # tracks the most recently add()ed object per flush slot
-
     async def fake_execute(stmt):
         nonlocal execute_call_count
         result = MagicMock()


### PR DESCRIPTION
@
## Summary
- Clone siege now queries PostPriorityConfig by post number instead of copying src_post.priority verbatim
- Prevents stale priority=0 values from propagating through every clone when the original siege predates the config seeds

## Root Cause
The original siege was created before PostPriorityConfig seeds existed, so all 18 posts had priority=0. clone_siege in lifecycle.py copied that value directly, perpetuating the bug across every subsequent siege. Meanwhile, create_siege already did the right thing — looking up PostPriorityConfig and falling back to priority 2.

## Changes
- **backend/app/services/lifecycle.py** — replaced priority=src_post.priority with a PostPriorityConfig lookup (matching create_siege behavior)
- **backend/tests/test_lifecycle.py** — added regression test test_clone_uses_post_priority_config_not_source_priority that verifies cloned posts get their priority from config, not the source

## Test Plan
- [x] Regression test verifies cloned post gets priority from config (4), not source (0)
- [x] Full backend test suite passes (274 tests)
- [ ] Manual: clone a siege and verify posts show correct priority in the UI

fixes #194

:robot: *Generated by Claude Code on behalf of @cbeaulieu-gt*
@