### PR TITLE
fix(ci): drop removed require_association input for claude-tag-respond v2.3.0

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pull-requests: write
   statuses: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,5 +22,3 @@ jobs:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       app_id: ${{ secrets.APP_ID }}
       app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-    with:
-      require_association: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   issues: write
+  packages: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

Closes #286. The `Claude` and `Claude PR Review` workflows have been producing `startup_failure` on every event since PR #282 bumped the reusable workflows to v2.3.0. **Two issues, both required for the fix:**

1. `packages: read` permission missing from caller workflows (the actual parse-time blocker)
2. `require_association: true` is a removed input in v2.3.0 (would surface once permissions are fixed)

## Root cause #1 — missing `packages: read` permission

v2.3.0 of `claude-tag-respond.yml` and `claude-pr-review.yml` both declare `permissions: packages: read` in their reusable-workflow permissions block. Reusable workflows can only have permissions that are a *subset* of the caller's granted permissions. Default for any unspecified scope is `none` since 2023 — so our callers, which never declared `packages:`, implicitly granted `packages: none` and tripped the parser:

```
Invalid workflow file: .github/workflows/claude-pr-review.yml#L13
Error calling workflow 'glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.3.0'.
The workflow is requesting 'packages: read', but is only allowed 'packages: none'.
```

This is a `startup_failure` with no fetchable log — `gh run view --log-failed` returns "log not found" because the run never reaches its first job. The error is only visible on the Actions UI run page, not via CLI.

## Root cause #2 — `require_association` removed in v2.3.0

v2.3.0 of `claude-tag-respond.yml` removed the `require_association` boolean input and replaced it with `authorized_users` (comma-separated allowlist). Our `claude.yml` still passed `require_association: true`. This would also produce a `startup_failure` once #1 is fixed.

Per the v2.3.0 input description ("When set, overrides author_association check"), leaving `authorized_users` empty preserves the v2.0.0 security posture — the inner action falls back to its default `author_association` gate (MEMBER / COLLABORATOR required).

## Changes

| File | Change |
|---|---|
| `.github/workflows/claude.yml` | Add `packages: read` to permissions; remove `with: require_association: true` (and the now-empty `with:` key) |
| `.github/workflows/claude-pr-review.yml` | Add `packages: read` to permissions |
| `.github/workflows/claude-ci-fix.yml` | **No change** — `ci-failure.yaml@v2.3.0` only requires `contents: write` + `pull-requests: write`, both already granted |

## Verification plan

- [ ] PR CI passes (validates the workflow files parse)
- [ ] After merge, the next `pull_request_target` event (any PR push) should run `Claude PR Review` to completion (success or skip — not startup_failure)
- [ ] After merge, an `@claude` mention in any issue comment should run `Claude` (claude-tag-respond) to completion

## References

- v2.3.0 reusable workflow source: https://github.com/glitchwerks/github-actions/blob/v2.3.0/.github/workflows/claude-tag-respond.yml
- Working sibling caller `claude-ci-fix.yml` on the same v2.3.0 tag — `ci-failure.yaml` doesn't request `packages` so its caller didn't trip
- Lesson saved to global memory at `feedback_reusable_workflow_permissions.md`

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*
