### PR TITLE
ci: bump third-party actions to drop Node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -74,10 +74,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -119,10 +119,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,10 +148,10 @@ jobs:
           echo "✅ All required variables present"
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -258,7 +258,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -295,7 +295,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -70,13 +70,13 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: github.event_name == 'pull_request'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Bicep
         run: az bicep install
@@ -93,7 +93,7 @@ jobs:
 
       - name: Post failure comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           # Use App token on PRs (enables @claude triggering); fall back to GITHUB_TOKEN on other events
           github-token: ${{ steps.app-token.outputs.token || github.token }}
@@ -119,13 +119,13 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: github.event_name == 'pull_request'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Bicep
         run: az bicep install
@@ -135,7 +135,7 @@ jobs:
 
       - name: Post failure comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
@@ -163,16 +163,16 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: github.event_name == 'pull_request'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -194,7 +194,7 @@ jobs:
 
       - name: Post failure comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
@@ -227,16 +227,16 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: github.event_name == 'pull_request'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -260,7 +260,7 @@ jobs:
 
       - name: Post what-if results as PR comment
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
@@ -276,7 +276,7 @@ jobs:
 
       - name: Post failure comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -139,10 +139,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Publish wiki/ to GitHub Wiki
-        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           path: wiki/
           token: ${{ secrets.WIKI_PAT }}


### PR DESCRIPTION
## Summary

Bumps every third-party action referenced in `.github/workflows/*.yml` to its current major to drop the upcoming Node 20 runtime deprecation (enforced 2026-06-02). All targets ship Node 24.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `actions/create-github-app-token` | v1 | **v3** |
| `actions/github-script` | v7 | **v9** |
| `azure/login` | v2 | **v3** |
| `Andrew-Chen-Wang/github-wiki-action` | v4 | **v5** |

`azure/container-apps-deploy-action` is already at its latest major (`v2`) and was not changed.

Internal `glitchwerks/github-actions/...` reusable-workflow refs are out of scope here — they're tracked separately in #279.

## Breaking-change exposure

Each major-version jump was checked against current usage:

- **`setup-node` v5** introduces auto-cache when `packageManager` is in `package.json`. `ci.yml` already passes `cache: "npm"` explicitly and no `packageManager` field is present, so behavior is unchanged.
- **`create-github-app-token` v2** dropped deprecated underscore inputs (`app_id`, `private_key`, `skip_token_revoke`). `infra-ci.yml` is already on the hyphenated `app-id`/`private-key`.
- **`create-github-app-token` v3** requires `NODE_USE_ENV_PROXY=1` only when proxies are in use; no proxies configured here.
- **`github-script` v9** removes `require('@actions/github')` from script context. No script in this repo uses that pattern.
- **`checkout` / `setup-python` / `azure/login`** major bumps are pure Node 24 runtime upgrades. GitHub-hosted runners auto-update past `v2.327.1`, so no runner action is required.

## Test plan

- [x] `Backend / Lint and test` runs with `actions/checkout@v6` + `actions/setup-python@v6`
- [x] `Frontend / Build, lint, test` runs with `actions/checkout@v6` + `actions/setup-node@v6` (Node 20 install via `node-version: "20"` still resolves)
- [x] `Bot / Lint and test` runs with `actions/checkout@v6` + `actions/setup-python@v6`
- [x] `Infra CI` gates pass with `actions/create-github-app-token@v3` + `actions/github-script@v9` + `azure/login@v3`
- [ ] On merge to `main`: `deploy.yml` deploys to dev with `azure/login@v3` + `azure/container-apps-deploy-action@v2`
- [ ] Wiki publish workflow successfully renders post-merge with `Andrew-Chen-Wang/github-wiki-action@v5` (verify `wiki/` content is intact)

Closes #280

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_