### PR TITLE
feat(infra): enable custom domain Phase 2 for prod

### DIFF
--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -129,12 +129,12 @@ param customDomainHostname = 'rslsiege.com'
 // See docs/RUNBOOK.md "Custom Domain — Cloudflare Origin Cert Rotation" for
 // the full step-by-step guide.
 
-param enableCustomDomain = false
+param enableCustomDomain = true
 
 // Set to the versionless secret URL after uploading the PFX to Key Vault.
 // Versionless URL lets KV serve the latest version automatically on rotation.
 // Example: 'https://siege-web-kv-prod-abc123.vault.azure.net/secrets/cloudflare-origin-cert'
-param kvCertSecretUrl = ''
+param kvCertSecretUrl = 'https://siege-web-kv-prod-yf3fl2.vault.azure.net/secrets/cloudflare-origin-cert'
 
 // ── Replica scaling ────────────────────────────────────────────────────────────
 // API stays warm in prod — Playwright cold starts on a scaled-to-zero replica


### PR DESCRIPTION
## What this changes

Two lines in `infra/main.prod.bicepparam`:

| Parameter | Before | After |
|---|---|---|
| `enableCustomDomain` | `false` | `true` |
| `kvCertSecretUrl` | `''` | versionless Key Vault secret URL |

The Key Vault secret URL is **versionless** (no trailing `/<guid>`), which lets Container Apps automatically pick up future cert rotations without re-running this deploy.

## Why now

PR #235 fixed the OpenSSL PFX generation step, which unblocked the out-of-band Key Vault upload. The cert is now in the vault and ready. This PR is Phase 2 of the rollout described in issue #228.

## Merging does NOT deploy

The Infra Deploy workflow (`infra-deploy.yml`) is `workflow_dispatch`-only. Merging this PR updates the param file in source control but **does not actuate any Azure change**. The operator must manually dispatch the workflow after merging.

## Post-merge operator checklist

1. Dispatch the **Infra Deploy** workflow targeting `prod` from the Actions tab.
2. Wait for the workflow to complete successfully.
3. Verify the custom domain resolves and the TLS cert is valid.
4. In Cloudflare: set SSL/TLS mode to **Full (strict)** and turn the **proxy (orange cloud) ON**.
5. Close issue #228 once the domain is verified live.

## ⚠️ Do not auto-merge

This is a prod infra change. It deserves an intentional click — please review the diff and dispatch the workflow manually.

refs #228

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*