### PR TITLE
feat(infra): add Bicep assert validation for enableCustomDomain preconditions (#230)

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "experimentalFeaturesEnabled": {
+    "assertions": true
+  }
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -163,14 +163,15 @@ param enableCustomDomain bool = false
 param kvCertSecretUrl string = ''
 
 // ── Custom-domain preconditions (Bicep `assert` — experimental feature, ──────
-//    gated via bicepconfig.json). Surfaces clear errors at compile time when
+//    gated via bicepconfig.json). Surfaces "Assertion failed: <name>" errors at compile time when
 //    enableCustomDomain=true but required params are missing or malformed.
+//    Assert names are descriptive so the failed-name itself is the error message.
 
-assert kvCertSecretUrlProvided = !enableCustomDomain || !empty(kvCertSecretUrl) : 'kvCertSecretUrl is required when enableCustomDomain is true'
+assert kvCertSecretUrlProvided = !enableCustomDomain || !empty(kvCertSecretUrl)
 
-assert kvCertSecretUrlFormat = !enableCustomDomain || contains(kvCertSecretUrl, '.vault.azure.net/secrets/') : 'kvCertSecretUrl must be a Key Vault secret URL containing ".vault.azure.net/secrets/"'
+assert kvCertSecretUrlFormat = !enableCustomDomain || contains(kvCertSecretUrl, '.vault.azure.net/secrets/')
 
-assert customDomainHostnameProvided = !enableCustomDomain || !empty(customDomainHostname) : 'customDomainHostname is required when enableCustomDomain is true'
+assert customDomainHostnameProvided = !enableCustomDomain || !empty(customDomainHostname)
 
 // ── Monitoring ────────────────────────────────────────────────────────────────
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -162,6 +162,16 @@ param enableCustomDomain bool = false
 @description('Versionless Key Vault secret URL for the Cloudflare Origin Cert PFX (e.g. https://<vault>.vault.azure.net/secrets/cloudflare-origin-cert). Required when enableCustomDomain is true.')
 param kvCertSecretUrl string = ''
 
+// ── Custom-domain preconditions (Bicep `assert` — experimental feature, ──────
+//    gated via bicepconfig.json). Surfaces clear errors at compile time when
+//    enableCustomDomain=true but required params are missing or malformed.
+
+assert kvCertSecretUrlProvided = !enableCustomDomain || !empty(kvCertSecretUrl) : 'kvCertSecretUrl is required when enableCustomDomain is true'
+
+assert kvCertSecretUrlFormat = !enableCustomDomain || contains(kvCertSecretUrl, '.vault.azure.net/secrets/') : 'kvCertSecretUrl must be a Key Vault secret URL containing ".vault.azure.net/secrets/"'
+
+assert customDomainHostnameProvided = !enableCustomDomain || !empty(customDomainHostname) : 'customDomainHostname is required when enableCustomDomain is true'
+
 // ── Monitoring ────────────────────────────────────────────────────────────────
 
 @description('Email address that receives alert notifications from the monitoring action group (dev and prod use the same address in v1).')


### PR DESCRIPTION
## Summary

Closes #230. Adds Bicep `assert` validation for `enableCustomDomain` preconditions so misconfigurations surface as clear messages at compile time / preflight rather than as generic ARM errors at deploy.

## Changes

**New file** — `bicepconfig.json` (repo root): enables the `assertions` experimental Bicep feature.

> Note: the correct flag name is `"assertions"` (plural), not `"asserts"` — confirmed against the [Bicep config docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config#enable-experimental-features) as of 2026-05-07.

**Modified** — `infra/main.bicep`: adds three assertions near the `enableCustomDomain` / `kvCertSecretUrl` / `customDomainHostname` params:

| Assert | Fires when |
|---|---|
| `kvCertSecretUrlProvided` | `enableCustomDomain=true` and `kvCertSecretUrl` is empty |
| `kvCertSecretUrlFormat` | `enableCustomDomain=true` and `kvCertSecretUrl` doesn't contain `.vault.azure.net/secrets/` |
| `customDomainHostnameProvided` | `enableCustomDomain=true` and `customDomainHostname` is empty |

Pattern: `!enableCustomDomain || <required-condition>` — vacuously true when the gate is off; only fires when the gate is on AND a precondition is missing.

## Why these three (and not `certIdentityId`)

Issue body mentioned `certIdentityId` as a candidate. Inspection showed it's wired from `certIdentity.outputs.identityId` in `main.bicep:289`, not user-controllable, always populated. No assert needed.

## Test plan

- [ ] Infra CI green (Bicep Lint, Build, Preflight Validate, What-if)
- [ ] What-if shows no resource changes (assert is compile-time only)
- [ ] Manual verification (post-merge, optional): on a throwaway branch, set `enableCustomDomain=true` with empty `kvCertSecretUrl`, run `az bicep build` locally, confirm the assert message surfaces

## Out of scope

- Full regex validation of the KV secret URL (Bicep string matching is limited; `contains` check matches the issue's "good enough" guidance)
- Validation of unrelated params

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*