### PR TITLE
feat(infra): scheduled acr purge task for image retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ On PR to `main`:
 - **Backend**: black check → ruff → pytest (uses test DB URL from env)
 - **Frontend**: npm ci → eslint → npm build
 
+Registry image retention is automated via a scheduled ACR Task (`weekly-purge`) in both registries — release tags (`v*`) are preserved forever; SHA/commit tags beyond the last 10 per repo and untagged manifests older than 7 days are deleted every Sunday at 03:00 UTC.
+
 Two deployment workflows exist and are fully operational:
 
 - **`.github/workflows/deploy.yml`** — triggered automatically on push to `main` (deploys to dev) and on `v*` tag push (deploys to prod). Builds Docker images, pushes to ACR, then updates Container App revisions with the new image tag.

--- a/infra/README.md
+++ b/infra/README.md
@@ -31,6 +31,43 @@ The registry name follows a fixed pattern: `${appPrefix}acr${environment}`.
 | dev | `siegeacrdev` | `siegeacrdev.azurecr.io` |
 | prod | `siegeacrprod` | `siegeacrprod.azurecr.io` |
 
+## Image retention
+
+Both registries run a **scheduled ACR Task** (`weekly-purge`) that executes `acr purge` every **Sunday at 03:00 UTC**. The task runs inside ACR via its system-assigned managed identity — no Container App or Function is needed.
+
+### Retention rules
+
+| Rule | Detail |
+|---|---|
+| Release tags (`v*`) | **Never deleted.** The SHA filter `^[a-f0-9]{40}$` only matches 40-char lowercase hex commit hashes — release tags (`v1.0.0`, etc.) are never touched. |
+| SHA / commit-hash tags | Keep the **last 10** per repo (`--keep 10`); delete older ones. |
+| Untagged manifests | Delete any untagged manifest older than **7 days** (`--untagged --ago 7d`). |
+
+Repositories covered: `siege-api`, `siege-bot`, `siege-frontend`.
+
+### First-time backlog clearance (mandatory after first deploy)
+
+The task is deployed but **not triggered automatically on deploy**. After the first infra deploy, run the task once on-demand to clear the existing backlog (~364 dev manifests, ~155 prod):
+
+```bash
+# Dev
+az acr task run --name weekly-purge --registry siegewebacr --resource-group siege-web-dev
+
+# Prod
+az acr task run --name weekly-purge --registry siegeacrprod --resource-group siege-web-prod
+```
+
+Verify storage dropped with:
+
+```bash
+az acr show-usage --name siegewebacr --resource-group siege-web-dev
+az acr show-usage --name siegeacrprod --resource-group siege-web-prod
+```
+
+### Changing the schedule or keep count
+
+Pass `acrPurgeSchedule` (cron string, UTC) and `acrPurgeKeepCount` (int ≥ 1) as parameters. The defaults (`'0 3 * * Sun'` / `10`) are set in each `.bicepparam` file and should be the same across environments for predictable behavior.
+
 ## Resource group naming convention
 
 | Environment | Resource group |

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -14,6 +14,13 @@ param acrSku string = 'Basic'
 @description('Override the generated ACR name. Leave empty to use the default convention (appPrefix + "acr" + environment).')
 param acrNameOverride string = ''
 
+@description('Number of recent SHA/commit-tagged images to keep per repo during the weekly purge. Release tags (v*) are never purged.')
+@minValue(1)
+param acrPurgeKeepCount int = 10
+
+@description('Cron schedule (UTC) for the weekly ACR purge task. Default: Sunday 03:00 UTC.')
+param acrPurgeSchedule string = '0 3 * * Sun'
+
 @description('Image tag to deploy')
 param imageTag string = 'latest'
 
@@ -175,6 +182,8 @@ module registry 'modules/registry.bicep' = {
     appPrefix: appPrefix
     acrSku: acrSku
     acrNameOverride: acrNameOverride
+    purgeKeepCount: acrPurgeKeepCount
+    purgeSchedule: acrPurgeSchedule
   }
 }
 

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -25,3 +25,9 @@ param discordBotApiKey = ''
 param botApiKey = ''
 
 param postgresGeoRedundantBackup = false
+
+// ── ACR image retention ───────────────────────────────────────────────────────
+// Release tags (v*) are never purged. SHA/commit tags beyond the keep count
+// are deleted weekly. Untagged manifests older than 7 days are also removed.
+param acrPurgeKeepCount = 10
+param acrPurgeSchedule = '0 3 * * Sun'

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -114,3 +114,12 @@ param botMemory = '0.5Gi'
 // Bot is excluded — it holds a Discord WebSocket and must stay warm.
 param apiMinReplicas = 0
 param frontendMinReplicas = 0
+
+// ── ACR image retention ───────────────────────────────────────────────────────
+// Dev currently has ~364 manifests (127/126/111 across api/bot/frontend).
+// Release tags (v*) are preserved forever. SHA/commit tags beyond the last 10
+// per repo are deleted weekly. Untagged manifests older than 7 days are removed.
+// After the first deploy, run once on-demand to clear the existing backlog:
+//   az acr task run --name weekly-purge --registry siegewebacr
+param acrPurgeKeepCount = 10
+param acrPurgeSchedule = '0 3 * * Sun'

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -142,3 +142,12 @@ param kvCertSecretUrl = 'https://siege-web-kv-prod-yf3fl2.vault.azure.net/secret
 // Frontend is Nginx only; a 2–3s cold start is acceptable in prod.
 param apiMinReplicas = 1
 param frontendMinReplicas = 0
+
+// ── ACR image retention ───────────────────────────────────────────────────────
+// Prod currently has ~155 manifests (51/52/52 across api/bot/frontend).
+// Release tags (v*) are preserved forever. SHA/commit tags beyond the last 10
+// per repo are deleted weekly. Untagged manifests older than 7 days are removed.
+// After the first deploy, run once on-demand to clear the existing backlog:
+//   az acr task run --name weekly-purge --registry siegeacrprod
+param acrPurgeKeepCount = 10
+param acrPurgeSchedule = '0 3 * * Sun'

--- a/infra/modules/registry.bicep
+++ b/infra/modules/registry.bicep
@@ -13,12 +13,37 @@ param acrSku string = 'Basic'
 @description('Override the generated ACR name (must be globally unique, 5-50 alphanumeric chars). Leave empty to use the default: appPrefix + "acr" + environment.')
 param acrNameOverride string = ''
 
+@description('Number of recent non-release (SHA/commit) tags to keep per repository during purge. Older tags beyond this count are deleted.')
+@minValue(1)
+param purgeKeepCount int = 10
+
+@description('Cron schedule for the weekly purge task (UTC). Default: Sunday 03:00 UTC.')
+param purgeSchedule string = '0 3 * * Sun'
+
 // ACR names must be alphanumeric only, 5-50 chars. Using a fixed, predictable
 // name (e.g. siegeacrdev / siegeacrprod) so the GitHub Actions workflow can
 // reference it without reading Bicep output at deploy time.
 // acrNameOverride lets the dev environment supply a pre-checked globally-unique
 // name (e.g. 'siegewebacr') without changing the default convention for prod.
 var sanitizedName = empty(acrNameOverride) ? '${appPrefix}acr${environment}' : acrNameOverride
+
+// ── acr purge command ────────────────────────────────────────────────────────
+//
+// Filter logic:
+//   --filter 'repo:^[a-f0-9]{40}$'  — matches 40-char lowercase hex SHA tags
+//                                      (the full Git commit SHA used by CI).
+//                                      Does NOT match v* release tags.
+//   --keep N                        — retains the N most-recently-pushed SHA
+//                                      tags per repo; deletes older ones.
+//   --untagged --ago 7d             — also deletes untagged manifests older
+//                                      than 7 days (dangling layers, etc.).
+//
+// Release tags (v1.0.0, v2.3.1 …) are never matched by the SHA filter, so
+// they accumulate without bound. This is intentional: release images are
+// treated as permanent artifacts.
+//
+// Note: acr purge is currently in public preview (mcr.microsoft.com/acr/acr-cli:0.17).
+var purgeCmd = 'acr purge --filter \'siege-api:^[a-f0-9]{40}$\' --filter \'siege-bot:^[a-f0-9]{40}$\' --filter \'siege-frontend:^[a-f0-9]{40}$\' --untagged --ago 7d --keep ${purgeKeepCount}'
 
 resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   name: sanitizedName
@@ -32,6 +57,53 @@ resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   }
   properties: {
     adminUserEnabled: true
+  }
+}
+
+// ── Scheduled ACR Task: weekly image retention purge ─────────────────────────
+//
+// The task runs acr purge inside ACR itself — no Container App or Function
+// needed. Auth is handled by the task's system-assigned managed identity, which
+// is automatically granted AcrDelete on the parent registry by Azure when the
+// identity type is SystemAssigned.
+//
+// Schedule: weekly, Sunday 03:00 UTC (cron: "0 3 * * Sun").
+// Platform: linux (required for ACR task runners).
+//
+// First-run note: this task is deployed but NOT triggered automatically.
+// After the first infra deploy, run once on-demand to clear the existing
+// backlog:
+//   az acr task run --name weekly-purge --registry <acrName>
+resource purgeTask 'Microsoft.ContainerRegistry/registries/tasks@2019-06-01-preview' = {
+  name: 'weekly-purge'
+  parent: registry
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    platform: {
+      os: 'Linux'
+    }
+    agentConfiguration: {
+      cpu: 2
+    }
+    step: {
+      type: 'EncodedTask'
+      encodedTaskContent: base64('version: v1.1.0\nsteps:\n  - cmd: ${purgeCmd}\n    disableWorkingDirectoryOverride: true\n    timeout: 3600\n')
+    }
+    trigger: {
+      timerTriggers: [
+        {
+          name: 'weekly-sunday-0300-utc'
+          schedule: purgeSchedule
+          status: 'Enabled'
+        }
+      ]
+    }
+    isSystemTask: false
+    status: 'Enabled'
+    timeout: 3600
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a `Microsoft.ContainerRegistry/registries/tasks` resource (`weekly-purge`) to `infra/modules/registry.bicep`, deployed to both `siegewebacr` (dev, Basic) and `siegeacrprod` (prod, Standard)
- Purge runs every **Sunday at 03:00 UTC** via a cron timer trigger
- Retention rules: keep last 10 SHA/commit tags per repo, preserve all `v*` release tags forever, delete untagged manifests older than 7 days
- Two new params (`acrPurgeKeepCount`, `acrPurgeSchedule`) wired through `main.bicep` and all three `.bicepparam` files
- `infra/README.md` updated with "Image retention" subsection (schedule, rules, first-run backlog clearance commands)
- `CLAUDE.md` CI section updated with one-line retention note

## Retention rules detail

| Rule | Behavior |
|---|---|
| Release tags (`v1.0.0`, `v2.3.1` …) | **Never deleted** — SHA filter `^[a-f0-9]{40}$` only matches 40-char lowercase hex commit hashes |
| SHA / commit-hash tags | Keep last **10** per repo (`--keep 10`); older ones deleted |
| Untagged manifests | Deleted if older than **7 days** (`--untagged --ago 7d`) |

Repositories covered: `siege-api`, `siege-bot`, `siege-frontend`.

## Purge command

```
acr purge \
  --filter 'siege-api:^[a-f0-9]{40}$' \
  --filter 'siege-bot:^[a-f0-9]{40}$' \
  --filter 'siege-frontend:^[a-f0-9]{40}$' \
  --untagged --ago 7d --keep 10
```

## Bicep validation

`az bicep build --file infra/main.bicep` — **pending human verification** (Bash not available in this agent session). Run this before triggering the infra-deploy workflow.

## What-if diff

**Pending human verification.** The expected diff for both dev and prod should show only two resources being added (no modifications to existing resources):

```
~ Microsoft.ContainerRegistry/registries/siegewebacr  [No change]
+ Microsoft.ContainerRegistry/registries/siegewebacr/tasks/weekly-purge  [Create]
```

Run to verify:

```bash
# Dev
az deployment group what-if \
  --resource-group siege-web-dev \
  --template-file infra/main.bicep \
  --parameters infra/main.dev.bicepparam \
  --parameters postgresAdminPassword="$PG_ADMIN_PASSWORD" \
  --parameters discordToken="$DISCORD_TOKEN" \
  --parameters discordBotApiKey="$DISCORD_BOT_API_KEY" \
  --parameters botApiKey="$BOT_API_KEY" \
  --parameters sessionSecret="$SESSION_SECRET" \
  --parameters discordClientId="$DISCORD_CLIENT_ID" \
  --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"

# Prod
az deployment group what-if \
  --resource-group siege-web-prod \
  --template-file infra/main.bicep \
  --parameters infra/main.prod.bicepparam \
  --parameters postgresAdminPassword="$PG_ADMIN_PASSWORD" \
  --parameters discordToken="$DISCORD_TOKEN" \
  --parameters discordBotApiKey="$DISCORD_BOT_API_KEY" \
  --parameters botApiKey="$BOT_API_KEY" \
  --parameters sessionSecret="$SESSION_SECRET" \
  --parameters discordClientId="$DISCORD_CLIENT_ID" \
  --parameters discordClientSecret="$DISCORD_CLIENT_SECRET"
```

## First-time backlog clearance (operator action required after merge)

The task is deployed but **not triggered automatically on deploy**. After the infra-deploy workflow completes, run once on-demand to clear the existing backlog (~364 dev manifests, ~155 prod):

```bash
# Dev — clears the ~69.7 GB backlog
az acr task run --name weekly-purge --registry siegewebacr --resource-group siege-web-dev

# Prod — clears the ~31.9 GB backlog
az acr task run --name weekly-purge --registry siegeacrprod --resource-group siege-web-prod
```

Verify storage dropped afterward:

```bash
az acr show-usage --name siegewebacr --resource-group siege-web-dev
az acr show-usage --name siegeacrprod --resource-group siege-web-prod
```

Closes #244

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*