### PR TITLE
feat(obs): add DB dependency p95 tile + DB connection error alert

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -487,17 +487,15 @@ Click into Edit mode to modify; layout is deployed from `infra/modules/workbook.
 
 ### 6B. Alert Inventory
 
-Four alert rules are active in both dev and prod.  A fifth alert (DB connection
-errors) can now be wired — DB dependency spans are confirmed in App Insights
-as of 2026-04-30 (PR #265; type `"postgresql"`, Pattern A — see the KQL block
-above):
+Five alert rules are active in both dev and prod:
 
 | Alert | Threshold | Meaning | First action |
 |---|---|---|---|
 | `alert5xxRate` | 5xx rate >1% over 5m | Backend is throwing 500s at >1% of requests | Open dev workbook Tile 2 (4xx/5xx rates), then Tile 3 (top 10 exceptions) to identify the failing endpoint |
-| `alertLatencyP95` | Request p95 >3s over 5m | At least 5% of requests taking >3s | Tile 1 (volume + p50/p95) to confirm it's not just one outlier; Tile 5 (DB p95) for DB causation |
+| `alertLatencyP95` | Request p95 >3s over 5m | At least 5% of requests taking >3s | Tile 1 (volume + p50/p95) to confirm it's not just one outlier; Tile 6 (DB query duration) for DB causation |
 | `alertBotRestart` | Any restart | `siege-bot` process restarted (Container App revision recycled, OOM, crash, or deploy) | Check Container App revisions blade in Azure portal for restart cause; query `traces` for the bot in the 5 min before the alert fired |
 | `alertImageGenSlow` | Image gen p95 >10s | Playwright image generation latency degraded | Check `requests \| where name has "generate-images"`; usually correlates with high concurrent image gen or Playwright pool exhaustion |
+| `alertDbConnectionError` | Any failed PostgreSQL dependency in 5m | siege-api cannot reach the database; all data-path requests will 500 | Check `database-url` secret; check firewall rules; check pool exhaustion — see existing 'DB connection errors' row in 'What to watch' table |
 
 ### 6C. Acknowledgement Policy
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -10,11 +10,12 @@ lifecycle. Vitest component tests cover the assignment board and notification po
 is fully deployed for both dev and prod environments via GitHub Actions CD pipelines.
 
 As of 2026-04-30 (v1.0.1, issue #246), the observability layer is live in both dev and prod: an
-Application Insights workbook (5 tiles — request rates, latency p50/p95, exception counts, bot restarts,
-image gen latency) plus 4 active alert rules (`alert5xxRate`, `alertLatencyP95`, `alertBotRestart`,
-`alertImageGenSlow`) wired to an email action group. SQLAlchemy/asyncpg OTel instrumentation shipped in PR #265; dev verification on 2026-04-30 confirmed
-Pattern A (type `"postgresql"`, no span duplication). The DB connection error alert and DB p95 tile
-can now be wired as follow-on work. See RUNBOOK.md §6 for workbook URLs, alert inventory, and acknowledgement policy.
+Application Insights workbook (6 tiles — request rates, latency p50/p95, exception counts, bot restarts,
+image gen latency, DB query duration p95) plus 5 active alert rules (`alert5xxRate`, `alertLatencyP95`,
+`alertBotRestart`, `alertImageGenSlow`, `alertDbConnectionError`) wired to an email action group.
+SQLAlchemy/asyncpg OTel instrumentation shipped in PR #265; dev verification on 2026-04-30 confirmed
+Pattern A (type `"postgresql"`, no span duplication). The DB tile and alert were deferred from #246 and
+are now wired in PR #270. See RUNBOOK.md §6 for workbook URLs, alert inventory, and acknowledgement policy.
 
 ## Phase Completion
 
@@ -103,4 +104,4 @@ CI via GitHub Actions on every PR to `main`:
 
 ## Active Workstream — Infra Hygiene & Cost (Milestone #6)
 
-Issue #246 (workbook + alerts) is closed. **#257** (SQLAlchemy/asyncpg OTel instrumentation) shipped in PR #265 (commit `9a11733`) and is resolved: dev verification on 2026-04-30 confirmed Pattern A — `type == "postgresql"`, single row per `target`, no span duplication; both instrumentors retained. RUNBOOK.md §6 updated accordingly (PR #269). The DB connection error alert rule and DB p95 workbook tile can now be wired as follow-on work.
+Issue #246 (workbook + alerts) is closed. **#257** (SQLAlchemy/asyncpg OTel instrumentation) shipped in PR #265 (commit `9a11733`) and is resolved: dev verification on 2026-04-30 confirmed Pattern A — `type == "postgresql"`, single row per `target`, no span duplication; both instrumentors retained. RUNBOOK.md §6 updated accordingly (PR #269). The two items deferred from #246 pending DB telemetry are now addressed in PR #270: the DB query duration p95 workbook tile (Tile 6) and the DB connection error alert rule (`alertDbConnectionError`, alert 5) are wired and deploy with the next `infra-deploy.yml` run.

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -239,7 +239,7 @@ resource alertDbConnectionError 'Microsoft.Insights/scheduledQueryRules@2023-12-
   location: location
   tags: tags
   properties: {
-    displayName: 'Siege Web — DB connection error'
+    displayName: '[${environment}] siege-api — DB connection error'
     description: 'Fires when any PostgreSQL dependency call from siege-api fails in a 5-minute window. DB spans confirmed in App Insights 2026-04-30 (PR #265, Pattern A).'
     enabled: true
     severity: 2
@@ -253,11 +253,10 @@ resource alertDbConnectionError 'Microsoft.Insights/scheduledQueryRules@2023-12-
         {
           query: '''
 dependencies
-| where timestamp > ago(5m)
 | where cloud_RoleName == "siege-api"
 | where type == "postgresql"
 | where success == false
-| summarize FailureCount = count() by bin(timestamp, 5m)
+| summarize FailureCount = count()
 | where FailureCount > 0
 '''
           timeAggregation: 'Count'

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -226,11 +226,55 @@ traces
   }
 }
 
-// Alert 4 (DB connection error) deferred to follow-up PR.
-// Blocked by #257 — backend's OTel pipeline is missing SQLAlchemy + asyncpg
-// instrumentors, so DB dependency spans don't exist in App Insights yet.
-// Re-add after #257 ships and `dependencies | where cloud_RoleName == "siege-api"`
-// shows real PostgreSQL rows.
+// ── Alert 4: DB connection error ─────────────────────────────────────────────
+// Severity 2 — page-worthy; any failed PostgreSQL dependency means the backend
+// cannot reach the database and all data-path requests will 500.
+//
+// Previously deferred (PR #246) pending #257. DB dependency spans confirmed in
+// App Insights as of 2026-04-30 (PR #265, commit 9a11733): type == "postgresql",
+// Pattern A (no span duplication). Blocker removed — alert wired here.
+
+resource alertDbConnectionError 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: '${appPrefix}-alert-db-connection-error-${environment}'
+  location: location
+  tags: tags
+  properties: {
+    displayName: 'Siege Web — DB connection error'
+    description: 'Fires when any PostgreSQL dependency call from siege-api fails in a 5-minute window. DB spans confirmed in App Insights 2026-04-30 (PR #265, Pattern A).'
+    enabled: true
+    severity: 2
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    scopes: [appInsightsId]
+    autoMitigate: false
+    muteActionsDuration: 'PT15M'
+    criteria: {
+      allOf: [
+        {
+          query: '''
+dependencies
+| where timestamp > ago(5m)
+| where cloud_RoleName == "siege-api"
+| where type == "postgresql"
+| where success == false
+| summarize FailureCount = count() by bin(timestamp, 5m)
+| where FailureCount > 0
+'''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+        }
+      ]
+    }
+    actions: {
+      actionGroups: [actionGroup.id]
+    }
+  }
+}
 
 // ── Alert 5: Image generation > 10s ──────────────────────────────────────────
 // Severity 3 — warning; slow renders degrade UX but requests still complete.

--- a/infra/modules/workbook.template.json
+++ b/infra/modules/workbook.template.json
@@ -80,6 +80,22 @@
         "visualization": "linechart"
       },
       "name": "Image generation duration"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "dependencies\n| where cloud_RoleName == \"siege-api\"\n| where type == \"postgresql\"\n| summarize p50 = percentile(duration, 50),\n            p95 = percentile(duration, 95),\n            Max = max(duration)\n            by bin(timestamp, 5m)\n| order by timestamp asc",
+        "size": 0,
+        "title": "Database query duration (siege-api → PostgreSQL)",
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "linechart"
+      },
+      "name": "Database query duration (siege-api → PostgreSQL)"
     }
   ],
   "fallbackResourceIds": [


### PR DESCRIPTION
## Summary

- **Tile 6** added to `infra/modules/workbook.template.json`: DB query duration p95 linechart (`dependencies | where type == "postgresql"`, matching the structure of Tile 5 — image gen duration)
- **`alertDbConnectionError`** added to `infra/modules/monitoring.bicep`: severity 2, PT5M window, fires on any failed PostgreSQL dependency from `siege-api`; structure mirrors `alert5xxRate` exactly
- **RUNBOOK.md §6B** updated: alert count 4 → 5, new `alertDbConnectionError` row added with first-response action
- **STATUS.md** updated: reflects 6 tiles + 5 alerts; records that the two items deferred from #246 are addressed here

Both items were deferred from PR #246 pending DB OTel instrumentation (#257). PR #265 (commit `9a11733`) shipped SQLAlchemy/asyncpg spans; dev verification on 2026-04-30 confirmed Pattern A (`type == "postgresql"`, no span duplication). Blocker removed.

## Verification (pre-merge)

- `az bicep build --file infra/modules/monitoring.bicep` — compiled clean (version upgrade advisory only, no errors)
- `python -c "import json; json.load(open('infra/modules/workbook.template.json'))"` — JSON valid

## Test plan (post-merge — manual)

After merge, trigger `infra-deploy.yml` → dev → ref `main`:

1. Confirm Tile 6 (DB query duration) renders in the dev workbook (App Insights → Workbooks → Siege App Health)
2. Confirm `alertDbConnectionError` appears in Azure Monitor → Alerts → Alert rules in `Enabled` state
3. Once dev is verified, trigger `infra-deploy.yml` → prod → ref `main`

> Note: synthetic DB connection error testing to confirm the alert fires end-to-end is tracked separately — see #270 for the verification checklist.

Closes #270

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_