### PR TITLE
fix(infra): declare custom domain binding in Bicep

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -702,3 +702,89 @@ is still running the old revision or the new revision shows a failed status.
 4. Check for connection pool exhaustion (see Board loads slowly, Step 3 above).
    If the pool is exhausted, restarting the `siege-api` Container App (Section 1) will
    reset all connections as a temporary fix while you investigate the root cause.
+
+---
+
+## 8. Custom Domain and TLS Certificate
+
+The custom domain binding and managed TLS certificate are declared in Bicep and survive
+every infrastructure re-deployment. You should never need to manually re-bind the domain
+or re-provision the certificate under normal operations.
+
+### How it works
+
+`infra/modules/container-apps.bicep` uses a two-phase approach when `customDomainHostname`
+is set in the `.bicepparam` file:
+
+- **Phase 1** — registers the hostname on the frontend with `bindingType: 'Disabled'` so
+  Azure can verify DNS ownership.
+- **Phase 2** — provisions a `Microsoft.App/managedEnvironments/managedCertificates`
+  resource (CNAME validation) and rebinds the frontend with `bindingType: 'SniEnabled'`
+  and the certificate ID.
+
+Re-running the Bicep deployment with the same `customDomainHostname` value is idempotent —
+the binding and cert are preserved.
+
+### Certificate renewal
+
+Azure auto-renews managed certificates before expiry. No operator action is required.
+
+### Re-provisioning a failed certificate
+
+If the certificate enters a failed state (visible in the Azure portal under the Container
+Apps Environment → Certificates, or reported by `az containerapp env certificate list`):
+
+1. **Check DNS first** — the certificate is issued via CNAME validation. Confirm the CNAME
+   still resolves to the Container App FQDN:
+   ```bash
+   # Replace with your domain and expected FQDN
+   nslookup rslsiege.com
+   ```
+
+2. **Cloudflare users** — if the Cloudflare proxy (orange cloud) is enabled, disable it
+   temporarily (set to DNS-only / grey cloud) so Azure can validate the CNAME directly.
+   Re-enable after the cert is issued.
+
+3. **Delete the stale certificate and re-deploy** — remove the certificate resource from
+   the managed environment, then run the Bicep deployment again to re-provision it:
+   ```bash
+   # List certificates in the environment
+   az containerapp env certificate list \
+     --name {ENVIRONMENT_NAME} \
+     --resource-group {RESOURCE_GROUP} \
+     --output table
+
+   # Delete the stale certificate by name
+   az containerapp env certificate delete \
+     --name {ENVIRONMENT_NAME} \
+     --resource-group {RESOURCE_GROUP} \
+     --certificate {CERT_NAME} \
+     --yes
+   ```
+   Then trigger a Bicep re-deployment (via `infra-deploy.yml` or `az deployment group create`)
+   with `customDomainHostname` set — Azure will re-provision the cert and re-bind.
+
+### Checking the current binding state
+
+```bash
+az containerapp show \
+  --name {CONTAINER_APP_FRONTEND} \
+  --resource-group {RESOURCE_GROUP} \
+  --query "properties.configuration.ingress.customDomains" \
+  --output json
+```
+
+Expected output when fully bound:
+
+```json
+[
+  {
+    "bindingType": "SniEnabled",
+    "certificateId": "/subscriptions/.../managedCertificates/...",
+    "name": "rslsiege.com"
+  }
+]
+```
+
+If `bindingType` is `"Disabled"`, Phase 2 of the Bicep deployment did not complete — re-run
+the infrastructure deployment after confirming DNS is correct.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -128,6 +128,9 @@ param frontendMinReplicas int = 1
 @description('Public-facing URL for canonical/og tags (e.g. https://rslsiege.com). Leave empty for dev.')
 param publicUrl string = ''
 
+@description('Custom hostname to bind to the frontend (e.g. rslsiege.com). Leave empty to skip custom domain binding. DNS must point to the Container App FQDN via CNAME before deploying with this set.')
+param customDomainHostname string = ''
+
 // ── Modules ──────────────────────────────────────────────────────────────────
 
 module logAnalytics 'modules/log-analytics.bicep' = {
@@ -236,6 +239,8 @@ module containerApps 'modules/container-apps.bicep' = {
     apiMinReplicas: apiMinReplicas
     frontendMinReplicas: frontendMinReplicas
     publicUrl: publicUrl
+    containerAppsEnvironmentName: containerEnv.outputs.environmentName
+    customDomainHostname: customDomainHostname
   }
 }
 

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -107,6 +107,14 @@ param botMemory = '0.5Gi'
 // Injected as VITE_PUBLIC_URL into the frontend container for canonical/og tags.
 param publicUrl = 'https://rslsiege.com'
 
+// The bare hostname (no https://) Bicep binds the managed TLS certificate to.
+// Prerequisites before deploying with this set:
+//   1. Add a CNAME record at your DNS provider pointing rslsiege.com to the
+//      Container App's Azure FQDN (e.g. siege-web-frontend-prod.*.azurecontainerapps.io).
+//   2. Cloudflare users: set the CNAME to DNS-only (grey cloud) during first deploy
+//      so Azure can perform CNAME validation. Re-enable the proxy after the cert is issued.
+param customDomainHostname = 'rslsiege.com'
+
 // ── Replica scaling ────────────────────────────────────────────────────────────
 // API stays warm in prod — Playwright cold starts on a scaled-to-zero replica
 // are too slow for an acceptable user experience.

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -10,6 +10,12 @@ param appPrefix string
 @description('Container Apps Environment resource ID')
 param containerAppsEnvironmentId string
 
+@description('Container Apps Environment name — required for the managed certificate child resource')
+param containerAppsEnvironmentName string
+
+@description('Custom hostname to bind to the frontend (e.g. rslsiege.com). Leave empty to skip custom domain setup.')
+param customDomainHostname string = ''
+
 @description('Container registry login server (e.g. myregistry.azurecr.io)')
 param acrLoginServer string
 
@@ -81,6 +87,10 @@ param botMemory string = '0.5Gi'
 var apiAppName = '${appPrefix}-api-${environment}'
 var frontendAppName = '${appPrefix}-frontend-${environment}'
 var botAppName = '${appPrefix}-bot-${environment}'
+
+// Whether a custom domain has been specified. Used to conditionally create
+// the managed certificate and update the frontend ingress binding.
+var hasCustomDomain = !empty(customDomainHostname)
 
 // ── siege-api ────────────────────────────────────────────────────────────────
 
@@ -212,6 +222,31 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: true
         targetPort: 80
         transport: 'http'
+        // Step 1 of 2 for custom domain binding.
+        //
+        // Azure managed certificates have a bootstrapping circular dependency:
+        // the certificate resource needs the hostname pre-registered on the app
+        // to perform domain validation, but the app's ingress needs the cert ID
+        // to bind with SniEnabled. We break this cycle with a two-phase approach:
+        //
+        //   Phase 1 (this resource): register the hostname with bindingType
+        //   'Disabled' so DNS ownership is verified and the cert can be issued.
+        //
+        //   Phase 2 (frontendAppCertBinding below): after the managedCertificate
+        //   resource is provisioned, re-deploy the app with bindingType
+        //   'SniEnabled' and the cert resource ID.
+        //
+        // On a fresh environment this completes in one `az deployment group create`
+        // run. On subsequent runs the hostname is already registered so Phase 1 is
+        // a no-op, and Phase 2 refreshes the binding if the cert was rotated.
+        customDomains: hasCustomDomain
+          ? [
+              {
+                name: customDomainHostname
+                bindingType: 'Disabled'
+              }
+            ]
+          : []
       }
       registries: [
         {
@@ -256,6 +291,96 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
       }
     }
   }
+}
+
+// ── Custom domain: Phase 2 ────────────────────────────────────────────────────
+//
+// Phase 1 (frontendApp above) registered the hostname with bindingType 'Disabled'
+// so Azure could verify DNS ownership. Phase 2 provisions the managed TLS
+// certificate and re-binds the frontend with 'SniEnabled'.
+//
+// The two resources below are only created when hasCustomDomain is true.
+// On subsequent re-deployments both resources are idempotent: the cert is
+// already issued and the binding is already SniEnabled — ARM simply confirms
+// the desired state matches the live state and makes no changes.
+
+// Reference to the managed environment so we can attach a child certificate
+// resource to it. Using an `existing` reference avoids duplicating the
+// environment definition here and keeps the dependency graph correct.
+resource containerAppsEnv 'Microsoft.App/managedEnvironments@2024-03-01' existing = if (hasCustomDomain) {
+  name: containerAppsEnvironmentName
+}
+
+// Managed certificate issued by Azure (Let's Encrypt / DigiCert) for the
+// custom hostname. Azure performs CNAME validation: the hostname must already
+// resolve to the Container App's FQDN via a CNAME record before this resource
+// can be successfully created.
+//
+// NOTE for Cloudflare users: disable the proxy (grey cloud) on the CNAME record
+// during first deploy so Azure can reach your domain for CNAME validation. Once
+// the cert is issued and the binding is active you can re-enable the proxy.
+resource managedCert 'Microsoft.App/managedEnvironments/managedCertificates@2024-03-01' = if (hasCustomDomain) {
+  parent: containerAppsEnv
+  name: '${replace(customDomainHostname, '.', '-')}-cert'
+  location: location
+  properties: {
+    subjectName: customDomainHostname
+    domainControlValidation: 'CNAME'
+  }
+  dependsOn: [
+    frontendApp
+  ]
+}
+
+// Second deployment of the frontend Container App that upgrades the custom
+// domain binding from 'Disabled' (Phase 1) to 'SniEnabled' now that the
+// managed certificate has been issued.
+//
+// ARM Container App updates are full PUTs, not PATCHes — all required properties
+// must be included. This resource is an exact copy of frontendApp except for the
+// customDomains bindingType and certificateId. Bicep's symbolic reference to
+// frontendApp.properties.template copies the current template (containers,
+// scale rules, etc.) so we don't duplicate container config here.
+resource frontendAppCertBinding 'Microsoft.App/containerApps@2024-03-01' = if (hasCustomDomain) {
+  name: frontendAppName
+  location: location
+  tags: { project: appPrefix, environment: environment }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 80
+        transport: 'http'
+        customDomains: [
+          {
+            name: customDomainHostname
+            bindingType: 'SniEnabled'
+            certificateId: managedCert.id
+          }
+        ]
+      }
+      registries: [
+        {
+          server: acrLoginServer
+          username: acrUsername
+          passwordSecretRef: 'acr-password'
+        }
+      ]
+      secrets: [
+        {
+          name: 'acr-password'
+          value: acrPassword
+        }
+      ]
+    }
+    template: frontendApp.properties.template
+  }
+  // No explicit dependsOn needed: Bicep infers the dependency on managedCert
+  // through the certificateId reference above.
 }
 
 // ── siege-bot ─────────────────────────────────────────────────────────────────

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -321,7 +321,7 @@ resource containerAppsEnv 'Microsoft.App/managedEnvironments@2024-03-01' existin
 // the cert is issued and the binding is active you can re-enable the proxy.
 resource managedCert 'Microsoft.App/managedEnvironments/managedCertificates@2024-03-01' = if (hasCustomDomain) {
   parent: containerAppsEnv
-  name: '${replace(customDomainHostname, '.', '-')}-cert'
+  name: take('${replace(customDomainHostname, '.', '-')}-cert', 60)
   location: location
   properties: {
     subjectName: customDomainHostname
@@ -341,6 +341,10 @@ resource managedCert 'Microsoft.App/managedEnvironments/managedCertificates@2024
 // customDomains bindingType and certificateId. Bicep's symbolic reference to
 // frontendApp.properties.template copies the current template (containers,
 // scale rules, etc.) so we don't duplicate container config here.
+// MAINTENANCE WARNING: This resource duplicates the frontendApp configuration
+// to update the custom domain binding from Disabled to SniEnabled. If you change
+// the frontendApp ingress, registries, or secrets, you MUST mirror those changes
+// here or the binding deployment will revert them.
 resource frontendAppCertBinding 'Microsoft.App/containerApps@2024-03-01' = if (hasCustomDomain) {
   name: frontendAppName
   location: location

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -177,6 +177,10 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
               { name: 'DISCORD_CLIENT_SECRET', secretRef: 'discord-client-secret' }
               { name: 'DISCORD_REDIRECT_URI', value: discordRedirectUri }
               { name: 'BOT_SERVICE_TOKEN', secretRef: 'discord-bot-api-key' }
+              // When a custom domain is configured, allow CORS from that origin so
+              // the browser can reach /api/* from the custom domain frontend.
+              // Falls back to localhost:5173 for dev deployments without a custom domain.
+              { name: 'ALLOWED_ORIGINS', value: !empty(customDomainHostname) ? 'https://${customDomainHostname}' : 'http://localhost:5173' }
             ],
             // Only inject the Application Insights connection string when one
             // has been provided — keeps dev deployments lightweight.

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -383,6 +383,8 @@ param customDomainHostname = 'siege.yourclan.com'         // bare hostname — n
 
 Then run the infrastructure deploy (via the `infra-deploy.yml` workflow or `az deployment group create` directly). The managed certificate is provisioned and the binding is activated in one pass.
 
+Setting `customDomainHostname` also automatically configures the backend's `ALLOWED_ORIGINS` env var to `https://<your-domain>`, so CORS is handled without any manual steps.
+
 ### After the custom domain is active
 
 Update `discordRedirectUri` to use the new domain. This is a plain Bicep parameter (not a Key Vault secret), so update it in your `.bicepparam` file and redeploy:

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -385,25 +385,32 @@ Then run the infrastructure deploy (via the `infra-deploy.yml` workflow or `az d
 
 ### After the custom domain is active
 
-Update `discordRedirectUri` to use the new domain. First, update the Key Vault secret:
+Update `discordRedirectUri` to use the new domain. This is a plain Bicep parameter (not a Key Vault secret), so update it in your `.bicepparam` file and redeploy:
 
-```powershell
-az keyvault secret set `
-    --vault-name <your-vault-name> `
-    --name "discord-redirect-uri" `
-    --value "https://siege.yourclan.com/api/auth/callback"
-```
+1. In `infra/main.prod.bicepparam`, set the new value:
 
-> Get your vault name with: `az keyvault list --resource-group siege-rg-prod --query "[0].name" --output tsv`
+   ```bicep
+   param discordRedirectUri = 'https://siege.yourclan.com/api/auth/callback'
+   ```
 
-Then force a new revision of the API Container App to pick up the updated secret:
+2. Redeploy infrastructure (either via the `infra-deploy.yml` workflow or directly):
 
-```powershell
-az containerapp update `
-    --name siege-web-api-prod `
-    --resource-group siege-rg-prod `
-    --revision-suffix "redirect-update"
-```
+   ```powershell
+   az deployment group create `
+       --resource-group siege-rg-prod `
+       --template-file infra/main.bicep `
+       --parameters infra/main.prod.bicepparam
+   ```
+
+   Or pass it as a one-off override without editing the file:
+
+   ```powershell
+   az deployment group create `
+       --resource-group siege-rg-prod `
+       --template-file infra/main.bicep `
+       --parameters infra/main.prod.bicepparam `
+       --parameters discordRedirectUri="https://siege.yourclan.com/api/auth/callback"
+   ```
 
 Also update the redirect URI in the Discord Developer Portal (your app → OAuth2 → Redirects) to match.
 

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -335,46 +335,77 @@ Repeat for `dev`, substituting `siege-rg-dev`, `siegeacrdev`, `siegeacrdev.azure
 
 Azure Container Apps provide a public FQDN automatically (e.g. `siege-web-frontend-prod.wonderfulrock-12345678.westus.azurecontainerapps.io`). If that's acceptable, skip this section.
 
-To use a custom domain (e.g. `siege.yourclan.com`):
+Custom domain binding — including the managed TLS certificate — is declared in Bicep and survives every infrastructure re-deployment. You do not need to bind the domain or provision the certificate manually.
 
-### Wire the custom domain into Bicep
+### How the Bicep-managed binding works
 
-The `publicUrl` Bicep parameter sets `VITE_PUBLIC_URL` on the frontend container so canonical and og:url meta tags use your domain instead of the Container Apps FQDN. Set it in `infra/main.prod.bicepparam`:
+The `customDomainHostname` parameter (bare hostname, no `https://`) triggers a two-phase provisioning sequence inside `infra/modules/container-apps.bicep`:
 
-```bicep
-param publicUrl = 'https://siege.yourclan.com'
+1. **Phase 1** — registers the hostname on the frontend Container App with `bindingType: 'Disabled'`. This tells Azure which hostname to validate without yet serving TLS for it.
+2. **Phase 2** — provisions an `Azure-managed certificate` (`Microsoft.App/managedEnvironments/managedCertificates`) via CNAME validation, then rebinds the frontend with `bindingType: 'SniEnabled'` and the issued certificate ID.
+
+Both phases run in a single `az deployment group create` call. On subsequent re-deployments the hostname is already registered and the cert already issued, so both phases are no-ops — the binding is preserved automatically.
+
+### Prerequisites before enabling the custom domain parameter
+
+**Step 1 — get your Container App FQDN** (if you haven't already):
+
+```powershell
+az containerapp show `
+    --name siege-web-frontend-prod `
+    --resource-group siege-rg-prod `
+    --query "properties.configuration.ingress.fqdn" `
+    --output tsv
 ```
 
-The backend's `ALLOWED_ORIGINS` env var controls which origins the CORS middleware accepts. By default it is set to the dev frontend URL — when using a custom domain you must update it on the backend Container App at runtime. This is not an infrastructure parameter; set it directly on the container after deploy:
+**Step 2 — configure DNS at your registrar / DNS provider:**
+
+Add a CNAME record for your domain pointing to the Container App FQDN:
+
+| Type | Host | Value |
+|---|---|---|
+| `CNAME` | `siege.yourclan.com` (or `@` for an apex domain) | `siege-web-frontend-prod.wonderfulrock-12345678.westus.azurecontainerapps.io` |
+
+> **Apex domains:** most DNS providers do not support a bare CNAME on the apex (`@`). Use a CNAME-flattening provider (e.g. Cloudflare) or a subdomain instead.
+
+> **Cloudflare users:** set the CNAME record to **DNS-only (grey cloud)** during the first deploy. Azure performs CNAME validation to issue the certificate, and Cloudflare's proxy intercepts that validation. Once the certificate has been issued and the binding shows `SniEnabled`, you can re-enable the proxy (orange cloud).
+
+Allow 5–15 minutes for DNS to propagate before deploying.
+
+### Enable the parameter in Bicep
+
+Set both parameters in `infra/main.prod.bicepparam`:
+
+```bicep
+param publicUrl           = 'https://siege.yourclan.com'  // sets VITE_PUBLIC_URL (canonical/og tags)
+param customDomainHostname = 'siege.yourclan.com'         // bare hostname — no https://
+```
+
+Then run the infrastructure deploy (via the `infra-deploy.yml` workflow or `az deployment group create` directly). The managed certificate is provisioned and the binding is activated in one pass.
+
+### After the custom domain is active
+
+Update `discordRedirectUri` to use the new domain. First, update the Key Vault secret:
+
+```powershell
+az keyvault secret set `
+    --vault-name <your-vault-name> `
+    --name "discord-redirect-uri" `
+    --value "https://siege.yourclan.com/api/auth/callback"
+```
+
+> Get your vault name with: `az keyvault list --resource-group siege-rg-prod --query "[0].name" --output tsv`
+
+Then force a new revision of the API Container App to pick up the updated secret:
 
 ```powershell
 az containerapp update `
     --name siege-web-api-prod `
     --resource-group siege-rg-prod `
-    --set-env-vars "ALLOWED_ORIGINS=https://siege.yourclan.com"
+    --revision-suffix "redirect-update"
 ```
 
-This takes effect immediately for new requests (Azure creates a new revision). No Bicep re-deploy is needed for this change.
-
-1. In the Azure portal, navigate to the Container App → **Custom domains** → **Add custom domain**.
-2. Follow the wizard: it shows the CNAME and TXT records you need to add at your DNS provider.
-3. Azure automatically provisions a managed TLS certificate (Let's Encrypt) once DNS propagates.
-4. After the custom domain is active, update `discordRedirectUri` in Key Vault and in the Discord Developer Portal to use the new domain:
-   ```powershell
-   az keyvault secret set `
-       --vault-name <your-vault-name> `
-       --name "discord-redirect-uri" `
-       --value "https://siege.yourclan.com/api/auth/callback"
-   ```
-   Then force a new Container App revision to pick up the updated secret:
-   ```powershell
-   az containerapp update `
-       --name siege-web-api-prod `
-       --resource-group siege-rg-prod `
-       --revision-suffix "redirect-update"
-   ```
-
-> Get your vault name with: `az keyvault list --resource-group siege-rg-prod --query "[0].name" --output tsv`
+Also update the redirect URI in the Discord Developer Portal (your app → OAuth2 → Redirects) to match.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `customDomainHostname` Bicep parameter so the managed SSL certificate and custom domain binding survive infrastructure redeployments
- Uses a two-phase approach: Phase 1 registers hostname (`bindingType: Disabled`), Phase 2 provisions managed cert and binds with `SniEnabled`
- Sets `rslsiege.com` as the prod custom domain in `main.prod.bicepparam`
- Updates Self-Host-on-Azure wiki and RUNBOOK with custom domain lifecycle docs

Fixes #220

## Context

After a production redeploy on 2026-04-13, the custom domain binding and managed SSL certificate were removed because they weren't declared in Bicep — Azure treated them as drift and deleted them, causing a Cloudflare 525 SSL error.

## Test plan

- [ ] `az bicep build --file infra/main.bicep` passes (verified locally)
- [ ] Infra CI (Bicep Lint + Build + ARM Preflight) passes
- [ ] Dev what-if shows no unexpected changes (dev has no custom domain — should be a no-op)
- [ ] Prod deploy provisions managed cert and binds custom domain automatically
- [ ] Subsequent redeploy preserves the binding (no 525 regression)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*