### PR TITLE
feat: widen landing page carousel viewport (#207)

### DIFF
--- a/frontend/src/components/Carousel.tsx
+++ b/frontend/src/components/Carousel.tsx
@@ -73,7 +73,7 @@ export default function Carousel({ slides }: CarouselProps) {
         ref={viewportRef}
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className="relative mx-auto max-w-2xl overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+        className="relative mx-auto max-w-5xl overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
         data-testid="carousel-viewport"
       >
         {/* Track */}
@@ -96,11 +96,11 @@ export default function Carousel({ slides }: CarouselProps) {
                 <img
                   src={slide.image}
                   alt={slide.title}
-                  className="h-[28rem] w-full object-cover"
+                  className="h-[36rem] w-full object-cover"
                   loading="lazy"
                 />
               ) : (
-                <div className="flex h-[28rem] items-center justify-center border-b-2 border-dashed border-slate-300 bg-slate-50">
+                <div className="flex h-[36rem] items-center justify-center border-b-2 border-dashed border-slate-300 bg-slate-50">
                   <span className="px-4 text-center text-sm font-semibold text-slate-400">
                     {slide.placeholder}
                   </span>

--- a/frontend/src/components/Carousel.tsx
+++ b/frontend/src/components/Carousel.tsx
@@ -73,7 +73,7 @@ export default function Carousel({ slides }: CarouselProps) {
         ref={viewportRef}
         tabIndex={0}
         onKeyDown={handleKeyDown}
-        className="relative mx-auto max-w-5xl overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+        className="relative mx-auto max-w-2xl overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 lg:max-w-5xl"
         data-testid="carousel-viewport"
       >
         {/* Track */}
@@ -96,11 +96,11 @@ export default function Carousel({ slides }: CarouselProps) {
                 <img
                   src={slide.image}
                   alt={slide.title}
-                  className="h-[36rem] w-full object-cover"
+                  className="h-[28rem] w-full object-cover lg:h-[36rem]"
                   loading="lazy"
                 />
               ) : (
-                <div className="flex h-[36rem] items-center justify-center border-b-2 border-dashed border-slate-300 bg-slate-50">
+                <div className="flex h-[28rem] items-center justify-center border-b-2 border-dashed border-slate-300 bg-slate-50 lg:h-[36rem]">
                   <span className="px-4 text-center text-sm font-semibold text-slate-400">
                     {slide.placeholder}
                   </span>


### PR DESCRIPTION
## Summary
- Widen carousel viewport from `max-w-2xl` (672px) to `max-w-5xl` (1024px) so it fills the `max-w-6xl` content section width more naturally
- Scale slide image height from `h-[28rem]` (448px) to `h-[36rem]` (576px) to match the wider viewport proportionally for the 16:10 screenshots

## Changes
- `frontend/src/components/Carousel.tsx` — three CSS class changes (viewport max-width, img height, placeholder div height)

## Test Plan
- [ ] Visual: carousel fills the landing page content column without awkward narrow band
- [ ] Screenshots are large enough to read without a lightbox
- [ ] Arrow buttons and dot pagination still render correctly (relative/absolute positioning is unaffected)

closes #207

> 🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*