### PR TITLE
fix(infra): mark Log Analytics primary key output as @secure()

### DIFF
--- a/infra/modules/log-analytics.bicep
+++ b/infra/modules/log-analytics.bicep
@@ -30,6 +30,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
 output workspaceId string = workspace.id
 output workspaceName string = workspace.name
 output customerId string = workspace.properties.customerId
+@secure()
 output primarySharedKey string = workspace.listKeys().primarySharedKey
 
 // Resource ID used to link Application Insights in workspace-based mode


### PR DESCRIPTION
## What changed

Added `@secure()` to the `primarySharedKey` output declaration in `infra/modules/log-analytics.bicep` (one line, no resource changes).

## Why

The Bicep linter was emitting this warning on every `infra-deploy` run:

```
infra/modules/log-analytics.bicep(33,34) : Warning outputs-should-not-contain-secrets:
Outputs should not contain secrets. Found possible secret: function 'listKeys'
```

The root cause: the output calls `workspace.listKeys().primarySharedKey` but was not annotated as sensitive, so Bicep (and ARM) treated the value like any other string output — meaning it was stored in plaintext in `Microsoft.Resources/deployments` history, readable by anyone with read access to the resource group's deployment history.

## How `@secure()` fixes it

`@secure()` is a **metadata-only decorator** — it does not change the deployed resource at all. What it does:

1. **Suppresses the linter warning** — Bicep recognises the output is intentionally sensitive.
2. **Instructs ARM to redact the value** — Azure Resource Manager omits the value from deployment history and portal output, so only principals with direct resource access (e.g. `Microsoft.OperationalInsights/workspaces/sharedKeys/action`) can read the key. Anyone who can only read deployment history cannot.

This is the approach recommended by the [Azure Verified Modules spec (SNFR26)](https://azure.github.io/Azure-Verified-Modules/specs/bcp/res/#id-snfr26---output-parameters---decorators) and the [official Bicep outputs docs](https://learn.microsoft.com/azure/azure-resource-manager/bicep/outputs#secure-outputs).

## Scope

- `infra/modules/log-analytics.bicep` — added `@secure()` to `output primarySharedKey`
- `infra/modules/container-env.bicep` — **no change needed**; `param logAnalyticsPrimaryKey` already had `@secure()` (line 14)
- `infra/main.bicep` — **no change needed**; wiring at line 213 is unchanged
- `infra/modules/registry.bicep` — **intentionally untouched** (out of scope; covered by #225)

## Verification

`az bicep build --file infra/main.bicep` output after this change:
- `outputs-should-not-contain-secrets` on `log-analytics.bicep` — **gone**
- Only remaining warnings are the two `use-resource-symbol-reference` entries in `registry.bicep` — out of scope for this PR

`what-if` behaviour: no resource modifications expected — `@secure()` is metadata only.

closes #224

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*