### PR TITLE
fix(board): sort Posts tab by Post # not priority

### DIFF
--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -31,7 +31,8 @@ async def list_posts(
     db: AsyncSession = Depends(get_db),
 ):
     posts = await posts_service.list_posts(db, siege_id)
-    return [_serialize_post(p) for p in posts]
+    posts_sorted = sorted(posts, key=lambda p: p.building.building_number)
+    return [_serialize_post(p) for p in posts_sorted]
 
 
 @router.put("/sieges/{siege_id}/posts/{post_id}", response_model=PostResponse)

--- a/backend/app/services/posts.py
+++ b/backend/app/services/posts.py
@@ -3,6 +3,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.building import Building
 from app.models.enums import SiegeStatus
 from app.models.post import Post
 from app.models.post_active_condition import post_active_condition
@@ -42,7 +43,9 @@ async def list_posts(session: AsyncSession, siege_id: int) -> list[Post]:
 
     result = await session.execute(
         select(Post)
+        .join(Post.building)
         .where(Post.siege_id == siege_id)
+        .order_by(Building.building_number)
         .options(selectinload(Post.active_conditions), selectinload(Post.building))
     )
     return list(result.scalars().all())

--- a/backend/tests/test_posts.py
+++ b/backend/tests/test_posts.py
@@ -26,6 +26,7 @@ def _make_post(
     id: int = 1,
     siege_id: int = 1,
     building_id: int = 10,
+    building_number: int = 1,
     priority: int = 1,
     description: str | None = None,
 ) -> SimpleNamespace:
@@ -36,7 +37,7 @@ def _make_post(
         priority=priority,
         description=description,
         active_conditions=[],
-        building=_make_building(id=building_id),
+        building=_make_building(id=building_id, building_number=building_number),
     )
 
 
@@ -102,3 +103,37 @@ async def test_set_post_conditions_too_many_returns_400(client):
 
     assert response.status_code == 400
     assert "3" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 4. list_posts response is sorted by building_number ascending
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_posts_sorted_by_building_number(client):
+    """Posts endpoint returns rows sorted by Post # (building_number) ascending.
+
+    The service returns posts in DB-insertion order: building_number 3 first
+    (highest priority=3), then 1, then 2.  The endpoint must re-order them
+    to [1, 2, 3] regardless of priority so that priority edits never change
+    the visual order.
+    """
+    posts = [
+        _make_post(id=3, building_id=30, building_number=3, priority=3),
+        _make_post(id=1, building_id=10, building_number=1, priority=1),
+        _make_post(id=2, building_id=20, building_number=2, priority=2),
+    ]
+    with patch("app.api.posts.posts_service.list_posts", new_callable=AsyncMock) as mock:
+        mock.return_value = posts
+        async with client as c:
+            response = await c.get("/api/sieges/1/posts")
+
+    assert response.status_code == 200
+    data = response.json()
+    building_numbers = [item["building_number"] for item in data]
+    assert building_numbers == [
+        1,
+        2,
+        3,
+    ], f"Expected posts sorted by building_number [1,2,3], got {building_numbers}"

--- a/frontend/src/pages/PostsPage.tsx
+++ b/frontend/src/pages/PostsPage.tsx
@@ -259,7 +259,7 @@ export default function PostsPage() {
     queryFn: () => getBoard(siegeId),
   });
 
-  const sorted = posts?.slice().sort((a, b) => a.priority - b.priority);
+  const sorted = posts?.slice().sort((a, b) => a.building_number - b.building_number);
 
   return (
     <div>

--- a/frontend/src/test/pages/PostsPage.test.tsx
+++ b/frontend/src/test/pages/PostsPage.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * PostsPage component tests
+ *
+ * Covers:
+ *  - Posts list sorted by Post # (building_number) ascending
+ *  - Priority changes must not reorder the list
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import PostsPage from "../../pages/PostsPage";
+import type { Post } from "../../api/types";
+
+// ─── Server lifecycle ──────────────────────────────────────────────────────────
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── Fixture factories ─────────────────────────────────────────────────────────
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: 1,
+    siege_id: 42,
+    building_id: 10,
+    building_number: 1,
+    priority: 1,
+    description: null,
+    active_conditions: [],
+    ...overrides,
+  };
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderPostsPage(siegeId: number = 42) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/sieges/:id/posts" element={<PostsPage />} />
+    </Routes>,
+    { initialEntries: [`/sieges/${siegeId}/posts`] }
+  );
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PostsPage — sort order", () => {
+  it("renders posts in building_number ascending order regardless of priority", async () => {
+    /**
+     * The API returns posts where priority order disagrees with building_number order:
+     *   Post #1 has priority=3 (highest)
+     *   Post #2 has priority=1 (lowest)
+     *   Post #3 has priority=2 (medium)
+     *
+     * Sorting by priority ascending would yield: Post 2, Post 3, Post 1
+     * The UI must instead display by building_number ascending: Post 1, Post 2, Post 3
+     */
+    const posts: Post[] = [
+      makePost({ id: 1, building_id: 10, building_number: 1, priority: 3 }),
+      makePost({ id: 2, building_id: 20, building_number: 2, priority: 1 }),
+      makePost({ id: 3, building_id: 30, building_number: 3, priority: 2 }),
+    ];
+
+    server.use(
+      http.get("/api/sieges/42", () =>
+        HttpResponse.json({
+          id: 42,
+          name: "Siege 42",
+          status: "draft",
+          attack_day: null,
+          created_at: "2024-01-01T00:00:00Z",
+          member_count: 0,
+        })
+      ),
+      http.get("/api/sieges/42/posts", () => HttpResponse.json(posts)),
+      http.get("/api/sieges/42/board", () =>
+        HttpResponse.json({ siege_id: 42, buildings: [] })
+      )
+    );
+
+    renderPostsPage(42);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
+
+    // Query all "Post N" headings rendered by PostRow.
+    const postHeadings = screen
+      .getAllByText(/^Post \d+$/)
+      .map((el) => el.textContent);
+
+    expect(postHeadings).toEqual(["Post 1", "Post 2", "Post 3"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #255.

The Board / Posts tab was sorting posts by `priority`, causing the list to re-shuffle whenever priorities were edited. Per #255, the order should be locked to **Post # (`building.building_number`) ascending** so positional reference is stable across priority edits.

## Fix

Two sort sites — both fixed:

1. **Frontend** (`frontend/src/pages/PostsPage.tsx`) — comparator swapped from `a.priority - b.priority` to `a.building_number - b.building_number`.
2. **Backend service** (`backend/app/services/posts.py`) — `list_posts` query now joins `Building` and orders by `building.building_number` (DB-level ordering as defense-in-depth).
3. **Backend API** (`backend/app/api/posts.py`) — `list_posts` endpoint sorts service results by `building.building_number` before serializing (this is what the mock-based tests exercise).

## Tests added

- `backend/tests/test_posts.py::test_list_posts_sorted_by_building_number` — fixture has priority and `building_number` ranks deliberately disagree; asserts response order follows `building_number` ascending.
- `frontend/src/test/pages/PostsPage.test.tsx` (new file) — renders PostsPage with the same priority-vs-`building_number` conflict; asserts DOM order matches `building_number` ascending.

Both tests fail on current `main` and pass on this branch.

## Verification

CI-mirror commands run from the worktree:

| Command | Result |
|---|---|
| `black --check backend/` | pass (pre-existing `seed_demo.py` violation unchanged) |
| `ruff check backend/` | pass (pre-existing `seed_demo.py` warning unchanged) |
| `pytest --ignore=tests/test_schema.py -v` | 314 passed (+1 new), 1 pre-existing failure in `test_config` (untouched, unrelated) |
| `npx eslint frontend/src/` | pass (6 pre-existing warnings, 0 errors) |
| `npm run build` | pass |
| `npm run test` | 12 files, 116 passed (+1 new file, +1 test) |

## Test plan

- [x] Posts list sorted by Post # ascending in the UI (frontend test)
- [x] API response sorted by Post # ascending (backend test)
- [x] Priority changes do not reorder the list (both tests use priority/`building_number` conflict fixtures)
- [x] Test added covering the sort order (one frontend, one backend)

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_