### PR TITLE
docs: document Key Vault Secrets Officer grant in origin cert runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Deployment uses a two-phase approach controlled by `enableCustomDomain` in
   created but no cert is bound.
 - **Phase 2** (`enableCustomDomain = true`): Upload the PFX to Key Vault, then redeploy.
   Azure imports the cert and binds it to the frontend Container App.
+  (Flip `enableCustomDomain` at line 132 and set `kvCertSecretUrl` at line 137 in
+  `infra/main.prod.bicepparam`.)
 
 See `scripts/generate-origin-pfx.ps1` to convert the Cloudflare-issued PEM files to PFX,
 and `docs/RUNBOOK.md` section 8 for the full step-by-step guide including cert rotation.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -808,7 +808,16 @@ Note the **versionless secret URL** -- it looks like:
 
 **Step 5 -- Update the param file and trigger Phase 2 deploy**
 
-Edit `infra/main.prod.bicepparam` and set:
+Edit [`infra/main.prod.bicepparam`](../infra/main.prod.bicepparam) (prod only — dev does not set
+this param and correctly inherits the `false` default from
+[`infra/main.bicep`](../infra/main.bicep)):
+
+- Around **line 132** (at time of writing): change `enableCustomDomain = false` → `true`.
+- Around **line 137** (at time of writing): set `kvCertSecretUrl` to the versionless URL from
+  Step 4 above.
+
+The file contains an inline comment block (around lines 113–130) that walks through the
+two-phase procedure in-situ — read it for additional context.
 
 ```bicep
 param enableCustomDomain = true

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -868,6 +868,42 @@ az keyvault secret set `
   --content-type application/x-pkcs12
 ```
 
+**Step 3.5 -- Grant yourself Key Vault Secrets Officer**
+
+The vault has `enableRbacAuthorization: true` (see `infra/modules/keyvault.bicep`). The
+Bicep deployment only grants `Key Vault Secrets User` (read-only) to runtime managed
+identities — write access is not assigned to operator accounts by the deployment pipeline.
+Without this step, Step 3's `az keyvault secret set` returns `(Forbidden)`.
+
+Role selection notes:
+
+- **Not** `Key Vault Secrets User` — that is read-only; it is what the Container App
+  managed identities receive at deploy time.
+- **Not** `Key Vault Certificates Officer` — that role covers Key Vault certificate
+  *objects* (`/certificates/*`). This runbook uploads the PFX as a **secret** with
+  `application/x-pkcs12` content type (see Step 3), which Container Apps' `keyVaultUrl`
+  binding consumes directly. The correct role for writing secrets is `Key Vault Secrets
+  Officer`.
+
+> **Placeholder convention**: `{RESOURCE_GROUP}` and `{KEY_VAULT_NAME}` are literal
+> placeholders — replace them with your actual values before running.
+
+```powershell
+$MyObjectId = az ad signed-in-user show --query id -o tsv
+$VaultName  = az keyvault list -g {RESOURCE_GROUP} --query "[0].name" -o tsv
+$VaultId    = az keyvault show --name $VaultName --query id -o tsv
+
+az role assignment create `
+  --role "Key Vault Secrets Officer" `
+  --assignee $MyObjectId `
+  --scope $VaultId
+```
+
+RBAC propagation through the Key Vault data plane is eventually consistent. Wait 30--60
+seconds before running Step 4. If Step 4 returns `(Forbidden)` shortly after this step,
+the role has almost certainly not propagated yet -- retry after another minute rather than
+re-running this step.
+
 **Step 4 -- Trigger Infra Deploy**
 
 Re-run the Infra Deploy workflow. Container Apps detects the new secret version and
@@ -875,6 +911,27 @@ rotates the certificate automatically within a few minutes. No `enableCustomDoma
 change is needed -- it should remain `true`.
 
 **Step 5 -- Verify** (repeat Step 7 above)
+
+**Step 6 -- (Optional) Revoke operator write access**
+
+Operator write access to Key Vault is only needed during cert rotations, which happen
+rarely. Following least-privilege hygiene, revoke the role assignment once the rotation
+is confirmed working -- especially on prod.
+
+```powershell
+$MyObjectId = az ad signed-in-user show --query id -o tsv
+$VaultName  = az keyvault list -g {RESOURCE_GROUP} --query "[0].name" -o tsv
+$VaultId    = az keyvault show --name $VaultName --query id -o tsv
+
+az role assignment delete `
+  --role "Key Vault Secrets Officer" `
+  --assignee $MyObjectId `
+  --scope $VaultId
+```
+
+This step is not a gate on completing the rotation -- the cert is already in Key Vault
+and the deploy has run. Revoke at your convenience, but do not skip it indefinitely on
+production.
 
 ---
 


### PR DESCRIPTION
## Problem

The Cloudflare origin cert rotation runbook (\"Certificate rotation\" chapter in \`docs/RUNBOOK.md\`) told operators to run \`az keyvault secret set\` in Step 3 without first granting them the RBAC role required to write secrets. Because the vault uses \`enableRbacAuthorization: true\` and the Bicep deployment only assigns \`Key Vault Secrets User\` (read-only) to runtime managed identities, the command fails with \`(Forbidden)\` until the operator grants themselves write access out-of-band.

Fixes #236.

## Changes

**\`docs/RUNBOOK.md\` and \`README.md\` only — no code or infrastructure touched.**

### Step 3.5 — Grant yourself Key Vault Secrets Officer (inserted between Steps 3 and 4)

- Opening rationale: explains why the vault's RBAC model means operators must self-assign write access before each rotation.
- Role selection callout: clarifies why \`Key Vault Secrets Officer\` is correct and why the two look-alike roles (\`Key Vault Secrets User\` = read-only runtime role; \`Key Vault Certificates Officer\` = wrong object type — this runbook stores the PFX as a secret, not a certificate object) are not.
- PowerShell command block: follows the \`az ad signed-in-user show\` / \`az keyvault list\` / \`az keyvault show --query id\` pattern from \`infra/README.md\` with backtick line continuation.
- Propagation note: instructs operators to wait 30–60 seconds and retry Step 4 before assuming the role assignment is missing.

### Step 6 — (Optional) Revoke operator write access (appended after Step 5)

- Least-privilege hygiene note: operator write access is needed only during rotations.
- \`az role assignment delete\` command reusing the same \`$VaultId\` / \`$MyObjectId\` pattern.
- Framed as optional (not a gate on rotation completion), with a note to prioritise revocation on prod.

### File/line callouts for Phase 2 param flip (Step 5 in RUNBOOK, two-phase section in README)

- RUNBOOK Step 5 now names \`infra/main.prod.bicepparam\` as a hyperlink and calls out lines 132 (\`enableCustomDomain\`) and 137 (\`kvCertSecretUrl\`) by approximate line number, with a note that the file contains an inline comment block (lines 113–130) walking through the two-phase procedure.
- Clarifies prod-only scope: dev does not set this param and inherits the \`false\` default from \`infra/main.bicep\`.
- README Phase 2 bullet adds a terse parenthetical pointing at the same lines in \`infra/main.prod.bicepparam\`.

## Numbering decision

Used option (1) — inserted as \"Step 3.5\" rather than renumbering the remaining steps. The rotation chapter had no prior precedent for mid-sequence renumbering, and avoiding a cascade of step-number changes reduces diff noise and keeps cross-references (e.g. \"repeat Step 7 above\") valid.

---

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*