### PR TITLE
Rename app to RSL Siege Manager

### DIFF
--- a/backend/app/services/image_gen.py
+++ b/backend/app/services/image_gen.py
@@ -224,7 +224,7 @@ def _build_assignments_html(
 </style>
 </head>
 <body>
-  <h1>Siege Assignments &mdash; {siege_date}</h1>
+  <h1>RSL Siege Manager &mdash; {siege_date}</h1>
   {sections_html}
 </body>
 </html>"""

--- a/backend/tests/test_image_gen.py
+++ b/backend/tests/test_image_gen.py
@@ -89,7 +89,7 @@ def test_build_assignments_html_contains_title():
     board = _make_board()
     html = _build_assignments_html(board, "2026-03-20")
     assert "2026-03-20" in html
-    assert "Siege Assignments" in html
+    assert "RSL Siege Manager" in html
 
 
 def test_build_assignments_html_contains_building_type():
@@ -124,7 +124,7 @@ def test_build_assignments_html_empty_board():
     board = _make_board()
     html = _build_assignments_html(board, "2026-03-20")
     assert len(html) > 0
-    assert "Siege Assignments" in html
+    assert "RSL Siege Manager" in html
 
 
 def test_build_assignments_html_all_building_types_colored():
@@ -204,7 +204,7 @@ async def test_generate_assignments_image_calls_render():
     mock_render.assert_awaited_once()
     # Verify the HTML passed to render contains expected content
     called_html = mock_render.call_args[0][0]
-    assert "Siege Assignments" in called_html
+    assert "RSL Siege Manager" in called_html
 
 
 @pytest.mark.asyncio

--- a/docs/mockups/mockup-landing.html
+++ b/docs/mockups/mockup-landing.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Siege Assignments — open-source Raid: Shadow Legends clan tool</title>
+  <title>RSL Siege Manager — open-source Raid: Shadow Legends clan tool</title>
   <meta name="description" content="A fully open-source web app for managing Raid: Shadow Legends siege assignments. Built for Master's Of Magicka. Deploy your own instance anywhere Docker runs." />
-  <meta property="og:title" content="Siege Assignments" />
+  <meta property="og:title" content="RSL Siege Manager" />
   <meta property="og:description" content="Open-source siege assignment tool for Raid: Shadow Legends clans. Self-host anywhere." />
   <meta property="og:type" content="website" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -45,7 +45,7 @@
              stroke="#7c3aed" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
         </svg>
-        <span class="font-semibold text-base tracking-tight">Siege Assignments</span>
+        <span class="font-semibold text-base tracking-tight">RSL Siege Manager</span>
       </a>
       <!-- Right: GitHub + Sign in -->
       <div class="flex items-center gap-3">
@@ -324,7 +324,7 @@
       <div class="max-w-6xl mx-auto px-6">
         <h2 class="text-3xl font-bold text-slate-900 mb-4">Run it for your own clan</h2>
         <p class="text-slate-600 max-w-2xl mb-12 leading-relaxed">
-          Siege Assignments is fully open source and deliberately cloud-agnostic. Three paths — pick the one that fits your setup.
+          RSL Siege Manager is fully open source and deliberately cloud-agnostic. Three paths — pick the one that fits your setup.
         </p>
         <div class="grid lg:grid-cols-3 gap-6 mb-8">
 

--- a/docs/mockups/mockup-login.html
+++ b/docs/mockups/mockup-login.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Sign in — Siege Assignments</title>
+  <title>Sign in — RSL Siege Manager</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -51,7 +51,7 @@
       </div>
 
       <!-- Title -->
-      <h1 class="text-center text-xl font-semibold text-slate-900 mb-2">Siege Assignments</h1>
+      <h1 class="text-center text-xl font-semibold text-slate-900 mb-2">RSL Siege Manager</h1>
 
       <!-- Caption -->
       <p class="text-center text-sm text-slate-500 mb-6 leading-relaxed">
@@ -92,7 +92,7 @@
       <div class="text-center mb-5">
         <a href="/#self-host"
            class="text-sm text-slate-600 hover:text-slate-900 transition-colors">
-          Run Siege Assignments for your own clan ↗
+          Run RSL Siege Manager for your own clan ↗
         </a>
       </div>
 

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -9,7 +9,7 @@ test.describe('Smoke', () => {
     await page.goto('/');
     await expect(page).toHaveURL('/sieges');
     // The main nav brand is always present
-    await expect(page.getByText('Siege Assignments')).toBeVisible();
+    await expect(page.getByText('RSL Siege Manager')).toBeVisible();
   });
 
   test('backend health endpoint returns healthy', async ({ request }) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,17 +6,17 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Siege Assignments — open-source Raid: Shadow Legends clan tool</title>
+    <title>RSL Siege Manager — open-source Raid: Shadow Legends clan tool</title>
     <meta name="description" content="A fully open-source web app for managing Raid: Shadow Legends siege assignments. Built for Master's Of Magicka. Deploy your own instance anywhere Docker runs." />
     <link rel="canonical" href="%VITE_PUBLIC_URL%" />
-    <meta property="og:title" content="Siege Assignments" />
+    <meta property="og:title" content="RSL Siege Manager" />
     <meta property="og:description" content="Open-source siege assignment tool for Raid: Shadow Legends clans. Self-host anywhere." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%VITE_PUBLIC_URL%" />
     <meta property="og:image" content="/landing/og-image.png" />
     <meta name="twitter:image" content="/landing/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Siege Assignments" />
+    <meta name="twitter:title" content="RSL Siege Manager" />
     <meta name="twitter:description" content="Open-source siege assignment tool for Raid: Shadow Legends clans. Self-host anywhere." />
   </head>
   <body>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -42,7 +42,7 @@ export default function Layout() {
           <div className="flex h-14 items-center gap-6">
             <div className="flex items-center gap-2 text-slate-900">
               <Shield className="h-5 w-5 text-violet-600" />
-              <span className="text-sm font-semibold">Siege Assignments</span>
+              <span className="text-sm font-semibold">RSL Siege Manager</span>
             </div>
             <div className="flex flex-1 items-center gap-1">
               <NavLink to="/sieges" className={navLinkClass}>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -184,7 +184,7 @@ export default function LandingPage() {
           >
             <ShieldIcon />
             <span className="text-base font-semibold tracking-tight">
-              Siege Assignments
+              RSL Siege Manager
             </span>
           </a>
 
@@ -366,7 +366,7 @@ export default function LandingPage() {
               Run it for your own clan
             </h2>
             <p className="mb-12 max-w-2xl leading-relaxed text-slate-600">
-              Siege Assignments is fully open source and deliberately
+              RSL Siege Manager is fully open source and deliberately
               cloud-agnostic. Three paths — pick the one that fits your setup.
             </p>
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -226,7 +226,7 @@ export default function LandingPage() {
           <div className="mx-auto max-w-4xl px-6 py-24 text-center">
             <p className="mb-5 text-xs font-semibold uppercase tracking-widest text-slate-500">
               A portfolio project by{" "}
-              <a href="https://www.linkedin.com/in/christopher-beaulieu/" target="_blank" rel="noopener noreferrer" className="text-violet-600 hover:underline">Christopher Beaulieu</a>
+              <a href="https://christopherbeaulieu.net" target="_blank" rel="noopener noreferrer" className="text-violet-600 hover:underline">Christopher Beaulieu</a>
             </p>
             <h1 className="mb-4 text-4xl font-bold leading-tight tracking-tight text-slate-900 sm:text-5xl">
               A siege assignment tool I built

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
         <div className="flex flex-col items-center gap-2">
           <Shield className="h-8 w-8 text-violet-600" />
           <h1 className="text-xl font-semibold text-slate-900">
-            Siege Assignments
+            RSL Siege Manager
           </h1>
         </div>
 
@@ -98,8 +98,8 @@ export default function LoginPage() {
               data-testid="self-host-link"
             >
               {isMembershipDenied
-                ? "Run Siege Assignments for your own clan →"
-                : "Run Siege Assignments for your own clan ↗"}
+                ? "Run RSL Siege Manager for your own clan →"
+                : "Run RSL Siege Manager for your own clan ↗"}
             </a>
           </div>
 

--- a/frontend/src/test/pages/LoginPage.test.tsx
+++ b/frontend/src/test/pages/LoginPage.test.tsx
@@ -108,7 +108,7 @@ describe("LoginPage — rejection reframe", () => {
     });
     expect(
       screen.getByRole("link", {
-        name: /Run Siege Assignments for your own clan/i,
+        name: /Run RSL Siege Manager for your own clan/i,
       })
     ).toBeInTheDocument();
   });
@@ -118,7 +118,7 @@ describe("LoginPage — rejection reframe", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("link", {
-          name: /Run Siege Assignments for your own clan/i,
+          name: /Run RSL Siege Manager for your own clan/i,
         })
       ).toBeInTheDocument();
     });

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Get a populated local instance of Siege Assignments running in under 5 minutes. No Discord account needed — the default dev profile runs in demo mode with pre-seeded data and authentication disabled.
+Get a populated local instance of RSL Siege Manager running in under 5 minutes. No Discord account needed — the default dev profile runs in demo mode with pre-seeded data and authentication disabled.
 
 ## What you need
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,4 +1,4 @@
-# Siege Assignments
+# RSL Siege Manager
 
 A web app for managing Raid Shadow Legends clan siege assignments. Replaces the Discord-plus-Excel workflow with a unified web UI backed by a relational database. Open source, self-hostable, and free.
 

--- a/wiki/Self-Host-on-Any-VPS.md
+++ b/wiki/Self-Host-on-Any-VPS.md
@@ -64,7 +64,7 @@ If you don't have a domain or can't open ports, skip ahead to [Section 6](#6-tun
 The app uses Discord OAuth2 for user login. Only the backend's `/api/auth/callback` endpoint needs to be publicly reachable — the frontend and bot do not need their own public URLs.
 
 1. Go to [discord.com/developers/applications](https://discord.com/developers/applications) and click **New Application**.
-2. Name it (e.g. "Siege Assignments") and click **Create**.
+2. Name it (e.g. "RSL Siege Manager") and click **Create**.
 3. Under **OAuth2 → General**, note the **Client ID** and click **Reset Secret** to generate a **Client Secret**. Copy both — these become `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` in your env file.
 4. Under **OAuth2 → Redirects**, click **Add Redirect** and enter your callback URL:
    ```

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -66,7 +66,7 @@ This is the managed, hands-off path. Azure handles TLS, scaling, secret rotation
 The app uses Discord OAuth2 for user login. You need a Discord application with a bot user.
 
 1. Go to [discord.com/developers/applications](https://discord.com/developers/applications) and click **New Application**.
-2. Give it a name (e.g. "Siege Assignments").
+2. Give it a name (e.g. "RSL Siege Manager").
 3. Under **OAuth2 → General**, note the **Client ID** and generate a **Client Secret**. Save both — they become `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` in Bicep and in GitHub Secrets.
 4. Under **OAuth2 → Redirects**, add your callback URL. For the prod deployment this will be:
    ```

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,4 @@
-**Siege Assignments**
+**RSL Siege Manager**
 
 - [Home](Home)
 - [Getting Started](Getting-Started)


### PR DESCRIPTION
## Summary
- Renames the application from "Siege Assignments" to "RSL Siege Manager" across all user-facing UI, backend image generation, tests, wiki, and mockups
- Improves clarity and SEO — the old name was too generic to convey the game/domain context

closes #214

## Test plan
- [ ] Nav bar shows "RSL Siege Manager" on all pages
- [ ] Login page heading reads "RSL Siege Manager"
- [ ] Browser tab title includes "RSL Siege Manager"
- [ ] Generated Discord PNG header shows "RSL Siege Manager"
- [ ] Landing page nav and self-host section use new name
- [ ] All backend and frontend tests pass

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*