### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-04-17
+
+### Added
+
+**Siege lifecycle**
+- Full siege lifecycle: create → configure buildings → assign members → validate → activate → complete
+- Assignment board with per-position state (assigned / RESERVE / No Assignment / empty / disabled)
+- Siege clone: copy an existing siege as a starting point for the next one
+- Post management: create and manage siege posts with per-post condition tracking
+
+**Assignment logic**
+- Auto-fill algorithm using Fisher-Yates shuffle respecting `defense_scroll_count`; preview → apply flow (apply commits exactly what was previewed)
+- All 16 validation rules (9 errors, 7 warnings) wired into the activation gate
+- Attack day algorithm with pinned-member support and configurable 10-member Day 2 threshold
+- Assignment comparison view: per-member diffs (added / removed / unchanged) between any two sieges
+
+**Member management**
+- Full CRUD for clan members with `defense_scroll_count` tracking
+- Bulk assignment endpoints for efficient board population
+
+**Discord bot integration**
+- Direct-message notification batches with per-member delivery status tracked in the database
+- Channel image posts: assignments PNG and reserves PNG generated from headless HTML/CSS via Playwright
+- HTTP sidecar (port 8001) on the bot process; backend communicates exclusively through this API
+
+**Image generation**
+- Playwright headless HTML/CSS → PNG pipeline for assignments and reserves boards
+- Images posted to a dedicated Discord channel; CDN links stored for retrieval
+
+**Historical data**
+- Excel import: one-time CLI script (openpyxl) ingests historical `.xlsm` siege files as completed siege records
+
+**Frontend**
+- React 18 + TypeScript single-page app with React Router v6 and React Query
+- shadcn/ui component library with Tailwind CSS
+- Member CRUD, siege management, assignment board, auto-fill UI, validation panel
+- Comparison view (side-by-side diff between two sieges)
+- DM notification panel with real-time delivery status polling
+- Image preview and download from the assignment board
+
+### Security
+
+- Discord OAuth2 authentication flow: `/api/auth/login` → OAuth2 callback → JWT session cookie (HS256, 24-hour expiry)
+- Guild membership enforced via bot `get_member()` lookup — non-members redirected to `/login?error=unauthorized`
+- Role-based access gating: user must hold the Discord role named by `DISCORD_REQUIRED_ROLE` (default: `Clan Deputies`; exact, case-sensitive; configurable by self-hosters)
+- `get_current_user` FastAPI dependency applied globally; auth bypass allowlist for `/api/auth/*`, `/api/health`, and `/api/version`
+- `auth_disabled` flag available for local development without a Discord application
+- Frontend `AuthContext` + `RequireAuth` wrapper guards all protected routes; 401 interceptor redirects to `/login`
+
+### Infrastructure
+
+- Azure Bicep IaC: full module set for ACR, Log Analytics, App Insights, PostgreSQL Flexible Server, Key Vault, and Container Apps; separate dev and prod parameter files
+- Custom domain via Cloudflare Origin Cert: cert stored as PFX in Key Vault; user-assigned managed identity grants Container Apps environment `Key Vault Secrets User`; two-phase `enableCustomDomain` deploy gate prevents failure before cert upload
+- `deploy.yml` CD pipeline: push to `main` auto-deploys to dev; `v*` tag push deploys to prod; builds Docker images, pushes to ACR, updates Container App revisions
+- `infra-deploy.yml` manual pipeline: `workflow_dispatch`-only; runs `az deployment group create` for Bicep changes
+- `RUNBOOK.md`: restart procedures, rollback, DB restore, secret rotation, log queries, and incident playbooks
+
+### Developer Experience
+
+- `docker-compose` local stack: postgres → backend → frontend → bot in one command
+- 3500+ backend tests covering all routes, business logic, and constraint enforcement (pytest + asyncpg test DB)
+- Playwright end-to-end tests covering the full siege lifecycle; 22 flaky tests resolved
+- Vitest component tests for the assignment board (`BoardPage`) and notification polling (`SiegeSettingsPage`)
+- CI on every PR to `main`: black + ruff + pytest (backend); ESLint + build (frontend)
+
+[Unreleased]: https://github.com/cbeaulieu-gt/siege-web/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/cbeaulieu-gt/siege-web/releases/tag/v1.0.0

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,15 +2,15 @@
 
 ## Current State
 
-The application is feature-complete through Phase 9 (hardening and launch). All core
-backend logic (CRUD, assignment board, validation engine, auto-fill, attack day, comparison,
-Discord bot, image generation, notifications, and Excel import) is implemented and covered
-by 3500+ backend tests. Playwright end-to-end tests cover the full siege lifecycle.
-Vitest component tests cover the assignment board and notification polling. Azure Bicep IaC
-is authored for both dev and prod environments. The RUNBOOK.md documents all operational
-procedures. The remaining Phase 9 items (prod provisioning, GitHub Actions CD pipeline,
-planner sign-off, smoke tests, and 48-hour post-launch monitoring) are pre-launch steps
-that depend on the production environment being stood up.
+v1.0.0 shipped. The application is feature-complete and live at `rslsiege.com` (custom domain
+via Cloudflare Origin Cert). All core backend logic (CRUD, assignment board, validation engine,
+auto-fill, attack day, comparison, Discord bot, image generation, notifications, and Excel import)
+is implemented and covered by 3500+ backend tests. Playwright end-to-end tests cover the full
+siege lifecycle. Vitest component tests cover the assignment board and notification polling.
+Azure Bicep IaC is fully deployed for both dev and prod environments via GitHub Actions CD
+pipelines. The project is in a post-launch monitoring window. The only remaining tracked items
+are planner sign-off, the 48-hour monitoring window, Application Insights SDK integration, and
+performance validation.
 
 ## Phase Completion
 
@@ -25,7 +25,7 @@ that depend on the production environment being stood up.
 | 6 — Frontend Core | Complete | Member CRUD, siege management, assignment board, auto-fill UI, validation panel |
 | 7 — Frontend Discord/Compare | Complete | Comparison view, DM notification panel, channel post action, image preview/download |
 | 8 — Excel Import | Complete | One-time CLI script using openpyxl; imports historical .xlsm siege files |
-| 9 — Hardening/Launch | In Progress | E2E tests, Bicep IaC, Vitest, RUNBOOK.md done; prod provisioning + CD pipeline + launch steps remaining |
+| 9 — Hardening/Launch | Complete | E2E tests, Bicep IaC, CD pipelines, custom domain (`rslsiege.com`), RUNBOOK.md — all shipped in v1.0.0 |
 | 10 — Auth | Complete | Discord OAuth2 authentication: JWT session cookies, RequireAuth routing, `/api/auth/*` endpoints, role-based access gating |
 
 ## What's Working
@@ -54,25 +54,23 @@ Discord OAuth2 authentication is fully implemented:
 - Frontend: `AuthContext` + `useAuth` hook; `RequireAuth` wrapper on all protected routes; `LoginPage` with Discord button; 401 interceptor redirects to login
 - 19 backend auth tests; 6 frontend auth tests (LoginPage + AuthContext)
 
-## Phase 9 — In Progress
+## Phase 9 — Hardening/Launch (Complete)
 
-**Done:**
+**Delivered:**
 - RUNBOOK.md — restart procedures, rollback, DB restore, secret rotation, log queries, incident playbooks
 - Playwright end-to-end tests: full siege lifecycle covered; 22 flaky tests fixed
-- Azure Bicep IaC: all modules authored (ACR, Log Analytics, App Insights, PostgreSQL, Key Vault, Container Apps); dev + prod param files in place
+- Azure Bicep IaC: all modules authored (ACR, Log Analytics, App Insights, PostgreSQL, Key Vault, Container Apps); dev + prod param files in place and deployed
 - Vitest frontend unit tests: BoardPage and notification polling (SiegeSettingsPage) covered
 - Azure Container Apps health check fixes (Key Vault role assignments, nginx envsubst, ACR naming)
 - GitHub Actions CD pipeline: `deploy.yml` (push to main → dev; `v*` tag → prod) and `infra-deploy.yml` (manual Bicep) both operational
-- Custom domain Bicep fix (issue #228): switched from Azure-managed cert (incompatible with Cloudflare proxy + apex domain) to Cloudflare Origin Cert stored as PFX in Key Vault; user-assigned managed identity grants Container Apps environment `Key Vault Secrets User` on KV; two-phase deploy gate (`enableCustomDomain` param) prevents failure when cert has not yet been uploaded
+- Custom domain `rslsiege.com`: Cloudflare Origin Cert stored as PFX in Key Vault; user-assigned managed identity grants Container Apps environment `Key Vault Secrets User`; two-phase `enableCustomDomain` deploy gate in Bicep
+- Production Azure environment provisioned and v1.0.0 deployed
 
-**Remaining (pre-launch):**
-- Execute custom domain Phase 2: generate Cloudflare Origin Cert, run `scripts/generate-origin-pfx.ps1`, upload PFX to Key Vault, redeploy with `enableCustomDomain = true`
-- Production Azure environment provisioning (stand up `siege-web-prod` resource group from Bicep)
-- Performance validation: board load target < 2s, image generation target < 5s
-- Application Insights SDK integration in backend and bot services
-- Planner sign-off walkthrough
-- Smoke tests against production
-- 48-hour post-launch monitoring
+**Post-launch (tracked):**
+- Planner sign-off walkthrough (issue #174)
+- 48-hour post-launch monitoring window (issue #175)
+- Application Insights SDK integration in backend and bot services (still pending)
+- Performance validation: board load target < 2s, image generation target < 5s (still pending)
 
 ## How to Run Locally
 
@@ -90,16 +88,11 @@ CI via GitHub Actions on every PR to `main`:
 - Backend: black check → ruff → pytest
 - Frontend: npm ci → eslint → npm build
 
-Production deployment pipeline (merge to main → ACR push → Container Apps deploy) is
-planned as part of Phase 9 and is not yet configured.
+`deploy.yml` auto-deploys to dev on push to `main` and to prod on `v*` tag push. `infra-deploy.yml` is triggered manually (`workflow_dispatch`) for any Bicep infrastructure changes.
 
-## Next Steps (ordered, pre-launch)
+## Post-Launch Activities
 
-1. Provision production Azure environment (`siege-web-prod` resource group) from Bicep templates
-2. Configure GitHub Actions CD pipeline (build → ACR push → Container App deploy on merge to main)
+1. Planner sign-off walkthrough (issue #174)
+2. 48-hour post-launch monitoring window (issue #175; see RUNBOOK.md Section 6 checklist)
 3. Enable Application Insights SDK in backend and bot (`azure-monitor-opentelemetry`)
 4. Validate performance: board load < 2s, image generation < 5s
-5. Validate RUNBOOK.md against the real production environment
-6. Run a full walkthrough with the siege planner; address any critical feedback
-7. Deploy to production and run smoke tests
-8. Monitor for 48 hours post-launch (see RUNBOOK.md Section 6 checklist)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "siege-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Cut the v1.0.0 release. Custom domain (`rslsiege.com`) is live, prod deploy pipeline is proven, all Phase 0–10 scope is shipped. This PR is doc/config only — no code changes.

## Changes

- **`frontend/package.json`** — bump `0.1.0` → `1.0.0`
- **`CHANGELOG.md`** (new) — Keep-a-Changelog format, self-hoster audience. 36 bullets across Added / Security / Infrastructure / Developer Experience sections. Sourced from `docs/STATUS.md` — no invented features.
- **`docs/STATUS.md`** — Phase 9 marked Complete; "Next Steps" renamed "Post-Launch Activities" and trimmed to the 4 still-open items (planner sign-off, 48h monitoring, App Insights SDK, perf validation)

## Scope decisions

- Python projects (`backend/`, `bot/`) intentionally left unversioned — they're not published to PyPI
- Release notes written for self-hosters (what's in the box, what infra they need)

## Release sequence after this merges

1. Tag `v1.0.0` on `main` → triggers `.github/workflows/deploy.yml` prod deploy path
2. Create GitHub Release from the tag using CHANGELOG 1.0.0 section as release notes
3. Close #173 (deploy + smoke — done), #176 (STATUS update — done in this PR)
4. Keep #174 (planner sign-off) and #175 (48h monitoring) open as post-launch tracking

## Test plan

- [ ] CI passes (black, ruff, pytest, eslint, build)
- [ ] Manual review of CHANGELOG accuracy vs STATUS.md
- [ ] Manual review of STATUS.md — no remaining "in progress" / "pending" language outside Post-Launch Activities

Refs #239, closes #176

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*