### PR TITLE
fix(infra): unblock #246 alerts — disable autoMitigate to resolve deploy failure

### DIFF
--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -71,7 +71,7 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
 // Common settings:
 //   - evaluationFrequency PT1M — check every minute
 //   - severity 2 (warning) or 3 (informational)
-//   - autoMitigate true — alert resolves automatically when condition clears
+//   - autoMitigate false — required when muteActionsDuration is set (Azure rejects the combination)
 //   - muteActionsDuration PT15M — suppresses repeat emails during an incident
 //
 // All KQL queries are written to return zero rows in the steady state and ≥1
@@ -97,7 +97,7 @@ resource alert5xxRate 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
     evaluationFrequency: 'PT1M'
     windowSize: 'PT5M'
     scopes: [appInsightsId]
-    autoMitigate: true
+    autoMitigate: false
     muteActionsDuration: 'PT15M'
     criteria: {
       allOf: [
@@ -144,7 +144,7 @@ resource alertLatencyP95 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
     evaluationFrequency: 'PT1M'
     windowSize: 'PT5M'
     scopes: [appInsightsId]
-    autoMitigate: true
+    autoMitigate: false
     muteActionsDuration: 'PT15M'
     criteria: {
       allOf: [
@@ -196,7 +196,7 @@ resource alertBotRestart 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
     evaluationFrequency: 'PT1M'
     windowSize: 'PT1M'
     scopes: [appInsightsId]
-    autoMitigate: true
+    autoMitigate: false
     muteActionsDuration: 'PT15M'
     criteria: {
       allOf: [
@@ -255,7 +255,7 @@ resource alertImageGenSlow 'Microsoft.Insights/scheduledQueryRules@2023-12-01' =
     evaluationFrequency: 'PT1M'
     windowSize: 'PT5M'
     scopes: [appInsightsId]
-    autoMitigate: true
+    autoMitigate: false
     muteActionsDuration: 'PT15M'
     criteria: {
       allOf: [


### PR DESCRIPTION
## Summary

- Dev infra-deploy run #22 (2026-04-30 00:11:50 UTC, post-merge of #260) failed with `BadRequest: "Auto mitigation must be disabled when action suppression is set"` on all four `scheduledQueryRules` resources
- Root cause: `autoMitigate: true` (Azure default) and `muteActionsDuration: 'PT15M'` were set simultaneously — Azure rejects this combination
- Fix: explicitly set `autoMitigate: false` on all four alert rules (`alert5xxRate`, `alertLatencyP95`, `alertBotRestart`, `alertImageGenSlow`)

## Azure error (verbatim)

```
BadRequest: "Auto mitigation must be disabled when action suppression is set"
```

## What changed

`infra/modules/monitoring.bicep` — four `scheduledQueryRules` resources:

| Resource | Before | After |
|---|---|---|
| `alert5xxRate` | `autoMitigate: true` | `autoMitigate: false` |
| `alertLatencyP95` | `autoMitigate: true` | `autoMitigate: false` |
| `alertBotRestart` | `autoMitigate: true` | `autoMitigate: false` |
| `alertImageGenSlow` | `autoMitigate: true` | `autoMitigate: false` |

The `actionGroup` and `workbook` resources are not modified — they deployed successfully in run #22.

`az bicep build --file infra/main.bicep` passes cleanly.

## Behavioral note

With `autoMitigate: false`, fired alerts will not auto-resolve when the condition clears — on-call must acknowledge and close them manually. This is intentional for our use cases (5xx spike, latency, bot restart, slow image gen) and is consistent with the `muteActionsDuration` suppression pattern already in place.

## Related

- #246 — original monitoring issue (already closed by #260; not re-closing here)
- #261 — dev validation tracking issue; dev validation can resume once this merges and `infra-deploy.yml` is re-triggered manually

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*