### PR TITLE
chore(infra): bump no-op Bicep API versions (PR A of #249)

### DIFF
--- a/infra/modules/cert-identity.bicep
+++ b/infra/modules/cert-identity.bicep
@@ -34,7 +34,7 @@ param vaultName string
 
 // ── User-assigned managed identity ───────────────────────────────────────────
 
-resource certIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource certIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: '${appPrefix}-cert-uami-${environment}'
   location: location
   tags: {
@@ -53,7 +53,7 @@ resource certIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-
 
 var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
   name: vaultName
 }
 

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -49,7 +49,7 @@ param softDeleteRetentionDays int = 7
 
 var vaultName = '${appPrefix}-kv-${environment}-${take(uniqueString(resourceGroup().id), 6)}'
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: vaultName
   location: location
   tags: {
@@ -71,49 +71,49 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   }
 }
 
-resource secretDatabaseUrl 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDatabaseUrl 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'database-url'
   properties: { value: databaseUrl }
 }
 
-resource secretDiscordToken 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDiscordToken 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'discord-token'
   properties: { value: discordToken }
 }
 
-resource secretDiscordGuildId 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDiscordGuildId 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'discord-guild-id'
   properties: { value: discordGuildId }
 }
 
-resource secretDiscordBotApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDiscordBotApiKey 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'discord-bot-api-key'
   properties: { value: discordBotApiKey }
 }
 
-resource secretBotApiKey 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretBotApiKey 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'bot-api-key'
   properties: { value: botApiKey }
 }
 
-resource secretSessionSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretSessionSecret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'session-secret'
   properties: { value: sessionSecret }
 }
 
-resource secretDiscordClientId 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDiscordClientId 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'discord-client-id'
   properties: { value: discordClientId }
 }
 
-resource secretDiscordClientSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource secretDiscordClientSecret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   parent: keyVault
   name: 'discord-client-secret'
   properties: { value: discordClientSecret }

--- a/infra/modules/kv-role-assignments.bicep
+++ b/infra/modules/kv-role-assignments.bicep
@@ -16,7 +16,7 @@ var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 // Resolving `existing` from a plain string parameter is valid at compile time —
 // this is why role assignments must live in their own module rather than in
 // main.bicep, where the vault name would be a runtime module output (BCP120).
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
   name: vaultName
 }
 

--- a/infra/modules/log-analytics.bicep
+++ b/infra/modules/log-analytics.bicep
@@ -12,7 +12,7 @@ param retentionInDays int = 30
 
 var workspaceName = '${appPrefix}-logs-${environment}-${uniqueString(resourceGroup().id)}'
 
-resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource workspace 'Microsoft.OperationalInsights/workspaces@2025-02-01' = {
   name: workspaceName
   location: location
   tags: {

--- a/infra/modules/registry.bicep
+++ b/infra/modules/registry.bicep
@@ -45,7 +45,7 @@ var sanitizedName = empty(acrNameOverride) ? '${appPrefix}acr${environment}' : a
 // Note: acr purge is currently in public preview (mcr.microsoft.com/acr/acr-cli:0.17).
 var purgeCmd = 'acr purge --filter \'siege-api:^[a-f0-9]{40}$\' --filter \'siege-bot:^[a-f0-9]{40}$\' --filter \'siege-frontend:^[a-f0-9]{40}$\' --untagged --ago 7d --keep ${purgeKeepCount}'
 
-resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+resource registry 'Microsoft.ContainerRegistry/registries@2025-04-01' = {
   name: sanitizedName
   location: location
   tags: {
@@ -74,6 +74,12 @@ resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
 // After the first infra deploy, run once on-demand to clear the existing
 // backlog:
 //   az acr task run --name weekly-purge --registry <acrName>
+//
+// Microsoft.ContainerRegistry/registries/tasks has never shipped a GA apiVersion;
+// the latest available is 2025-03-01-preview. We intentionally stay on
+// 2019-06-01-preview because preview-to-preview churn buys nothing on a stable
+// surface (admin/anon-pull settings only). Re-evaluate if Microsoft promotes
+// the tasks resource to GA. Audit reference: issue #249 (2026-05-07).
 resource purgeTask 'Microsoft.ContainerRegistry/registries/tasks@2019-06-01-preview' = {
   name: 'weekly-purge'
   parent: registry


### PR DESCRIPTION
## Summary

PR A of the #249 audit closeout. Bumps Bicep `apiVersion` strings for resource types where the audit identified a newer GA with no behavior change (additive properties only). The behavior-tier bumps (Postgres family, `containerApps`, `scheduledQueryRules`) ship separately in PR B with mandatory what-if validation.

Audit table and rationale: https://github.com/glitchwerks/siege-web/issues/249#issuecomment-4397701836

## Changes

| Resource type | Old | New | File |
|---|---|---|---|
| `Microsoft.ContainerRegistry/registries` | `2023-07-01` | `2025-04-01` | `infra/modules/registry.bicep` |
| `Microsoft.KeyVault/vaults` | `2023-07-01` | `2024-11-01` | `infra/modules/keyvault.bicep` |
| `Microsoft.KeyVault/vaults/secrets` | `2023-07-01` | `2024-11-01` | `infra/modules/keyvault.bicep` |
| `Microsoft.KeyVault/vaults` (existing ref) | `2023-07-01` | `2024-11-01` | `infra/modules/kv-role-assignments.bicep` |
| `Microsoft.KeyVault/vaults` (existing ref) | `2023-07-01` | `2024-11-01` | `infra/modules/cert-identity.bicep` |
| `Microsoft.OperationalInsights/workspaces` | `2022-10-01` | `2025-02-01` | `infra/modules/log-analytics.bicep` |
| `Microsoft.ManagedIdentity/userAssignedIdentities` | `2023-01-31` | `2024-11-30` | `infra/modules/cert-identity.bicep` |

Also adds a code comment in `registry.bicep` documenting why `Microsoft.ContainerRegistry/registries/tasks` stays on `2019-06-01-preview` (audit found this child resource type has never had a GA release).

## Test plan

- [ ] Infra CI green: `bicep lint` + `bicep build` + `validate (dev)` + `what-if (dev)`
- [ ] What-if PR comment shows zero resource changes (or only no-op property defaults if any) — confirms additive-only nature of the bumps
- [ ] Post-merge: dev deploy via `deploy.yml` succeeds, no resource recreation

Refs #249 (closed by PR B once it lands).

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*
