### PR TITLE
Configurable CORS origins and custom domain support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ DISCORD_REQUIRED_ROLE=Clan Deputies
 # TIER 3 — Azure / deploy-only (not needed for local dev)
 # =============================================================================
 
+# Comma-separated CORS origins. Default: http://localhost:5173 (dev frontend).
+# Production: set to your custom domain, e.g. https://rslsiege.com
+ALLOWED_ORIGINS=http://localhost:5173
+
 # Public-facing canonical URL for this deployment.
 # Used in <link rel="canonical"> and og:url meta tags.
 # Set to your domain when self-hosting (e.g. https://siege.example.com/).

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ ALLOWED_ORIGINS=http://localhost:5173
 # Public-facing canonical URL for this deployment.
 # Used in <link rel="canonical"> and og:url meta tags.
 # Set to your domain when self-hosting (e.g. https://siege.example.com/).
-VITE_PUBLIC_URL=https://siege.higgsbp.com/
+VITE_PUBLIC_URL=https://yourdomain.example.com
 
 # Path used by the one-time Excel import CLI script
 IMPORT_EXCEL_PATH=C:/path/to/siege/excel/files

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Copy `.env.deploy.example` to both files and fill in the values.
 |---|---|
 | **1 — Always required** | `DATABASE_URL`, `ENVIRONMENT`, `AUTH_DISABLED`, `SESSION_SECRET` |
 | **2 — Discord / real auth** | OAuth2 credentials, bot token, guild ID, channel names, API keys, `DISCORD_REQUIRED_ROLE` |
-| **3 — Azure / deploy only** | `IMPORT_EXCEL_PATH` and anything used only by Bicep or CI |
+| **3 — Azure / deploy only** | `ALLOWED_ORIGINS`, `IMPORT_EXCEL_PATH` and anything used only by Bicep or CI |
 
 `AUTH_DISABLED=true` (the default in `.env.example`) bypasses login entirely — anyone who can reach the URL has full access. Never use this outside a local dev environment.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     # at OAuth callback with an insufficient_role error.
     discord_required_role: str = "Clan Deputies"
 
+    # Comma-separated list of origins allowed by CORS middleware.
+    # Default covers local dev frontend. In production set to your public domain,
+    # e.g. "https://rslsiege.com" or "https://rslsiege.com,https://www.rslsiege.com".
+    allowed_origins: str = "http://localhost:5173"
+
 
 settings = Settings()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,7 +70,7 @@ app = FastAPI(
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=[o.strip() for o in settings.allowed_origins.split(",") if o.strip()],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,8 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 
+logger = logging.getLogger(__name__)
+
 configure_telemetry()
 
 
@@ -68,9 +70,13 @@ app = FastAPI(
 )
 
 app.add_middleware(RequestLoggingMiddleware)
+
+_cors_origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
+logger.info("CORS allowed origins: %s", _cors_origins)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[o.strip() for o in settings.allowed_origins.split(",") if o.strip()],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -67,6 +67,18 @@ class TestSettingsDefaults:
         s = self._make_settings(discord_required_role="Admin")
         assert s.discord_required_role == "Admin"
 
+    def test_allowed_origins_defaults_to_localhost(self):
+        s = self._make_settings()
+        assert s.allowed_origins == "http://localhost:5173"
+
+    def test_allowed_origins_accepts_override(self):
+        s = self._make_settings(allowed_origins="https://rslsiege.com")
+        assert s.allowed_origins == "https://rslsiege.com"
+
+    def test_allowed_origins_accepts_comma_separated_values(self):
+        s = self._make_settings(allowed_origins="https://rslsiege.com,https://www.rslsiege.com")
+        assert s.allowed_origins == "https://rslsiege.com,https://www.rslsiege.com"
+
     def test_new_fields_accept_provided_values(self):
         s = self._make_settings(
             discord_client_id="cid",

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -14,7 +14,6 @@ that each test group exercises an independent CORS configuration without
 mutating the global ``app`` object (which is shared across tests).
 """
 
-import pytest
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,201 @@
+"""
+Integration tests for the CORS middleware wired in app/main.py.
+
+The middleware is configured with:
+
+    allow_origins=[o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
+
+These tests verify that the real CORSMiddleware (via FastAPI's TestClient /
+httpx ASGITransport) correctly allows or blocks origins based on what is
+parsed from the comma-separated ``allowed_origins`` setting.
+
+We monkeypatch ``settings.allowed_origins`` and then rebuild a minimal app so
+that each test group exercises an independent CORS configuration without
+mutating the global ``app`` object (which is shared across tests).
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(allowed_origins_str: str) -> FastAPI:
+    """Return a minimal FastAPI app whose CORS middleware mirrors main.py logic.
+
+    The middleware list in main.py uses:
+        [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
+
+    We replicate that parsing here so the tests exercise the same code path.
+    """
+    origins = [o.strip() for o in allowed_origins_str.split(",") if o.strip()]
+
+    test_app = FastAPI()
+    test_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @test_app.get("/api/health")
+    def health():
+        return {"status": "ok"}
+
+    return test_app
+
+
+def _cors_headers(client: TestClient, origin: str) -> dict:
+    """Send a simple GET with an Origin header and return the response headers."""
+    response = client.get("/api/health", headers={"Origin": origin})
+    assert response.status_code == 200
+    return dict(response.headers)
+
+
+# ---------------------------------------------------------------------------
+# Parsing: comma-separated origins
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedOriginsParsingIntegration:
+    """The middleware must honour each comma-separated origin independently."""
+
+    def test_single_origin_is_allowed(self):
+        client = TestClient(_make_app("https://example.com"))
+        headers = _cors_headers(client, "https://example.com")
+        assert headers.get("access-control-allow-origin") == "https://example.com"
+
+    def test_first_of_two_origins_is_allowed(self):
+        client = TestClient(_make_app("https://a.example.com,https://b.example.com"))
+        headers = _cors_headers(client, "https://a.example.com")
+        assert headers.get("access-control-allow-origin") == "https://a.example.com"
+
+    def test_second_of_two_origins_is_allowed(self):
+        client = TestClient(_make_app("https://a.example.com,https://b.example.com"))
+        headers = _cors_headers(client, "https://b.example.com")
+        assert headers.get("access-control-allow-origin") == "https://b.example.com"
+
+    def test_whitespace_around_origins_is_stripped(self):
+        """Spaces around commas must not break origin matching."""
+        client = TestClient(_make_app("https://a.example.com , https://b.example.com"))
+        headers = _cors_headers(client, "https://b.example.com")
+        assert headers.get("access-control-allow-origin") == "https://b.example.com"
+
+    def test_trailing_comma_is_ignored(self):
+        """A trailing comma must not produce an empty string in the origins list."""
+        client = TestClient(_make_app("https://example.com,"))
+        headers = _cors_headers(client, "https://example.com")
+        assert headers.get("access-control-allow-origin") == "https://example.com"
+
+    def test_leading_comma_is_ignored(self):
+        """A leading comma must not produce an empty string in the origins list."""
+        client = TestClient(_make_app(",https://example.com"))
+        headers = _cors_headers(client, "https://example.com")
+        assert headers.get("access-control-allow-origin") == "https://example.com"
+
+    def test_whitespace_only_entries_are_excluded(self):
+        """Entries that are only whitespace after stripping must be dropped."""
+        client = TestClient(_make_app("https://example.com,   ,https://other.example.com"))
+        headers = _cors_headers(client, "https://example.com")
+        assert headers.get("access-control-allow-origin") == "https://example.com"
+
+
+# ---------------------------------------------------------------------------
+# Allowed origin → CORS headers present
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedOriginReceivesCorsHeaders:
+    """A request from an explicitly allowed origin must get CORS response headers."""
+
+    def test_allowed_origin_receives_acao_header(self):
+        client = TestClient(_make_app("https://siege.example.com"))
+        headers = _cors_headers(client, "https://siege.example.com")
+        assert "access-control-allow-origin" in headers
+
+    def test_allowed_origin_acao_matches_request_origin(self):
+        """The echoed origin must match the request, not be a wildcard."""
+        client = TestClient(_make_app("https://siege.example.com"))
+        headers = _cors_headers(client, "https://siege.example.com")
+        assert headers["access-control-allow-origin"] == "https://siege.example.com"
+
+    def test_allowed_origin_receives_acac_header(self):
+        """allow_credentials=True means the vary/credentials header is set."""
+        client = TestClient(_make_app("https://siege.example.com"))
+        headers = _cors_headers(client, "https://siege.example.com")
+        assert headers.get("access-control-allow-credentials") == "true"
+
+    def test_localhost_dev_origin_allowed_by_default_config(self):
+        """The default value from Settings must allow the dev frontend."""
+        client = TestClient(_make_app("http://localhost:5173"))
+        headers = _cors_headers(client, "http://localhost:5173")
+        assert headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+
+# ---------------------------------------------------------------------------
+# Disallowed origin → no CORS headers
+# ---------------------------------------------------------------------------
+
+
+class TestDisallowedOriginReceivesNoCorsHeaders:
+    """A request from an origin not in the allow-list must NOT get CORS headers."""
+
+    def test_disallowed_origin_has_no_acao_header(self):
+        client = TestClient(_make_app("https://allowed.example.com"))
+        headers = _cors_headers(client, "https://evil.example.com")
+        assert "access-control-allow-origin" not in headers
+
+    def test_subdomain_not_allowed_when_only_apex_configured(self):
+        """Subdomains are not implicitly covered — must be listed explicitly."""
+        client = TestClient(_make_app("https://example.com"))
+        headers = _cors_headers(client, "https://sub.example.com")
+        assert "access-control-allow-origin" not in headers
+
+    def test_http_disallowed_when_only_https_configured(self):
+        """HTTP and HTTPS are distinct origins."""
+        client = TestClient(_make_app("https://example.com"))
+        headers = _cors_headers(client, "http://example.com")
+        assert "access-control-allow-origin" not in headers
+
+    def test_wrong_port_disallowed(self):
+        """The same host on a different port is a distinct origin."""
+        client = TestClient(_make_app("http://localhost:5173"))
+        headers = _cors_headers(client, "http://localhost:3000")
+        assert "access-control-allow-origin" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Preflight (OPTIONS) — smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightRequest:
+    """OPTIONS preflight with an allowed origin must return 200 with CORS headers."""
+
+    def test_preflight_allowed_origin_returns_200(self):
+        client = TestClient(_make_app("https://siege.example.com"))
+        response = client.options(
+            "/api/health",
+            headers={
+                "Origin": "https://siege.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "https://siege.example.com"
+
+    def test_preflight_disallowed_origin_has_no_acao(self):
+        client = TestClient(_make_app("https://siege.example.com"))
+        response = client.options(
+            "/api/health",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in dict(response.headers)

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -125,6 +125,9 @@ param apiMinReplicas int = 1
 @description('Minimum replicas for the frontend app (0 = scale to zero when idle)')
 param frontendMinReplicas int = 1
 
+@description('Public-facing URL for canonical/og tags (e.g. https://rslsiege.com). Leave empty for dev.')
+param publicUrl string = ''
+
 // ── Modules ──────────────────────────────────────────────────────────────────
 
 module logAnalytics 'modules/log-analytics.bicep' = {
@@ -232,6 +235,7 @@ module containerApps 'modules/container-apps.bicep' = {
     botMemory: botMemory
     apiMinReplicas: apiMinReplicas
     frontendMinReplicas: frontendMinReplicas
+    publicUrl: publicUrl
   }
 }
 

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -103,6 +103,10 @@ param frontendMemory = '0.5Gi'
 param botCpu = '0.25'
 param botMemory = '0.5Gi'
 
+// ── Custom domain ─────────────────────────────────────────────────────────────
+// Injected as VITE_PUBLIC_URL into the frontend container for canonical/og tags.
+param publicUrl = 'https://rslsiege.com'
+
 // ── Replica scaling ────────────────────────────────────────────────────────────
 // API stays warm in prod — Playwright cold starts on a scaled-to-zero replica
 // are too slow for an acceptable user experience.

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -39,6 +39,9 @@ param acrPassword string
 @description('Application Insights connection string for telemetry (pass empty string to disable)')
 param appInsightsConnectionString string = ''
 
+@description('Public-facing URL injected as VITE_PUBLIC_URL into the frontend container (e.g. https://rslsiege.com). Leave empty to omit the variable.')
+param publicUrl string = ''
+
 // ── CPU / memory sizing ───────────────────────────────────────────────────────
 // Container Apps allocates CPU and memory in fixed pairs:
 //   0.25 vCPU / 0.5 Gi  — fine for static content or very low traffic
@@ -240,6 +243,9 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
             ],
             empty(appInsightsConnectionString) ? [] : [
               { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+            ],
+            empty(publicUrl) ? [] : [
+              { name: 'VITE_PUBLIC_URL', value: publicUrl }
             ]
           )
         }

--- a/wiki/Self-Host-on-Any-VPS.md
+++ b/wiki/Self-Host-on-Any-VPS.md
@@ -169,9 +169,29 @@ BOT_SERVICE_TOKEN=<generated value>
 
 Both the backend and the bot read this value — make sure it is the same in both services (the single `.env.production` file loaded by both services via `env_file` ensures this when using the production compose overlay).
 
-### Tier 3 — Azure / deploy-only
+### Tier 3 — Custom domain / deploy-only
 
-Leave these blank or omit them. They are only used by the Azure deployment pipeline.
+These variables are optional for a basic deployment but required when you use a custom domain.
+
+**`ALLOWED_ORIGINS`** — Comma-separated list of origins the backend allows for CORS. Defaults to `http://localhost:5173` (local dev frontend). When self-hosting behind a reverse proxy or custom domain, set this to your public URL so the browser can make API calls:
+
+```
+ALLOWED_ORIGINS=https://siege.example.com
+```
+
+If you serve the app from multiple origins (e.g. with and without `www`), separate them with commas:
+
+```
+ALLOWED_ORIGINS=https://siege.example.com,https://www.siege.example.com
+```
+
+**`VITE_PUBLIC_URL`** — Canonical URL injected into the frontend for `<link rel="canonical">` and `og:url` meta tags. Set it to the same value as your public-facing URL:
+
+```
+VITE_PUBLIC_URL=https://siege.example.com
+```
+
+Leave both unset (or use the defaults) for a purely local deployment.
 
 ### Lock down the env file
 

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -337,6 +337,33 @@ Azure Container Apps provide a public FQDN automatically (e.g. `siege-web-fronte
 
 To use a custom domain (e.g. `siege.yourclan.com`):
 
+### Wire the custom domain into Bicep
+
+The `publicUrl` Bicep parameter sets `VITE_PUBLIC_URL` on the frontend container so canonical and og:url meta tags use your domain instead of the Container Apps FQDN. Set it in `infra/main.prod.bicepparam`:
+
+```bicep
+param publicUrl = 'https://siege.yourclan.com'
+```
+
+The backend's `ALLOWED_ORIGINS` env var controls which origins the CORS middleware accepts. By default it is set to the dev frontend URL — when using a custom domain you must add your domain. Pass it at deploy time (or add it to `main.prod.bicepparam` as a plain param if you are comfortable having it in source control, since it is not a secret):
+
+```powershell
+az deployment group create `
+    ... `
+    --parameters allowedOrigins="https://siege.yourclan.com"
+```
+
+Alternatively, update the `ALLOWED_ORIGINS` environment variable directly on the API Container App after deploy:
+
+```powershell
+az containerapp update `
+    --name siege-web-api-prod `
+    --resource-group siege-rg-prod `
+    --set-env-vars "ALLOWED_ORIGINS=https://siege.yourclan.com"
+```
+
+Then re-run the Bicep deploy with `--parameters publicUrl="https://siege.yourclan.com"` to record the value permanently.
+
 1. In the Azure portal, navigate to the Container App → **Custom domains** → **Add custom domain**.
 2. Follow the wizard: it shows the CNAME and TXT records you need to add at your DNS provider.
 3. Azure automatically provisions a managed TLS certificate (Let's Encrypt) once DNS propagates.

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -345,15 +345,7 @@ The `publicUrl` Bicep parameter sets `VITE_PUBLIC_URL` on the frontend container
 param publicUrl = 'https://siege.yourclan.com'
 ```
 
-The backend's `ALLOWED_ORIGINS` env var controls which origins the CORS middleware accepts. By default it is set to the dev frontend URL — when using a custom domain you must add your domain. Pass it at deploy time (or add it to `main.prod.bicepparam` as a plain param if you are comfortable having it in source control, since it is not a secret):
-
-```powershell
-az deployment group create `
-    ... `
-    --parameters allowedOrigins="https://siege.yourclan.com"
-```
-
-Alternatively, update the `ALLOWED_ORIGINS` environment variable directly on the API Container App after deploy:
+The backend's `ALLOWED_ORIGINS` env var controls which origins the CORS middleware accepts. By default it is set to the dev frontend URL — when using a custom domain you must update it on the backend Container App at runtime. This is not an infrastructure parameter; set it directly on the container after deploy:
 
 ```powershell
 az containerapp update `
@@ -362,7 +354,7 @@ az containerapp update `
     --set-env-vars "ALLOWED_ORIGINS=https://siege.yourclan.com"
 ```
 
-Then re-run the Bicep deploy with `--parameters publicUrl="https://siege.yourclan.com"` to record the value permanently.
+This takes effect immediately for new requests (Azure creates a new revision). No Bicep re-deploy is needed for this change.
 
 1. In the Azure portal, navigate to the Container App → **Custom domains** → **Add custom domain**.
 2. Follow the wizard: it shows the CNAME and TXT records you need to add at your DNS provider.


### PR DESCRIPTION
## Summary

- Replace hardcoded CORS origin (`localhost:5173`) with configurable `ALLOWED_ORIGINS` env var (comma-separated)
- Wire `VITE_PUBLIC_URL` through Bicep infrastructure to frontend container for canonical/og tags
- Add `publicUrl` Bicep parameter for production custom domain (`rslsiege.com`)
- Update all self-hosting docs with custom domain setup guidance

## Changes

| Layer | What |
|---|---|
| **Backend** | `ALLOWED_ORIGINS` setting in config + dynamic CORS in `main.py` |
| **Bicep** | `publicUrl` param → `VITE_PUBLIC_URL` on frontend container (conditional) |
| **Bicep prod params** | `publicUrl = 'https://rslsiege.com'` |
| **Docs** | `.env.example`, README, both wiki self-host guides |
| **Tests** | 3 new config tests (default, override, multi-origin) |

closes #218

## Test plan

- [ ] Backend: `pytest --ignore=tests/test_schema.py -v` passes (3 new CORS config tests)
- [ ] Verify CORS allows `localhost:5173` by default (dev)
- [ ] Verify CORS allows custom domain when `ALLOWED_ORIGINS` is set
- [ ] Verify Bicep deploys with `publicUrl` param
- [ ] Verify `VITE_PUBLIC_URL` only set on frontend when `publicUrl` is non-empty

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*