### PR TITLE
fix(infra): use ACR resource symbol for listCredentials() in registry.bicep

### DIFF
--- a/infra/modules/registry.bicep
+++ b/infra/modules/registry.bicep
@@ -40,7 +40,7 @@ output registryName string = registry.name
 output loginServer string = registry.properties.loginServer
 
 @secure()
-output acrUsername string = listCredentials(registry.id, '2023-07-01').username
+output acrUsername string = registry.listCredentials().username
 
 @secure()
-output acrPassword string = listCredentials(registry.id, '2023-07-01').passwords[0].value
+output acrPassword string = registry.listCredentials().passwords[0].value


### PR DESCRIPTION
## What

Replace the two `listCredentials(registry.id, '2023-07-01')` calls in `infra/modules/registry.bicep` with `registry.listCredentials()` — using the symbolic resource reference instead of a string-built resource ID.

**Before:**
```bicep
output acrUsername string = listCredentials(registry.id, '2023-07-01').username
output acrPassword string = listCredentials(registry.id, '2023-07-01').passwords[0].value
```

**After:**
```bicep
output acrUsername string = registry.listCredentials().username
output acrPassword string = registry.listCredentials().passwords[0].value
```

## Why

The standalone `listCredentials()` function accepts a resource ID as a plain string. Bicep cannot see through that string at compile time, so the dependency between the outputs and the ACR resource is invisible to the compiler. This triggers the `use-resource-symbol-reference` linter warning and also means the compiler cannot emit a tighter `dependsOn` in the compiled ARM template.

Using the symbolic form (`registry.listCredentials()`) makes the dependency explicit in Bicep's resource graph. The compiler can then:
- Silence the `use-resource-symbol-reference` warning (the documented fix pattern)
- Emit a correct `dependsOn` so ARM deploys the registry before attempting to read its credentials

The compiled ARM template produces the same runtime `listCredentials` REST call — this is a source-code-only refactor with no behavioral change at deploy time.

## Verification

- `az bicep build infra/main.bicep` — both `use-resource-symbol-reference` warnings on `registry.bicep:43,46` are gone. The unrelated `outputs-should-not-contain-secrets` warning in `log-analytics.bicep` remains (tracked in Issue #224).
- No new warnings introduced.
- The compiled ARM JSON confirms `listCredentials` is called against the same registry resource at runtime.

closes #225

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*