### PR TITLE
fix(obs): set service.name and instrument FastAPI for App Insights telemetry

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,8 +36,6 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-configure_telemetry()
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -68,6 +66,12 @@ app = FastAPI(
     redoc_url=None,
     lifespan=lifespan,
 )
+
+# Configure telemetry AFTER the app object is created so that
+# FastAPIInstrumentor can wrap it.  OTEL_SERVICE_NAME must be set in the
+# container environment (see infra/modules/container-apps.bicep) to populate
+# cloud_RoleName in Application Insights.
+configure_telemetry(app)
 
 app.add_middleware(RequestLoggingMiddleware)
 

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -47,7 +47,7 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
     """
     connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled.")
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
         return
 
     try:
@@ -72,5 +72,5 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry;" " continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
         )

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -45,13 +45,9 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
             no FastAPI instrumentation is applied (useful for non-HTTP
             processes or unit tests that only verify the monitor call).
     """
-    connection_string = os.environ.get(
-        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
-    ).strip()
+    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug(
-            "APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled."
-        )
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled.")
         return
 
     try:
@@ -76,6 +72,5 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry;"
-            " continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry;" " continuing without telemetry."
         )

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -1,43 +1,81 @@
-"""
-Application Insights / OpenTelemetry initialisation for the backend.
+"""Application Insights / OpenTelemetry initialisation for the backend.
 
-Call ``configure_telemetry()`` once at process start, before the ASGI app
-begins accepting requests.  If ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is
-not set the function is a no-op so local development is unaffected.
+Call ``configure_telemetry(app)`` once at process start, **after**
+``app = FastAPI(...)`` is constructed.  If
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the function is a
+no-op so local development is unaffected.
+
+``OTEL_SERVICE_NAME`` must be set in the environment (via the Bicep
+container-app definition for deployed environments) so that
+``configure_azure_monitor()`` picks it up automatically and tags every
+span with ``service.name``, which Azure Application Insights surfaces as
+``cloud_RoleName``.  Without it every span lands under the synthetic
+``unknown_service`` node and the Application Map cannot render.
 """
 
 import logging
 import os
 
+from fastapi import FastAPI
+
 logger = logging.getLogger(__name__)
 
 
-def configure_telemetry() -> None:
-    """Initialise Azure Monitor OpenTelemetry if the connection string is present.
+def configure_telemetry(app: FastAPI | None = None) -> None:
+    """Initialise Azure Monitor OpenTelemetry and instrument the FastAPI app.
 
     The ``azure-monitor-opentelemetry`` distro reads
-    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment automatically
-    when ``configure_azure_monitor()`` is called without an explicit
-    ``connection_string`` argument.  We guard the call so that a missing env var
-    is a silent no-op rather than an import-time or startup error.
+    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment
+    automatically when ``configure_azure_monitor()`` is called without an
+    explicit ``connection_string`` argument.  We guard the call so that a
+    missing env var is a silent no-op rather than an import-time or startup
+    error.
+
+    ``OTEL_SERVICE_NAME`` is read from the environment by the OpenTelemetry
+    SDK automatically — set it to ``siege-api`` in the container environment
+    so that ``cloud_RoleName`` is populated correctly in App Insights.
+
+    After configuring the Azure Monitor exporter, ``FastAPIInstrumentor`` is
+    used to wrap the provided *app* so that every inbound HTTP request
+    generates a ``requests`` span.  This also enables automatic exception
+    capture and upstream dependency correlation.
+
+    Args:
+        app: The FastAPI application instance to instrument.  When *None*
+            no FastAPI instrumentation is applied (useful for non-HTTP
+            processes or unit tests that only verify the monitor call).
     """
-    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
+    connection_string = os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
+    ).strip()
     if not connection_string:
-        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
+        logger.debug(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled."
+        )
         return
 
     try:
         from azure.monitor.opentelemetry import configure_azure_monitor
 
         configure_azure_monitor(
-            logger_name="app",  # collect logs from the 'app' namespace and children
+            logger_name="app",  # collect logs from 'app' namespace + children
         )
         logger.info("Azure Monitor OpenTelemetry configured for backend.")
+
+        if app is not None:
+            from opentelemetry.instrumentation.fastapi import (
+                FastAPIInstrumentor,
+            )
+
+            FastAPIInstrumentor().instrument_app(app)
+            logger.info("FastAPI instrumented for OpenTelemetry tracing.")
+
     # Catch-all: telemetry init failures must never crash the app.
     # Azure SDK init can raise ValueError (bad connection string),
     # ConnectionError (network), or ImportError (missing optional deps).
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry;"
+            " continuing without telemetry."
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ playwright>=1.49
 PyJWT>=2.9
 cryptography>=43
 azure-monitor-opentelemetry>=1.6
+opentelemetry-instrumentation-fastapi>=0.50b0

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -33,7 +33,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -52,7 +56,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -71,7 +79,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -103,7 +115,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -123,7 +137,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise — the function catches and logs the exception.
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()  # no exception expected
 
 
@@ -140,7 +156,9 @@ class TestConfigureTelemetryFastAPIInstrumentation:
         "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
     )
 
-    def test_instrument_app_called_when_connection_string_and_service_name_set(self, monkeypatch):
+    def test_instrument_app_called_when_connection_string_and_service_name_set(
+        self, monkeypatch
+    ):
         """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
 
         When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
@@ -171,7 +189,9 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
@@ -208,9 +228,50 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
 
         mock_configure.assert_called_once_with(logger_name="app")
+
+    def test_instrument_app_not_called_when_app_is_none(self, monkeypatch):
+        """FastAPIInstrumentor.instrument_app() is NOT called when app argument is None.
+
+        When configure_telemetry() is called without a FastAPI app (or with
+        app=None), the function must call configure_azure_monitor() but must
+        skip FastAPIInstrumentor().instrument_app() to avoid passing None to
+        the instrumentor. This pins the branch so a future refactor cannot
+        silently start instrumenting a None app.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-api")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": fake_fastapi_instrumentor_module,
+            },
+        ):
+            telemetry_module.configure_telemetry(app=None)
+
+        mock_configure.assert_called_once()
+        mock_instrumentor.instrument_app.assert_not_called()

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -5,9 +5,13 @@ Verifies:
 - configure_telemetry() is a no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset
 - configure_telemetry() calls configure_azure_monitor() when the env var is set
 - An unexpected exception from configure_azure_monitor() is swallowed (no crash)
+- When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME are set,
+  configure_azure_monitor() and FastAPIInstrumentor.instrument_app() are both called
 """
 
 from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
 
 
 class TestConfigureTelemetryNoop:
@@ -29,7 +33,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -48,7 +56,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -67,7 +79,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -99,7 +115,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -119,5 +137,102 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise — the function catches and logs the exception.
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()  # no exception expected
+
+
+class TestConfigureTelemetryFastAPIInstrumentation:
+    """Regression tests: FastAPIInstrumentor.instrument_app() must be called.
+
+    Issue #245: configure_azure_monitor was called without FastAPI
+    instrumentation, so no request/exception/dependency spans were emitted.
+    """
+
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_instrument_app_called_when_connection_string_and_service_name_set(
+        self, monkeypatch
+    ):
+        """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
+
+        When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
+        are present, configure_telemetry(app) must call both
+        configure_azure_monitor() and FastAPIInstrumentor.instrument_app(app)
+        so that request spans are emitted and cloud_RoleName is populated.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-api")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        fastapi_app = FastAPI()
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
+            },
+        ):
+            telemetry_module.configure_telemetry(fastapi_app)
+
+        mock_configure.assert_called_once()
+        mock_instrumentor.instrument_app.assert_called_once_with(fastapi_app)
+
+    def test_configure_azure_monitor_called_when_both_env_vars_set(self, monkeypatch):
+        """configure_azure_monitor() is called when both env vars are present.
+
+        Regression for issue #245: OTEL_SERVICE_NAME is set in Bicep so the
+        distro picks it up automatically — no explicit kwarg needed.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-api")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        fastapi_app = FastAPI()
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
+            },
+        ):
+            telemetry_module.configure_telemetry(fastapi_app)
+
+        mock_configure.assert_called_once_with(logger_name="app")

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -33,11 +33,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -56,11 +52,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -79,11 +71,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -115,9 +103,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -137,9 +123,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise — the function catches and logs the exception.
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()  # no exception expected
 
 
@@ -156,9 +140,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
         "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
     )
 
-    def test_instrument_app_called_when_connection_string_and_service_name_set(
-        self, monkeypatch
-    ):
+    def test_instrument_app_called_when_connection_string_and_service_name_set(self, monkeypatch):
         """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
 
         When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
@@ -189,9 +171,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (
-                    fake_fastapi_instrumentor_module
-                ),
+                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
@@ -228,9 +208,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (
-                    fake_fastapi_instrumentor_module
-                ),
+                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)

--- a/bot/app/main.py
+++ b/bot/app/main.py
@@ -47,5 +47,9 @@ async def main() -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    configure_telemetry()
+    # Configure telemetry with the HTTP sidecar app so FastAPIInstrumentor
+    # can wrap it.  OTEL_SERVICE_NAME must be set in the container environment
+    # (see infra/modules/container-apps.bicep) to populate cloud_RoleName
+    # in Application Insights.
+    configure_telemetry(http_app)
     asyncio.run(main())

--- a/bot/app/telemetry.py
+++ b/bot/app/telemetry.py
@@ -46,13 +46,9 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
             no FastAPI instrumentation is applied (useful for non-HTTP
             processes or unit tests that only verify the monitor call).
     """
-    connection_string = os.environ.get(
-        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
-    ).strip()
+    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug(
-            "APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled."
-        )
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
         return
 
     try:
@@ -77,6 +73,5 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry;"
-            " continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
         )

--- a/bot/app/telemetry.py
+++ b/bot/app/telemetry.py
@@ -1,44 +1,82 @@
-"""
-Application Insights / OpenTelemetry initialisation for the bot service.
+"""Application Insights / OpenTelemetry initialisation for the bot service.
 
-Call ``configure_telemetry()`` once at process start, before the asyncio
+Call ``configure_telemetry(app)`` once at process start, **after** the
+FastAPI HTTP-sidecar app object is constructed and before the asyncio
 TaskGroup spins up the Discord client and HTTP sidecar.  If
-``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the function is a no-op
-so local development is unaffected.
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the function is a
+no-op so local development is unaffected.
+
+``OTEL_SERVICE_NAME`` must be set in the environment (via the Bicep
+container-app definition for deployed environments) so that
+``configure_azure_monitor()`` picks it up automatically and tags every
+span with ``service.name``, which Azure Application Insights surfaces as
+``cloud_RoleName``.  Without it every span lands under the synthetic
+``unknown_service`` node and the Application Map cannot render.
 """
 
 import logging
 import os
 
+from fastapi import FastAPI
+
 logger = logging.getLogger(__name__)
 
 
-def configure_telemetry() -> None:
-    """Initialise Azure Monitor OpenTelemetry if the connection string is present.
+def configure_telemetry(app: FastAPI | None = None) -> None:
+    """Initialise Azure Monitor OpenTelemetry and instrument the HTTP sidecar.
 
     The ``azure-monitor-opentelemetry`` distro reads
-    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment automatically
-    when ``configure_azure_monitor()`` is called without an explicit
-    ``connection_string`` argument.  We guard the call so that a missing env var
-    is a silent no-op rather than an import-time or startup error.
+    ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment
+    automatically when ``configure_azure_monitor()`` is called without an
+    explicit ``connection_string`` argument.  We guard the call so that a
+    missing env var is a silent no-op rather than an import-time or startup
+    error.
+
+    ``OTEL_SERVICE_NAME`` is read from the environment by the OpenTelemetry
+    SDK automatically — set it to ``siege-bot`` in the container environment
+    so that ``cloud_RoleName`` is populated correctly in App Insights.
+
+    After configuring the Azure Monitor exporter, ``FastAPIInstrumentor`` is
+    used to wrap the provided *app* (the HTTP sidecar) so that every inbound
+    HTTP request generates a ``requests`` span.  The discord.py client itself
+    does not have an HTTP server to instrument; only the sidecar needs this.
+
+    Args:
+        app: The FastAPI application instance to instrument.  When *None*
+            no FastAPI instrumentation is applied (useful for non-HTTP
+            processes or unit tests that only verify the monitor call).
     """
-    connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
+    connection_string = os.environ.get(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING", ""
+    ).strip()
     if not connection_string:
-        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
+        logger.debug(
+            "APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled."
+        )
         return
 
     try:
         from azure.monitor.opentelemetry import configure_azure_monitor
 
         configure_azure_monitor(
-            logger_name="app",  # collect logs from the 'app' namespace and children
+            logger_name="app",  # collect logs from 'app' namespace + children
         )
         logger.info("Azure Monitor OpenTelemetry configured for bot.")
+
+        if app is not None:
+            from opentelemetry.instrumentation.fastapi import (
+                FastAPIInstrumentor,
+            )
+
+            FastAPIInstrumentor().instrument_app(app)
+            logger.info("FastAPI HTTP sidecar instrumented for OpenTelemetry tracing.")
+
     # Catch-all: telemetry init failures must never crash the app.
     # Azure SDK init can raise ValueError (bad connection string),
     # ConnectionError (network), or ImportError (missing optional deps).
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry;"
+            " continuing without telemetry."
         )

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings==2.6.1
 httpx==0.27.2
 python-multipart==0.0.20
 azure-monitor-opentelemetry>=1.6
+opentelemetry-instrumentation-fastapi>=0.50b0

--- a/bot/tests/test_telemetry.py
+++ b/bot/tests/test_telemetry.py
@@ -30,11 +30,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -53,11 +49,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -76,11 +68,7 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {
-                "azure.monitor.opentelemetry": MagicMock(
-                    configure_azure_monitor=mock_configure
-                )
-            },
+            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
         ):
             telemetry_module.configure_telemetry()
 
@@ -112,9 +100,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -134,9 +120,7 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise.
-        with patch.dict(
-            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
-        ):
+        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
             telemetry_module.configure_telemetry()  # no exception expected
 
 
@@ -153,9 +137,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
         "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
     )
 
-    def test_instrument_app_called_when_connection_string_and_service_name_set(
-        self, monkeypatch
-    ):
+    def test_instrument_app_called_when_connection_string_and_service_name_set(self, monkeypatch):
         """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
 
         When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
@@ -186,9 +168,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (
-                    fake_fastapi_instrumentor_module
-                ),
+                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
@@ -225,9 +205,7 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (
-                    fake_fastapi_instrumentor_module
-                ),
+                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)

--- a/bot/tests/test_telemetry.py
+++ b/bot/tests/test_telemetry.py
@@ -30,7 +30,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -49,7 +53,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -68,7 +76,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -100,7 +112,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -120,7 +134,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise.
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()  # no exception expected
 
 
@@ -137,7 +153,9 @@ class TestConfigureTelemetryFastAPIInstrumentation:
         "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
     )
 
-    def test_instrument_app_called_when_connection_string_and_service_name_set(self, monkeypatch):
+    def test_instrument_app_called_when_connection_string_and_service_name_set(
+        self, monkeypatch
+    ):
         """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
 
         When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
@@ -168,7 +186,9 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
@@ -205,9 +225,50 @@ class TestConfigureTelemetryFastAPIInstrumentation:
             "sys.modules",
             {
                 "azure.monitor.opentelemetry": fake_azure_module,
-                "opentelemetry.instrumentation.fastapi": (fake_fastapi_instrumentor_module),
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
             },
         ):
             telemetry_module.configure_telemetry(fastapi_app)
 
         mock_configure.assert_called_once_with(logger_name="app")
+
+    def test_instrument_app_not_called_when_app_is_none(self, monkeypatch):
+        """FastAPIInstrumentor.instrument_app() is NOT called when app argument is None.
+
+        When configure_telemetry() is called without a FastAPI app (or with
+        app=None), the function must call configure_azure_monitor() but must
+        skip FastAPIInstrumentor().instrument_app() to avoid passing None to
+        the instrumentor. This pins the branch so a future refactor cannot
+        silently start instrumenting a None app.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-bot")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": fake_fastapi_instrumentor_module,
+            },
+        ):
+            telemetry_module.configure_telemetry(app=None)
+
+        mock_configure.assert_called_once()
+        mock_instrumentor.instrument_app.assert_not_called()

--- a/bot/tests/test_telemetry.py
+++ b/bot/tests/test_telemetry.py
@@ -5,9 +5,13 @@ Verifies:
 - configure_telemetry() is a no-op when APPLICATIONINSIGHTS_CONNECTION_STRING is unset
 - configure_telemetry() calls configure_azure_monitor() when the env var is set
 - An unexpected exception from configure_azure_monitor() is swallowed (no crash)
+- When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME are set,
+  configure_azure_monitor() and FastAPIInstrumentor.instrument_app() are both called
 """
 
 from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
 
 
 class TestConfigureTelemetryNoop:
@@ -18,6 +22,7 @@ class TestConfigureTelemetryNoop:
         monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
 
         import importlib
+
         import app.telemetry as telemetry_module
 
         importlib.reload(telemetry_module)
@@ -25,7 +30,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -36,6 +45,7 @@ class TestConfigureTelemetryNoop:
         monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
 
         import importlib
+
         import app.telemetry as telemetry_module
 
         importlib.reload(telemetry_module)
@@ -43,7 +53,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -54,6 +68,7 @@ class TestConfigureTelemetryNoop:
         monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "   ")
 
         import importlib
+
         import app.telemetry as telemetry_module
 
         importlib.reload(telemetry_module)
@@ -61,7 +76,11 @@ class TestConfigureTelemetryNoop:
         mock_configure = MagicMock()
         with patch.dict(
             "sys.modules",
-            {"azure.monitor.opentelemetry": MagicMock(configure_azure_monitor=mock_configure)},
+            {
+                "azure.monitor.opentelemetry": MagicMock(
+                    configure_azure_monitor=mock_configure
+                )
+            },
         ):
             telemetry_module.configure_telemetry()
 
@@ -69,7 +88,7 @@ class TestConfigureTelemetryNoop:
 
 
 class TestConfigureTelemetryActive:
-    """When APPLICATIONINSIGHTS_CONNECTION_STRING is set, configure_azure_monitor() must be called."""
+    """When APPLICATIONINSIGHTS_CONNECTION_STRING is set, configure_azure_monitor() is called."""
 
     # Fake connection string — intentionally invalid; the SDK accepts any
     # syntactically-valid string at configure time and only fails on export.
@@ -84,6 +103,7 @@ class TestConfigureTelemetryActive:
         monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
 
         import importlib
+
         import app.telemetry as telemetry_module
 
         importlib.reload(telemetry_module)
@@ -92,7 +112,9 @@ class TestConfigureTelemetryActive:
         fake_azure_module = MagicMock()
         fake_azure_module.configure_azure_monitor = mock_configure
 
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()
 
         mock_configure.assert_called_once_with(logger_name="app")
@@ -102,6 +124,7 @@ class TestConfigureTelemetryActive:
         monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
 
         import importlib
+
         import app.telemetry as telemetry_module
 
         importlib.reload(telemetry_module)
@@ -111,5 +134,102 @@ class TestConfigureTelemetryActive:
         fake_azure_module.configure_azure_monitor = mock_configure
 
         # Should not raise.
-        with patch.dict("sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}):
+        with patch.dict(
+            "sys.modules", {"azure.monitor.opentelemetry": fake_azure_module}
+        ):
             telemetry_module.configure_telemetry()  # no exception expected
+
+
+class TestConfigureTelemetryFastAPIInstrumentation:
+    """Regression tests: FastAPIInstrumentor.instrument_app() must be called.
+
+    Issue #245: the bot HTTP sidecar app was not instrumented, so its
+    requests were not emitted to App Insights.
+    """
+
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_instrument_app_called_when_connection_string_and_service_name_set(
+        self, monkeypatch
+    ):
+        """FastAPIInstrumentor.instrument_app() is called with the FastAPI app.
+
+        When both APPLICATIONINSIGHTS_CONNECTION_STRING and OTEL_SERVICE_NAME
+        are present, configure_telemetry(app) must call both
+        configure_azure_monitor() and FastAPIInstrumentor.instrument_app(app)
+        so that bot HTTP-sidecar request spans are emitted.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-bot")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        fastapi_app = FastAPI()
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
+            },
+        ):
+            telemetry_module.configure_telemetry(fastapi_app)
+
+        mock_configure.assert_called_once()
+        mock_instrumentor.instrument_app.assert_called_once_with(fastapi_app)
+
+    def test_configure_azure_monitor_called_when_both_env_vars_set(self, monkeypatch):
+        """configure_azure_monitor() is called when both env vars are present.
+
+        Regression for issue #245: OTEL_SERVICE_NAME is set in Bicep so the
+        distro picks it up automatically — no explicit kwarg needed.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "siege-bot")
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        fastapi_app = FastAPI()
+        mock_configure = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_cls = MagicMock(return_value=mock_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_fastapi_instrumentor_module = MagicMock()
+        fake_fastapi_instrumentor_module.FastAPIInstrumentor = mock_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.fastapi": (
+                    fake_fastapi_instrumentor_module
+                ),
+            },
+        ):
+            telemetry_module.configure_telemetry(fastapi_app)
+
+        mock_configure.assert_called_once_with(logger_name="app")

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -395,6 +395,46 @@ az monitor log-analytics query \
 
 ## 6. Monitoring and Alerts
 
+### Application Insights role names
+
+Each service emits telemetry tagged with a `cloud_RoleName` that determines
+how it appears in the Application Map and in KQL queries.
+
+| Service | `cloud_RoleName` | Set by |
+|---|---|---|
+| Backend API (`siege-api` container) | `siege-api` | `OTEL_SERVICE_NAME=siege-api` env var (Bicep) |
+| Bot HTTP sidecar (`siege-bot` container) | `siege-bot` | `OTEL_SERVICE_NAME=siege-bot` env var (Bicep) |
+
+When writing KQL monitor queries, always filter on the correct role name:
+
+```kusto
+-- Backend requests
+requests
+| where cloud_RoleName == "siege-api"
+| where timestamp > ago(10m)
+
+-- Bot sidecar requests
+requests
+| where cloud_RoleName == "siege-bot"
+| where timestamp > ago(10m)
+
+-- Exceptions from the backend
+exceptions
+| where cloud_RoleName == "siege-api"
+| where timestamp > ago(1h)
+
+-- PostgreSQL dependency calls
+dependencies
+| where cloud_RoleName == "siege-api"
+| where type == "postgresql"
+| where timestamp > ago(1h)
+```
+
+The Application Map should render three named nodes: `siege-api`, `siege-bot`,
+and the PostgreSQL database, connected by traffic edges.  If the map shows
+`unknown_service` instead, verify that `OTEL_SERVICE_NAME` is set on the
+relevant Container App revision (see Bicep `infra/modules/container-apps.bicep`).
+
 ### What to watch
 
 | Signal | Threshold | Action |

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -202,10 +202,17 @@ resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
               // Falls back to localhost:5173 for dev deployments without a custom domain.
               { name: 'ALLOWED_ORIGINS', value: !empty(customDomainHostname) ? 'https://${customDomainHostname}' : 'http://localhost:5173' }
             ],
-            // Only inject the Application Insights connection string when one
-            // has been provided — keeps dev deployments lightweight.
+            // Only inject the Application Insights connection string and
+            // OTEL_SERVICE_NAME when a connection string has been provided.
+            // OTEL_SERVICE_NAME is what the Azure Monitor distro uses to set
+            // the service.name resource attribute, which App Insights surfaces
+            // as cloud_RoleName.  Without it every span lands under the
+            // synthetic "unknown_service" node and the Application Map cannot
+            // render.  The frontend container (nginx, no SDK) does not need
+            // either variable.
             empty(appInsightsConnectionString) ? [] : [
               { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+              { name: 'OTEL_SERVICE_NAME', value: 'siege-api' }
             ]
           )
           probes: [
@@ -456,8 +463,12 @@ resource botApp 'Microsoft.App/containerApps@2024-03-01' = {
               { name: 'DISCORD_GUILD_ID', value: discordGuildId }
               { name: 'ENVIRONMENT', value: environment }
             ],
+            // Inject App Insights connection string and OTEL_SERVICE_NAME for
+            // the bot sidecar when telemetry is enabled.  See the API comment
+            // block above for the rationale on OTEL_SERVICE_NAME.
             empty(appInsightsConnectionString) ? [] : [
               { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+              { name: 'OTEL_SERVICE_NAME', value: 'siege-bot' }
             ]
           )
           probes: [


### PR DESCRIPTION
## Summary

- `configure_telemetry()` was called before `app = FastAPI(...)` and never invoked `FastAPIInstrumentor`, so no request/exception/dependency spans reached App Insights.
- `OTEL_SERVICE_NAME` was never set, causing all spans to land under `cloud_RoleName = "unknown_service"` — the Application Map was empty.
- This PR fixes both root causes for `siege-api` and `siege-bot`, adds regression tests, and documents the role names in the runbook.

## Changes

| File | Change |
|---|---|
| `backend/app/telemetry.py` | Accept `app: FastAPI \| None`; call `FastAPIInstrumentor().instrument_app(app)` after `configure_azure_monitor()` |
| `bot/app/telemetry.py` | Same pattern for the HTTP sidecar |
| `backend/app/main.py` | Move `configure_telemetry(app)` call to after `app = FastAPI(...)` |
| `bot/app/main.py` | Pass `http_app` to `configure_telemetry()` |
| `backend/requirements.txt` | Add `opentelemetry-instrumentation-fastapi>=0.50b0` |
| `bot/requirements.txt` | Same |
| `infra/modules/container-apps.bicep` | Add `OTEL_SERVICE_NAME=siege-api` and `OTEL_SERVICE_NAME=siege-bot` to the App Insights env var block for each service |
| `backend/tests/test_telemetry.py` | Regression tests: assert `instrument_app()` is called with the app when both env vars are set |
| `bot/tests/test_telemetry.py` | Same |
| `docs/RUNBOOK.md` | Section 6: document `cloud_RoleName` values (`siege-api`, `siege-bot`) and add KQL query examples filtered by role name |

## Test plan

- [x] Backend telemetry tests: 7 passed (black + ruff clean)
- [x] Bot test suite: 38 passed (black + ruff clean)
- [ ] Post-deploy: hit `/api/health` and verify `requests | where cloud_RoleName == "siege-api" | where timestamp > ago(10m)` returns rows in App Insights
- [ ] Verify Application Map renders three nodes: `siege-api`, `siege-bot`, PostgreSQL

Closes #245

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*