### PR TITLE
chore(infra): bump behavior-tier Bicep API versions (PR B of #249)

### DIFF
--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -114,7 +114,7 @@ var certResourceName = bindCert ? take('${replace(customDomainHostname, '.', '-'
 
 // ── siege-api ────────────────────────────────────────────────────────────────
 
-resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
+resource apiApp 'Microsoft.App/containerApps@2025-07-01' = {
   name: apiAppName
   location: location
   tags: { project: appPrefix, environment: environment }
@@ -323,7 +323,7 @@ resource originCert 'Microsoft.App/managedEnvironments/certificates@2024-08-02-p
 // This is the .id property of the originCert resource — Bicep resolves it
 // symbolically, which also creates an implicit dependsOn.
 
-resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
+resource frontendApp 'Microsoft.App/containerApps@2025-07-01' = {
   name: frontendAppName
   location: location
   tags: { project: appPrefix, environment: environment }
@@ -398,7 +398,7 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
 
 // ── siege-bot ─────────────────────────────────────────────────────────────────
 
-resource botApp 'Microsoft.App/containerApps@2024-03-01' = {
+resource botApp 'Microsoft.App/containerApps@2025-07-01' = {
   name: botAppName
   location: location
   tags: { project: appPrefix, environment: environment }

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -85,7 +85,7 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
 // Severity 2 — page-worthy; the API is returning errors to real users.
 // Min-traffic floor (total >= 20) prevents false alarms during idle windows.
 
-resource alert5xxRate 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource alert5xxRate 'Microsoft.Insights/scheduledQueryRules@2026-03-01' = {
   name: '${appPrefix}-alert-5xx-rate-${environment}'
   location: location
   tags: tags
@@ -132,7 +132,7 @@ requests
 // Severity 3 — warning; latency is degraded but requests are still succeeding.
 // Min-traffic floor (sampleCount >= 20) avoids false alarms from a single slow call.
 
-resource alertLatencyP95 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource alertLatencyP95 'Microsoft.Insights/scheduledQueryRules@2026-03-01' = {
   name: '${appPrefix}-alert-latency-p95-${environment}'
   location: location
   tags: tags
@@ -184,7 +184,7 @@ requests
 //   "FastAPI HTTP sidecar instrumented for OpenTelemetry tracing."
 // Count > 0 in the 1-minute window is sufficient to confirm a restart occurred.
 
-resource alertBotRestart 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource alertBotRestart 'Microsoft.Insights/scheduledQueryRules@2026-03-01' = {
   name: '${appPrefix}-alert-bot-restart-${environment}'
   location: location
   tags: tags
@@ -234,7 +234,7 @@ traces
 // App Insights as of 2026-04-30 (PR #265, commit 9a11733): type == "postgresql",
 // Pattern A (no span duplication). Blocker removed — alert wired here.
 
-resource alertDbConnectionError 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource alertDbConnectionError 'Microsoft.Insights/scheduledQueryRules@2026-03-01' = {
   name: '${appPrefix}-alert-db-connection-error-${environment}'
   location: location
   tags: tags
@@ -286,7 +286,7 @@ dependencies
 // This alert queries the `requests` table filtered by operation_Name matching
 // the image generation route, rather than relying on a `customEvents` row.
 
-resource alertImageGenSlow 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+resource alertImageGenSlow 'Microsoft.Insights/scheduledQueryRules@2026-03-01' = {
   name: '${appPrefix}-alert-image-gen-slow-${environment}'
   location: location
   tags: tags

--- a/infra/modules/postgres.bicep
+++ b/infra/modules/postgres.bicep
@@ -48,7 +48,7 @@ param highAvailabilityMode string = 'Disabled'
 
 var serverName = '${appPrefix}-pg-${environment}-${uniqueString(resourceGroup().id)}'
 
-resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-06-01-preview' = {
+resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: serverName
   location: location
   tags: {
@@ -76,7 +76,7 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-06-01-pr
   }
 }
 
-resource siegeDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023-06-01-preview' = {
+resource siegeDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   parent: postgresServer
   name: 'siege'
   properties: {
@@ -88,7 +88,7 @@ resource siegeDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2023
 // Allow Azure services to connect (Container Apps use Azure-internal egress IPs).
 // For a hardened production deployment you could remove this rule and instead
 // configure a VNet integration so only Container Apps can reach the server.
-resource firewallRuleAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2023-06-01-preview' = {
+resource firewallRuleAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   parent: postgresServer
   name: 'AllowAzureServices'
   properties: {


### PR DESCRIPTION
## Summary

Closes #249. Final PR of the Bicep API-version audit closeout. PR A (no-op tier) merged in #284 and validated against dev. This PR ships the behavior-tier bumps — newer GA with documented behavior-change risk shapes per the audit.

Audit table: https://github.com/glitchwerks/siege-web/issues/249#issuecomment-4397701836

## Changes

| Resource type | Old | New | File |
|---|---|---|---|
| `Microsoft.DBforPostgreSQL/flexibleServers` | `2023-06-01-preview` | `2024-08-01` (GA) | `infra/modules/postgres.bicep` |
| `Microsoft.DBforPostgreSQL/flexibleServers/databases` | `2023-06-01-preview` | `2024-08-01` | `infra/modules/postgres.bicep` |
| `Microsoft.DBforPostgreSQL/flexibleServers/firewallRules` | `2023-06-01-preview` | `2024-08-01` | `infra/modules/postgres.bicep` |
| `Microsoft.App/containerApps` (×3 — api, frontend, bot) | `2024-03-01` | `2025-07-01` | `infra/modules/container-apps.bicep` |
| `Microsoft.Insights/scheduledQueryRules` (×5 alerts) | `2023-12-01` | `2026-03-01` | `infra/modules/monitoring.bicep` |

**Highest-leverage change**: Postgres family moves from a *preview* (`2023-06-01-preview`) to GA (`2024-08-01`). Preview APIs are subject to silent deprecation; this gets us off that surface.

## Risk callouts

- **containerApps `2024-03-01` → `2025-07-01`**: probe defaults, ingress IP-restriction shape, and secret-mount syntax may have evolved. The what-if comment below should be examined for any property-level drift; per the noise-floor pattern from PR A, expect `! Deploy` on every resource without property diffs.
- **scheduledQueryRules `2023-12-01` → `2026-03-01`**: alert evaluation/dimension semantics; `autoMitigate` defaulting. Re-validate all 5 alerts post-deploy.
- **Postgres trio (preview → GA)**: property name normalization possible. What-if and post-merge deploy are the gates.

## Pre-merge checks

- [ ] All Infra CI gates green: `bicep lint`, `bicep build`, `validate (dev)`, `what-if (dev)`
- [ ] What-if comment shows no property-level diffs (only `! Deploy` markers, matching the noise floor established by PR A's #284 what-if and PR #271's baseline)
- [ ] No CodeRabbit / Claude PR Review feedback indicating real drift

## Post-merge verification (executed automatically by `deploy.yml` against dev)

- [ ] Build & Push (siege-api, siege-frontend, siege-bot) succeed
- [ ] Deploy API / Frontend / Bot (dev) succeed
- [ ] No alert fires from real drift (the 5 scheduledQueryRules at the new API version)
- [ ] Login flow + board load smoke (manual, post-deploy)

## Deliberate skips (confirmed via audit)

- `Microsoft.App/managedEnvironments@2024-08-02-preview` and `…/certificates@2024-08-02-preview` — cert-binding preview pin; issue #283 tracks the revisit once GA covers the surface
- `Microsoft.ContainerRegistry/registries/tasks@2019-06-01-preview` — no GA exists for this resource type; comment block in `registry.bicep` (added by PR #284) documents the rationale
- `Microsoft.Authorization/roleAssignments@2022-04-01`, `Microsoft.Insights/actionGroups@2023-01-01`, `…/workbooks@2023-06-01`, `…/components@2020-02-02` — already on latest GA per audit

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*