### PR TITLE
feat(obs): instrument SQLAlchemy + asyncpg for DB dependency visibility

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.api.sieges import router as sieges_router
 from app.api.validation import router as validation_router
 from app.api.version import router as version_router
 from app.config import settings
+from app.db.session import engine
 from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
 from app.telemetry import configure_telemetry
@@ -68,10 +69,11 @@ app = FastAPI(
 )
 
 # Configure telemetry AFTER the app object is created so that
-# FastAPIInstrumentor can wrap it.  OTEL_SERVICE_NAME must be set in the
-# container environment (see infra/modules/container-apps.bicep) to populate
-# cloud_RoleName in Application Insights.
-configure_telemetry(app)
+# FastAPIInstrumentor can wrap it, and after the engine is imported so that
+# SQLAlchemyInstrumentor can hook the sync_engine.  OTEL_SERVICE_NAME must be
+# set in the container environment (see infra/modules/container-apps.bicep) to
+# populate cloud_RoleName in Application Insights.
+configure_telemetry(app=app, engine=engine)
 
 app.add_middleware(RequestLoggingMiddleware)
 

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -94,6 +94,24 @@ def configure_telemetry(
             SQLAlchemyInstrumentor().instrument(engine=engine.sync_engine)
             logger.info("SQLAlchemy instrumented for OpenTelemetry DB dependency" " tracing.")
 
+        # AsyncPGInstrumentor is intentionally kept alongside
+        # SQLAlchemyInstrumentor even though SQLAlchemy executes all
+        # queries through asyncpg under the hood.  During normal request
+        # handling both instrumentors observe the same underlying
+        # connection, so some dependency spans may be nested or duplicated
+        # in Application Insights.
+        #
+        # AsyncPG coverage is preserved here to capture code paths that
+        # bypass SQLAlchemy entirely — for example, raw asyncpg.connect()
+        # calls in utility scripts or Alembic migrations if they are ever
+        # invoked directly from within the app process.
+        #
+        # Post-deploy verification: run the KQL query in RUNBOOK.md §6 to
+        # check whether duplicate spans actually appear in practice.  If
+        # both a SQLAlchemy-emitted type and a separate "postgresql"
+        # (asyncpg) entry appear with comparable counts for the same
+        # target, AsyncPGInstrumentor can be removed in a follow-up PR
+        # (see #257 review thread).
         from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
 
         AsyncPGInstrumentor().instrument()

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -1,9 +1,9 @@
 """Application Insights / OpenTelemetry initialisation for the backend.
 
-Call ``configure_telemetry(app)`` once at process start, **after**
-``app = FastAPI(...)`` is constructed.  If
-``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the function is a
-no-op so local development is unaffected.
+Call ``configure_telemetry(app, engine)`` once at process start, **after**
+``app = FastAPI(...)`` is constructed and the SQLAlchemy async engine is
+available.  If ``APPLICATIONINSIGHTS_CONNECTION_STRING`` is not set the
+function is a no-op so local development is unaffected.
 
 ``OTEL_SERVICE_NAME`` must be set in the environment (via the Bicep
 container-app definition for deployed environments) so that
@@ -15,14 +15,21 @@ span with ``service.name``, which Azure Application Insights surfaces as
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
 
 logger = logging.getLogger(__name__)
 
 
-def configure_telemetry(app: FastAPI | None = None) -> None:
-    """Initialise Azure Monitor OpenTelemetry and instrument the FastAPI app.
+def configure_telemetry(
+    app: FastAPI | None = None,
+    engine: "AsyncEngine | None" = None,
+) -> None:
+    """Initialise Azure Monitor OpenTelemetry and instrument the app.
 
     The ``azure-monitor-opentelemetry`` distro reads
     ``APPLICATIONINSIGHTS_CONNECTION_STRING`` from the environment
@@ -35,19 +42,32 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
     SDK automatically — set it to ``siege-api`` in the container environment
     so that ``cloud_RoleName`` is populated correctly in App Insights.
 
-    After configuring the Azure Monitor exporter, ``FastAPIInstrumentor`` is
-    used to wrap the provided *app* so that every inbound HTTP request
-    generates a ``requests`` span.  This also enables automatic exception
-    capture and upstream dependency correlation.
+    After configuring the Azure Monitor exporter the following
+    instrumentations are applied:
+
+    - ``FastAPIInstrumentor`` — wraps inbound HTTP requests so that each
+      request generates a ``requests`` span with automatic exception capture
+      and upstream dependency correlation.
+    - ``SQLAlchemyInstrumentor`` — wraps every SQLAlchemy Core statement so
+      that DB round-trips appear as ``dependency`` spans in the Application
+      Map.  Requires a synchronous Engine; the async engine exposes one via
+      ``.sync_engine``.
+    - ``AsyncPGInstrumentor`` — hooks asyncpg at the library level so that
+      low-level PostgreSQL wire calls are captured even when SQLAlchemy is
+      bypassed (e.g. raw ``asyncpg.connect`` usage in migrations).
 
     Args:
         app: The FastAPI application instance to instrument.  When *None*
             no FastAPI instrumentation is applied (useful for non-HTTP
             processes or unit tests that only verify the monitor call).
+        engine: The SQLAlchemy ``AsyncEngine`` instance.  When provided,
+            ``SQLAlchemyInstrumentor`` is wired to ``engine.sync_engine``
+            so that SQL statements appear as dependency spans.  When *None*
+            SQLAlchemy instrumentation is skipped.
     """
     connection_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "").strip()
     if not connection_string:
-        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set — telemetry disabled.")
+        logger.debug("APPLICATIONINSIGHTS_CONNECTION_STRING not set" " — telemetry disabled.")
         return
 
     try:
@@ -66,11 +86,24 @@ def configure_telemetry(app: FastAPI | None = None) -> None:
             FastAPIInstrumentor().instrument_app(app)
             logger.info("FastAPI instrumented for OpenTelemetry tracing.")
 
+        if engine is not None:
+            from opentelemetry.instrumentation.sqlalchemy import (
+                SQLAlchemyInstrumentor,
+            )
+
+            SQLAlchemyInstrumentor().instrument(engine=engine.sync_engine)
+            logger.info("SQLAlchemy instrumented for OpenTelemetry DB dependency" " tracing.")
+
+        from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+
+        AsyncPGInstrumentor().instrument()
+        logger.info("asyncpg instrumented for OpenTelemetry DB dependency tracing.")
+
     # Catch-all: telemetry init failures must never crash the app.
     # Azure SDK init can raise ValueError (bad connection string),
     # ConnectionError (network), or ImportError (missing optional deps).
     # A failure here is always logged at ERROR and then swallowed.
     except Exception:  # pragma: no cover
         logger.exception(
-            "Failed to configure Azure Monitor OpenTelemetry; continuing without telemetry."
+            "Failed to configure Azure Monitor OpenTelemetry;" " continuing without telemetry."
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ PyJWT>=2.9
 cryptography>=43
 azure-monitor-opentelemetry>=1.6
 opentelemetry-instrumentation-fastapi>=0.50b0
+opentelemetry-instrumentation-sqlalchemy>=0.50b0
+opentelemetry-instrumentation-asyncpg>=0.50b0

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -253,3 +253,223 @@ class TestConfigureTelemetryFastAPIInstrumentation:
 
         mock_configure.assert_called_once()
         mock_instrumentor.instrument_app.assert_not_called()
+
+
+class TestConfigureTelemetrySQLAlchemyInstrumentation:
+    """SQLAlchemyInstrumentor must be called when engine is provided.
+
+    Issue #257: DB dependencies were invisible in App Insights because
+    SQLAlchemy spans were never emitted.  The fix wires
+    SQLAlchemyInstrumentor to the async engine's underlying sync_engine
+    so that every SQL statement appears as a ``dependency`` span.
+    """
+
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_sqlalchemy_instrument_called_with_sync_engine(self, monkeypatch):
+        """SQLAlchemyInstrumentor().instrument(engine=...) is called with
+        the engine's sync_engine when an engine is provided.
+
+        The SQLAlchemy OTel instrumentor only accepts a synchronous Engine
+        object.  Async engines expose their underlying sync engine via the
+        ``.sync_engine`` attribute — that is what must be passed.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        mock_sqlalchemy_instrumentor = MagicMock()
+        mock_sqlalchemy_instrumentor_cls = MagicMock(return_value=mock_sqlalchemy_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_sqlalchemy_module = MagicMock()
+        fake_sqlalchemy_module.SQLAlchemyInstrumentor = mock_sqlalchemy_instrumentor_cls
+
+        # Simulate an async engine whose .sync_engine is a sentinel object.
+        fake_sync_engine = MagicMock(name="sync_engine")
+        fake_engine = MagicMock(name="async_engine")
+        fake_engine.sync_engine = fake_sync_engine
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.sqlalchemy": fake_sqlalchemy_module,
+                "opentelemetry.instrumentation.asyncpg": MagicMock(AsyncPGInstrumentor=MagicMock()),
+            },
+        ):
+            telemetry_module.configure_telemetry(engine=fake_engine)
+
+        mock_sqlalchemy_instrumentor.instrument.assert_called_once_with(engine=fake_sync_engine)
+
+    def test_sqlalchemy_instrument_not_called_when_engine_is_none(self, monkeypatch):
+        """SQLAlchemyInstrumentor().instrument() is NOT called when no
+        engine argument is supplied.
+
+        When configure_telemetry() is called without an engine (e.g. from
+        the test suite or a non-DB process), the function must skip
+        SQLAlchemy instrumentation rather than raising AttributeError on
+        a None engine.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        mock_sqlalchemy_instrumentor = MagicMock()
+        mock_sqlalchemy_instrumentor_cls = MagicMock(return_value=mock_sqlalchemy_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_sqlalchemy_module = MagicMock()
+        fake_sqlalchemy_module.SQLAlchemyInstrumentor = mock_sqlalchemy_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.sqlalchemy": fake_sqlalchemy_module,
+                "opentelemetry.instrumentation.asyncpg": MagicMock(AsyncPGInstrumentor=MagicMock()),
+            },
+        ):
+            telemetry_module.configure_telemetry(engine=None)
+
+        mock_sqlalchemy_instrumentor.instrument.assert_not_called()
+
+    def test_sqlalchemy_instrument_not_called_when_telemetry_unconfigured(self, monkeypatch):
+        """SQLAlchemyInstrumentor().instrument() is NOT called when
+        APPLICATIONINSIGHTS_CONNECTION_STRING is absent.
+
+        If telemetry is disabled (no connection string), neither the Azure
+        Monitor nor any instrumentors should be called, even if an engine
+        is passed.
+        """
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_sqlalchemy_instrumentor = MagicMock()
+        mock_sqlalchemy_instrumentor_cls = MagicMock(return_value=mock_sqlalchemy_instrumentor)
+        fake_sqlalchemy_module = MagicMock()
+        fake_sqlalchemy_module.SQLAlchemyInstrumentor = mock_sqlalchemy_instrumentor_cls
+
+        fake_sync_engine = MagicMock(name="sync_engine")
+        fake_engine = MagicMock(name="async_engine")
+        fake_engine.sync_engine = fake_sync_engine
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(),
+                "opentelemetry.instrumentation.sqlalchemy": fake_sqlalchemy_module,
+                "opentelemetry.instrumentation.asyncpg": MagicMock(AsyncPGInstrumentor=MagicMock()),
+            },
+        ):
+            telemetry_module.configure_telemetry(engine=fake_engine)
+
+        mock_sqlalchemy_instrumentor.instrument.assert_not_called()
+
+
+class TestConfigureTelemetryAsyncPGInstrumentation:
+    """AsyncPGInstrumentor must be called whenever telemetry is active.
+
+    Issue #257: asyncpg spans were absent because AsyncPGInstrumentor was
+    never initialised.  Unlike the SQLAlchemy instrumentor, it needs no
+    engine argument — it hooks asyncpg at the library level globally.
+    """
+
+    _FAKE_CS = (
+        "InstrumentationKey=00000000-0000-0000-0000-000000000000;"
+        "IngestionEndpoint=https://eastus-1.in.applicationinsights.azure.com/;"
+        "LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+    )
+
+    def test_asyncpg_instrument_called_when_telemetry_configured(self, monkeypatch):
+        """AsyncPGInstrumentor().instrument() is called when telemetry is
+        active, regardless of whether an engine is provided.
+
+        asyncpg is hooked globally — no engine argument is required or
+        accepted.
+        """
+        monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", self._FAKE_CS)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_configure = MagicMock()
+        mock_asyncpg_instrumentor = MagicMock()
+        mock_asyncpg_instrumentor_cls = MagicMock(return_value=mock_asyncpg_instrumentor)
+
+        fake_azure_module = MagicMock()
+        fake_azure_module.configure_azure_monitor = mock_configure
+        fake_asyncpg_module = MagicMock()
+        fake_asyncpg_module.AsyncPGInstrumentor = mock_asyncpg_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": fake_azure_module,
+                "opentelemetry.instrumentation.sqlalchemy": MagicMock(
+                    SQLAlchemyInstrumentor=MagicMock()
+                ),
+                "opentelemetry.instrumentation.asyncpg": fake_asyncpg_module,
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_asyncpg_instrumentor.instrument.assert_called_once_with()
+
+    def test_asyncpg_instrument_not_called_when_telemetry_unconfigured(self, monkeypatch):
+        """AsyncPGInstrumentor().instrument() is NOT called when
+        APPLICATIONINSIGHTS_CONNECTION_STRING is absent.
+
+        No telemetry initialisation of any kind should occur when the
+        connection string is missing.
+        """
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+
+        import importlib
+
+        import app.telemetry as telemetry_module
+
+        importlib.reload(telemetry_module)
+
+        mock_asyncpg_instrumentor = MagicMock()
+        mock_asyncpg_instrumentor_cls = MagicMock(return_value=mock_asyncpg_instrumentor)
+        fake_asyncpg_module = MagicMock()
+        fake_asyncpg_module.AsyncPGInstrumentor = mock_asyncpg_instrumentor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "azure.monitor.opentelemetry": MagicMock(),
+                "opentelemetry.instrumentation.sqlalchemy": MagicMock(
+                    SQLAlchemyInstrumentor=MagicMock()
+                ),
+                "opentelemetry.instrumentation.asyncpg": fake_asyncpg_module,
+            },
+        ):
+            telemetry_module.configure_telemetry()
+
+        mock_asyncpg_instrumentor.instrument.assert_not_called()

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -423,12 +423,27 @@ exceptions
 | where cloud_RoleName == "siege-api"
 | where timestamp > ago(1h)
 
--- PostgreSQL dependency calls
+-- PostgreSQL dependency calls (SQLAlchemy + asyncpg spans — see note below)
 dependencies
 | where cloud_RoleName == "siege-api"
 | where type == "postgresql"
 | where timestamp > ago(1h)
+
+-- Verify DB dependency type emitted after first dev deploy (issue #257)
+-- The exact value of `type` depends on which instrumentor produced the span:
+-- SQLAlchemyInstrumentor typically emits "postgresql", AsyncPGInstrumentor
+-- may emit a different string.  Run this after the first dev deploy to confirm:
+dependencies
+| where cloud_RoleName == "siege-api"
+| distinct type
 ```
+
+> **Post-deploy verification (issue #257):** After deploying the first revision
+> that includes DB OTel instrumentation, run the `distinct type` query above in
+> Application Insights → Logs to confirm PostgreSQL dependency spans are
+> appearing.  The expected `type` values are `"postgresql"` (SQLAlchemy) and
+> potentially a separate entry from asyncpg — verify the exact strings against
+> the live data and update this note accordingly.
 
 The Application Map should render three named nodes: `siege-api`, `siege-bot`,
 and the PostgreSQL database, connected by traffic edges.  If the map shows
@@ -458,7 +473,10 @@ Click into Edit mode to modify; layout is deployed from `infra/modules/workbook.
 
 ### 6B. Alert Inventory
 
-Four alert rules are active in both dev and prod (a fifth — DB connection errors — is deferred to #257 pending SQLAlchemy/asyncpg OTel instrumentation):
+Four alert rules are active in both dev and prod.  A fifth alert (DB connection
+errors) can be wired once DB dependency spans are confirmed in App Insights
+after the #257 deploy (see the post-deploy verification note in the KQL block
+above):
 
 | Alert | Threshold | Meaning | First action |
 |---|---|---|---|

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -445,6 +445,17 @@ dependencies
 > potentially a separate entry from asyncpg — verify the exact strings against
 > the live data and update this note accordingly.
 
+To detect whether both instrumentors are producing duplicate spans for the same
+database calls, run:
+
+```kusto
+dependencies | where cloud_RoleName == "siege-api" | summarize count() by type, target | order by count_ desc
+```
+
+If both `postgresql` (asyncpg) and a SQLAlchemy-emitted type appear with
+comparable counts for the same `target`, the AsyncPG instrumentor can be
+removed in a follow-up PR (see #257 review thread).
+
 The Application Map should render three named nodes: `siege-api`, `siege-bot`,
 and the PostgreSQL database, connected by traffic edges.  If the map shows
 `unknown_service` instead, verify that `OTEL_SERVICE_NAME` is set on the


### PR DESCRIPTION
## Summary

- Adds `opentelemetry-instrumentation-sqlalchemy>=0.50b0` and `opentelemetry-instrumentation-asyncpg>=0.50b0` to `backend/requirements.txt`
- Extends `configure_telemetry()` in `backend/app/telemetry.py` with an optional `engine` argument; wires `SQLAlchemyInstrumentor` to `engine.sync_engine` and calls `AsyncPGInstrumentor().instrument()` globally whenever telemetry is active
- Updates `backend/app/main.py` to pass the module-level `engine` into `configure_telemetry(app=app, engine=engine)`
- Adds 5 new tests in `backend/tests/test_telemetry.py` covering both instrumentors: called when wired, skipped when engine is None, skipped when telemetry unconfigured
- Updates `docs/RUNBOOK.md` Section 6 with KQL to verify DB dependency spans post-deploy and a post-deploy verification note for the exact `type` string emitted by each instrumentor

## Files changed

- `backend/requirements.txt` — two new OTel instrumentation packages
- `backend/app/telemetry.py` — `engine` parameter + SQLAlchemy and asyncpg instrumentation blocks
- `backend/app/main.py` — pass `engine` into `configure_telemetry`
- `backend/tests/test_telemetry.py` — 5 new TDD tests (SQLAlchemy × 3, asyncpg × 2)
- `docs/RUNBOOK.md` — Section 6 KQL updated; post-deploy verification note added

## Post-deploy verification (your job — no Azure access here)

Run this KQL in Application Insights → Logs after the first dev deploy to confirm DB spans appear and identify the exact `type` value:

```kusto
dependencies
| where cloud_RoleName == "siege-api"
| distinct type
```

Expected: `"postgresql"` from SQLAlchemyInstrumentor; asyncpg may emit a separate entry. Update the RUNBOOK note once confirmed.

Closes #257

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*