### PR TITLE
chore: update reusable-workflow refs to glitchwerks org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]
     if: failure() && github.event_name == 'pull_request'
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-lint-fix.yml@v1
+    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@v1
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       gh_pat: ${{ secrets.GH_PAT }}

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fix:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/ci-failure.yaml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   review:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   respond:
-    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-tag-respond.yml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2.0.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary
- Updates 4 \`uses:\` references in caller workflows from \`cbeaulieu-gt/github-actions/...\` to \`glitchwerks/github-actions/...\`
- Library was transferred to \`glitchwerks\` org on 2026-04-29 (see glitchwerks/github-actions#148)
- HTTP redirect works today; updating to canonical path eliminates latent breakage risk

## Test plan
- [ ] CI passes

Closes #258.

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt