### PR TITLE
chore(frontend): update LandingPage URLs to glitchwerks org

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -191,7 +191,7 @@ export default function LandingPage() {
           {/* GitHub icon + Sign in */}
           <div className="flex items-center gap-3">
             <a
-              href="https://github.com/cbeaulieu-gt/siege-web"
+              href="https://github.com/glitchwerks/siege-web"
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
@@ -345,7 +345,7 @@ export default function LandingPage() {
 
             <div className="text-center">
               <a
-                href="https://github.com/cbeaulieu-gt/siege-web"
+                href="https://github.com/glitchwerks/siege-web"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 px-4 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900"
@@ -385,7 +385,7 @@ export default function LandingPage() {
                   UI with zero Discord setup.
                 </p>
                 <a
-                  href="https://github.com/cbeaulieu-gt/siege-web#quick-start"
+                  href="https://github.com/glitchwerks/siege-web#quick-start"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-slate-300 px-4 py-2 text-center text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
@@ -414,7 +414,7 @@ export default function LandingPage() {
                   containers. No cloud bill.
                 </p>
                 <a
-                  href="https://github.com/cbeaulieu-gt/siege-web/wiki/Self-Host-on-Any-VPS"
+                  href="https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-violet-400 px-4 py-2 text-center text-sm font-medium text-violet-700 transition-colors hover:bg-violet-50"
@@ -438,7 +438,7 @@ export default function LandingPage() {
                   hands-off infrastructure.
                 </p>
                 <a
-                  href="https://github.com/cbeaulieu-gt/siege-web/wiki/Self-Host-on-Azure"
+                  href="https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-slate-300 px-4 py-2 text-center text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
@@ -487,12 +487,12 @@ export default function LandingPage() {
                   GitHub
                 </span>
                 <a
-                  href="https://github.com/cbeaulieu-gt/siege-web"
+                  href="https://github.com/glitchwerks/siege-web"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-violet-600 hover:underline"
                 >
-                  github.com/cbeaulieu-gt/siege-web
+                  github.com/glitchwerks/siege-web
                 </a>
               </p>
             </div>

--- a/frontend/src/test/components/LandingPage.test.tsx
+++ b/frontend/src/test/components/LandingPage.test.tsx
@@ -111,11 +111,11 @@ describe("LandingPage (anonymous user)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("self-host-anywhere-link")).toHaveAttribute(
         "href",
-        "https://github.com/cbeaulieu-gt/siege-web/wiki/Self-Host-on-Any-VPS",
+        "https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS",
       );
       expect(screen.getByTestId("self-host-azure-link")).toHaveAttribute(
         "href",
-        "https://github.com/cbeaulieu-gt/siege-web/wiki/Self-Host-on-Azure",
+        "https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure",
       );
     });
   });
@@ -125,7 +125,7 @@ describe("LandingPage (anonymous user)", () => {
     await waitFor(() => {
       expect(screen.getByText("higgsbp")).toBeInTheDocument();
       const ghLink = screen.getByRole("link", {
-        name: /github.com\/cbeaulieu-gt\/siege-web/i,
+        name: /github.com\/glitchwerks\/siege-web/i,
       });
       expect(ghLink).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary

- Replace all `cbeaulieu-gt/siege-web` references with `glitchwerks/siege-web` in `frontend/src/pages/LandingPage.tsx` (7 occurrences: nav GitHub link, open-source section link, quick-start anchor, two self-host wiki links, and the contact section href + display text)
- Replace the same pattern in `frontend/src/test/components/LandingPage.test.tsx` (3 occurrences: two exact-string href assertions and the regex literal used by the contact-section `getByRole` query)

Refs #276

## Test plan

- [ ] All 14 LandingPage tests pass (`npm test -- src/test/components/LandingPage.test.tsx`) — verified locally before push
- [ ] `git diff --stat` shows exactly 2 files changed — confirmed
- [ ] No other `cbeaulieu-gt` references touched (CODE_OF_CONDUCT.md and any script comments are handled by the parallel docs PR)

> 🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_