### PR TITLE
ci: bump glitchwerks/github-actions reusable workflows to v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,11 @@ jobs:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]
     if: failure() && github.event_name == 'pull_request'
-    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@v1
+    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@v2.3.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      gh_pat: ${{ secrets.GH_PAT }}
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       pr_number: ${{ github.event.pull_request.number }}
       run_id: ${{ github.run_id }}

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fix:
-    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@v2.3.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.3.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   respond:
-    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2.0.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2.3.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary

Bumps every reference to the internal `glitchwerks/github-actions` reusable workflows up to the latest release (`v2.3.0`).

| File | Workflow | From | To |
|---|---|---|---|
| `ci.yml` | `claude-lint-fix.yml` | **v1** | **v2.3.0** (major) |
| `claude-ci-fix.yml` | `ci-failure.yaml` | v2.0.0 | v2.3.0 (minor) |
| `claude-pr-review.yml` | `claude-pr-review.yml` | v2.0.0 | v2.3.0 (minor) |
| `claude.yml` | `claude-tag-respond.yml` | v2.0.0 | v2.3.0 (minor) |

## Minor bumps (v2.0.0 → v2.3.0)

Per [v2.3.0 release notes](https://github.com/glitchwerks/github-actions/releases/tag/v2.3.0), the v2.x series introduced Phase 6 promote/rollback automation, freshness alarms, and App permission grants — all internal to `glitchwerks/github-actions`. None of the v2.x changes alter the consumer-facing input/secret surface of the four reusable workflows we call. These are pure version bumps.

## Major bump: `claude-lint-fix.yml` v1 → v2.3.0

Signature comparison (v1.8.0 → v2.3.0):

| Secret / Input | v1 | v2.3.0 | Action taken in `ci.yml` |
|---|---|---|---|
| `gh_pat` (secret) | optional, deprecated | **removed** | removed from secrets block |
| `app_id` (secret) | optional | **required** | added: `${{ secrets.APP_ID }}` |
| `app_private_key` (secret) | optional | **required** | added: `${{ secrets.APP_PRIVATE_KEY }}` |
| `claude_code_oauth_token` (secret) | required | required | unchanged |
| `pr_number`, `run_id`, `model`, `max_turns`, `auto_apply` (inputs) | (5 inputs) | (5 inputs, identical) | unchanged |

The `APP_ID` and `APP_PRIVATE_KEY` repo secrets are already provisioned and in use by `claude-ci-fix.yml` and `claude.yml` (both at v2.0.0). The v1 → v2 boundary is effectively a PAT-to-App-token security upgrade.

## Out of scope

- Adopting v2.3.0's STAGE 5 promote pattern (digest-pin migration) — would require wiring the `claude-action-runner` App into siege-web with `workflows: write` permission. Tracked as a possible future workstream, not covered here.
- Third-party action upgrades — already shipped in #281 (closed #280).

## Test plan

- [ ] `Backend / Lint and test`, `Frontend / Build, lint, test`, `Bot / Lint and test`, `Infra CI`, all `claude-*` reusable workflows resolve at `@v2.3.0` and run successfully on this PR
- [ ] If any of the CI jobs fails, `claude-lint-fix` (v2.3.0) fires and authenticates via the App token (verify the run uses `app_id` / `app_private_key`, not `gh_pat`)
- [ ] On PR review submission, `claude-pr-review.yml@v2.3.0` runs successfully
- [ ] On `@claude` comment in an issue or PR, `claude-tag-respond.yml@v2.3.0` runs successfully (smoke verifiable post-merge)

Closes #279

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_