### PR TITLE
fix(validation): count broken-building assignments in scroll budget (#253)

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -58,8 +58,7 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
             for position in group.positions:
                 all_positions.append((position, group, building))
 
-    # Broken-building exclusion — intentional asymmetry between scroll limit and assignment
-    # accounting:
+    # Scroll accounting notes:
     #
     #   - SCROLL LIMIT (compute_scroll_count in sieges.py) includes ALL buildings regardless
     #     of is_broken.  It sums theoretical capacity by building type + level from game data,
@@ -68,11 +67,10 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
     #     can happen once a siege is active (update_building in buildings.py rejects all
     #     building changes, including breaking, when the siege is active or complete).
     #
-    #   - SCROLL BUDGET usage (assignments_by_member, Rule 2) excludes broken buildings —
-    #     assignments on broken buildings do not burn the per-member scroll allowance because
-    #     those buildings are not active defenders.  The asymmetry is intentional: the scroll
-    #     limit counts every slot that *could* be defended; the budget only charges for slots
-    #     that *are* actively defended.
+    #   - SCROLL BUDGET usage (assignments_by_member, Rule 2) includes ALL buildings
+    #     regardless of is_broken.  Both the limit and the per-member assignment count
+    #     treat broken buildings identically — a member assigned to a broken building
+    #     still consumes a scroll slot from their allowance.
     #
     #   - COUNTING rules that are NOT scroll-related (Rule 15 reserve-set check) use
     #     all_assigned_member_ids, which INCLUDES broken buildings — every assigned member
@@ -82,18 +80,13 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
     #   - STRUCTURAL rules (Rules 1, 3, 4, 5, 7, 8, 9, 11) still check broken buildings —
     #     a broken building can still have invalid configuration or invalid assignments.
 
-    # Scroll-budget usage counter: excludes broken buildings because assignments on
-    # broken buildings do not count against the per-member scroll limit (Rule 2).
-    # Note: other rules (e.g. Rule 15) use all_assigned_member_ids which includes
+    # Scroll-budget usage counter: includes ALL buildings (broken or healthy) so that
+    # the per-member assignment count matches what the scroll limit already charges for.
+    # Note: other rules (e.g. Rule 15) use all_assigned_member_ids which also includes
     # broken buildings, because those rules are not scroll-related.
     assignments_by_member: dict[int, int] = defaultdict(int)
     for pos, group, building in all_positions:
-        if (
-            pos.member_id is not None
-            and not pos.is_reserve
-            and not pos.is_disabled
-            and not building.is_broken
-        ):
+        if pos.member_id is not None and not pos.is_reserve and not pos.is_disabled:
             assignments_by_member[pos.member_id] += 1
 
     # Build siege_member lookup by member_id

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -252,18 +252,16 @@ async def test_rule1_active_member_no_error():
 
 
 @pytest.mark.asyncio
-async def test_rule2_broken_building_assignment_not_counted():
-    """Rule 2: assignment on a broken building does not count toward the scroll limit (issue #94).
+async def test_rule2_broken_building_assignment_counts_toward_scroll_limit():
+    """Rule 2 regression (#253): assignments on broken buildings count toward scroll budget.
 
-    A member is assigned to 3 positions on a broken building.  compute_scroll_count (mocked to
-    return 5) gives a limit of 3.  If broken positions were counted, the member would appear to
-    have 3 assignments and — at the boundary — the test would still pass, so we add a 4th
-    position on the broken building (which would clearly exceed the limit if counted) to make
-    the exclusion unambiguous.  No Rule 2 error should fire because all assignments are on a
-    broken building and are excluded from scroll accounting.
+    A member is assigned to 4 positions on a broken building.
+    compute_scroll_count (mocked to return 5) gives a limit of 3.
+    All 4 assignments must count regardless of is_broken, so Rule 2
+    must fire with count=4 and limit=3.
     """
     member = _make_member(id=1, is_active=True)
-    # 4 positions on a broken building — would exceed the limit of 3 if counted
+    # 4 positions on a broken building — exceeds the limit of 3 when counted
     positions = [
         _make_position(id=i, position_number=i, member_id=1, member=member) for i in range(1, 5)
     ]
@@ -279,27 +277,25 @@ async def test_rule2_broken_building_assignment_not_counted():
     siege.siege_members = [sm]
 
     # compute_scroll_count returns 5 → limit = 3.  Member has 4 assignments on a
-    # broken building; they must all be excluded so no Rule 2 error fires.
+    # broken building; they must all count, so Rule 2 must fire.
     session = _session_with_siege_and_configs(siege)
     result = await svc_validate(session, 1)
     rule2_errors = [e for e in result.errors if e.rule == 2]
-    assert len(rule2_errors) == 0, (
-        "Assignments on broken buildings must not count toward the scroll limit; "
-        f"unexpected Rule 2 errors: {rule2_errors}"
+    assert len(rule2_errors) >= 1, (
+        "Assignments on broken buildings must count toward the scroll limit; "
+        "Rule 2 should have fired but did not"
     )
+    assert rule2_errors[0].context["count"] == 4
+    assert rule2_errors[0].context["limit"] == 3
 
 
 @pytest.mark.asyncio
-async def test_rule2_mixed_broken_and_healthy_assignments_not_counted():
-    """Rule 2: assignments on a broken building are excluded even when healthy ones also exist.
+async def test_rule2_broken_and_healthy_both_count_toward_scroll_limit():
+    """Rule 2: assignments on broken buildings add to healthy-building count.
 
     Member has 2 assignments on a healthy building + 2 assignments on a broken building.
     compute_scroll_count (mocked to return 5) → limit = 3.
-    Only the 2 healthy assignments count; 2 < 3, so Rule 2 must NOT fire.
-
-    If the broken-building exclusion were absent, the total would be 4 which exceeds the
-    limit of 3, and Rule 2 would incorrectly fire.  This test distinguishes that case from
-    test_rule2_broken_building_assignment_not_counted (which uses 0 healthy assignments).
+    Total count = 4 (both healthy and broken), which exceeds 3, so Rule 2 must fire.
     """
     member = _make_member(id=1, is_active=True)
 
@@ -329,14 +325,15 @@ async def test_rule2_mixed_broken_and_healthy_assignments_not_counted():
     siege.siege_members = [sm]
 
     # compute_scroll_count returns 5 → limit = 3.
-    # Healthy-building count = 2, which is within the limit → no Rule 2 error.
+    # Total count = 4 (2 healthy + 2 broken) → exceeds limit → Rule 2 must fire.
     session = _session_with_siege_and_configs(siege)
     result = await svc_validate(session, 1)
     rule2_errors = [e for e in result.errors if e.rule == 2]
-    assert len(rule2_errors) == 0, (
-        "Only healthy-building assignments should count toward the scroll limit; "
-        f"unexpected Rule 2 errors: {rule2_errors}"
+    assert len(rule2_errors) >= 1, (
+        "Broken-building assignments must add to the scroll budget total; "
+        "Rule 2 should have fired but did not"
     )
+    assert rule2_errors[0].context["count"] == 4
 
 
 @pytest.mark.asyncio

--- a/frontend/src/test/pages/BoardPage.test.tsx
+++ b/frontend/src/test/pages/BoardPage.test.tsx
@@ -8,6 +8,9 @@
  *  - Context-menu actions: Mark RESERVE, Mark No Assignment, Clear, Assign member
  *  - MemberBucket search and role-filter interactions
  *  - Locked (siege complete) board — context menu button hidden, auto-fill disabled
+ *  - Validation dialog: error-severity rows render with red badge and message
+ *  - Validation dialog: warning-severity rows render with yellow badge and message
+ *  - Validation dialog: "No issues found" shown when both arrays empty
  */
 
 import { screen, waitFor, within } from "@testing-library/react";
@@ -603,6 +606,97 @@ describe("BoardPage — action buttons", () => {
 
     // BuildingTypeSection renders the type label via BUILDING_LABELS; CSS uppercase doesn't change DOM text
     expect(screen.getByText("Stronghold")).toBeInTheDocument();
+  });
+});
+
+// ─── Validation dialog ────────────────────────────────────────────────────
+
+describe("BoardPage — validation dialog", () => {
+  it("renders error-severity rows with destructive badge when validate returns errors", async () => {
+    const user = userEvent.setup();
+    setupDefaultHandlers();
+    server.use(
+      http.post("/api/sieges/42/validate", () =>
+        HttpResponse.json({
+          errors: [
+            {
+              rule: 1,
+              message: "Assigned member 'Alice' is not active",
+              context: null,
+            },
+          ],
+          warnings: [],
+        })
+      )
+    );
+    renderBoard();
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/error 1/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/assigned member 'alice' is not active/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders warning-severity rows with yellow badge when validate returns warnings", async () => {
+    const user = userEvent.setup();
+    setupDefaultHandlers();
+    server.use(
+      http.post("/api/sieges/42/validate", () =>
+        HttpResponse.json({
+          errors: [],
+          warnings: [
+            {
+              rule: 10,
+              message: "Building has fewer members than recommended",
+              context: null,
+            },
+          ],
+        })
+      )
+    );
+    renderBoard();
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/warning 10/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/building has fewer members than recommended/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'No issues found' when validate returns empty errors and warnings", async () => {
+    const user = userEvent.setup();
+    setupDefaultHandlers();
+    server.use(
+      http.post("/api/sieges/42/validate", () =>
+        HttpResponse.json({ errors: [], warnings: [] })
+      )
+    );
+    renderBoard();
+    await waitFor(() =>
+      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole("button", { name: /^validate$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/no issues found/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/test/pages/SiegeSettingsPage.test.tsx
+++ b/frontend/src/test/pages/SiegeSettingsPage.test.tsx
@@ -14,6 +14,9 @@
  *  - Polling stops once all result items have success !== null
  *  - "Post to Discord" confirm dialog → success message / error message
  *  - "Post to Discord" button disabled when siege is complete
+ *  - Validation panel: error-severity rows render with red badge and message
+ *  - Validation panel: warning-severity rows render with yellow badge and message
+ *  - Notification-blocked banner appears when validate returns errors
  */
 
 import { screen, waitFor, within, act } from "@testing-library/react";
@@ -35,6 +38,7 @@ import { server } from "../server";
 import SiegeSettingsPage from "../../pages/SiegeSettingsPage";
 import type {
   Siege,
+  ValidationResult,
   NotifyResponse,
   NotificationBatchResponse,
   NotificationResultItem,
@@ -98,16 +102,32 @@ function makeBatchResponse(
 
 // ─── Render helper ────────────────────────────────────────────────────────────
 //
-// SiegeSettingsPage reads three routes on mount:
-//   GET /api/sieges/42          — siege details
-//   GET /api/sieges/42/buildings — building list
-//   GET /api/sieges/42/members   — siege member list
+// SiegeSettingsPage reads four routes on mount:
+//   GET /api/sieges/42              — siege details
+//   GET /api/sieges/42/buildings    — building list
+//   GET /api/sieges/42/members      — siege member list
+//   POST /api/sieges/42/validate    — eager validation (gates Notify button)
+//
+// validateResult defaults to an empty-pass response so the Notify button is
+// enabled in tests that don't care about validation state. Pass a custom value
+// to test error / warning rendering.
 
-function renderPage(siege: Siege = makeSiege()) {
+const emptyValidation: ValidationResult = { errors: [], warnings: [] };
+
+function renderPage(
+  siege: Siege = makeSiege(),
+  validateResult: ValidationResult = emptyValidation
+) {
   server.use(
     http.get("/api/sieges/42", () => HttpResponse.json(siege)),
     http.get("/api/sieges/42/buildings", () => HttpResponse.json([])),
-    http.get("/api/sieges/42/members", () => HttpResponse.json([]))
+    http.get("/api/sieges/42/members", () => HttpResponse.json([])),
+    // SiegeSettingsPage eagerly calls validateSiege on mount to gate the Notify
+    // button. Without this handler the mutation fails silently and validation
+    // state stays null, hiding error rows and the notification-blocked banner.
+    http.post("/api/sieges/42/validate", () =>
+      HttpResponse.json(validateResult)
+    )
   );
 
   const queryClient = new QueryClient({
@@ -722,5 +742,68 @@ describe("SiegeSettingsPage — Post to Discord", () => {
     expect(
       screen.getByRole("button", { name: /post to discord/i })
     ).toBeDisabled();
+  });
+});
+
+// ─── Validation panel ─────────────────────────────────────────────────────
+
+describe("SiegeSettingsPage — validation panel", () => {
+  it("renders error-severity rows with destructive badge when validate returns errors", async () => {
+    // Pass the error response directly to renderPage so it is registered
+    // before the component mounts and fires the eager validateMutation.
+    renderPage(makeSiege(), {
+      errors: [
+        {
+          rule: 1,
+          message: "Assigned member 'Alice' is not active",
+          context: null,
+        },
+      ],
+      warnings: [],
+    });
+    await waitForPageLoad();
+
+    // Eager validation fires on mount; wait for error row to appear
+    await waitFor(() =>
+      expect(screen.getByText(/error 1/i)).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText(/assigned member 'alice' is not active/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders warning-severity rows with yellow badge when validate returns warnings", async () => {
+    renderPage(makeSiege(), {
+      errors: [],
+      warnings: [
+        {
+          rule: 10,
+          message: "Building has fewer members than recommended",
+          context: null,
+        },
+      ],
+    });
+    await waitForPageLoad();
+
+    await waitFor(() =>
+      expect(screen.getByText(/warning 10/i)).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText(/building has fewer members than recommended/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the notification-blocked banner when validate returns errors", async () => {
+    renderPage(makeSiege(), {
+      errors: [
+        { rule: 2, message: "Duplicate member assignment", context: null },
+      ],
+      warnings: [],
+    });
+    await waitForPageLoad();
+
+    await waitFor(() =>
+      expect(screen.getByText(/notifications blocked/i)).toBeInTheDocument()
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes a post-v1.0 regression where validation **errors** of severity Rule 2 (member-over-scroll-limit) silently failed to fire when one of a member's assignments was on a broken building. The user-visible symptom was "warnings render, errors do not" on the prod board — but the actual cause was on the backend, in the rule-emission counter.

The bug was reproducible in prod and not in dev because the dev seed data had no broken buildings.

## Root cause

`backend/app/services/validation.py` excluded broken-building assignments from the per-member scroll-budget counter (`assignments_by_member`):

```python
if (
    pos.member_id is not None
    and not pos.is_reserve
    and not pos.is_disabled
    and not building.is_broken    # ← this clause
):
    assignments_by_member[pos.member_id] += 1
```

A member with 5 visible assignments where one was on a broken building counted as 4 internally. With `scroll_limit = 4`, the predicate `count > scroll_limit` evaluated `4 > 4 = False`, and Rule 2 never fired.

The exclusion was documented as intentional in the comment block at lines 61-83, on the rationale that broken buildings "are not active defenders." That rationale produced wrong product behavior: broken buildings count toward the **scroll limit** (`compute_scroll_count` includes them), so the asymmetric exclusion penalised members for assignments to broken buildings without crediting them with the corresponding budget.

## Fix

- Removed the `and not building.is_broken` clause from the counter.
- Rewrote the doc-comment block to reflect the new symmetry between scroll-limit accounting and scroll-budget accounting (both include broken buildings).
- `is_reserve` and `is_disabled` exclusions preserved — those positions genuinely should not burn scroll budget.

Verified safe against ghost assignments: when a building is toggled broken, `update_building` in `services/buildings.py` explicitly deletes excess groups and positions (with `cascade="all, delete-orphan"` on `BuildingGroup.positions` as belt-and-suspenders). No DB-resident position survives without a UI-visible counterpart.

## Commits

- `76961d4` — `test(frontend): add validation panel rendering coverage` — frontend test mocks + 6 regression tests for validation panel error/warning/empty rendering. Independent coverage gap closed during investigation; does not fix the bug.
- `7e03a46` — `fix(validation): count broken-building assignments in scroll budget` — the actual fix + 2 backend regression tests in `test_validation.py`.

## Test plan

- [x] Backend: `pytest --ignore=tests/test_schema.py` — 307 passed, 1 pre-existing failure unrelated to this PR (`test_config.py::test_missing_environment_raises_validation_error`, already failing on `main`).
- [x] Backend: `black --check` and `ruff check` clean.
- [x] Frontend: `npm run build` succeeds, `npx eslint src/` clean. 115/115 frontend tests pass (was 109 before the test commit).
- [x] New regression tests in `test_validation.py`:
  - `test_rule2_broken_building_assignment_counts_toward_scroll_limit` — member with 4 assignments on a broken building (limit=3) → asserts Rule 2 fires.
  - `test_rule2_broken_and_healthy_both_count_toward_scroll_limit` — member with 2 healthy + 2 broken assignments (limit=3) → asserts Rule 2 fires with `count=4`.
- [ ] Manual verification in prod after merge: re-load the board state with Takair Ovsouls' 5 assignments and confirm Rule 2 fires as an error in the validation panel.

Closes #253

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*