### PR TITLE
chore(board): remove dead N/A summary tile and unreachable fallbacks

### DIFF
--- a/frontend/src/api/board.ts
+++ b/frontend/src/api/board.ts
@@ -14,7 +14,6 @@ export async function updatePosition(
   data: {
     member_id?: number | null;
     is_reserve?: boolean;
-    has_no_assignment?: boolean;
     matched_condition_id?: number | null;
   }
 ): Promise<PositionResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -83,7 +83,6 @@ export interface PositionResponse {
   member_name: string | null;
   is_reserve: boolean;
   is_disabled: boolean;
-  has_no_assignment: boolean;
   matched_condition_id: number | null;
 }
 

--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -145,7 +145,6 @@ function MemberAssignRow({
       updatePosition(siegeId, positionId, {
         member_id: data.member_id,
         is_reserve: false,
-        has_no_assignment: false,
         matched_condition_id: data.matched_condition_id,
       }),
     onSuccess: () => {
@@ -350,7 +349,6 @@ function PostRow({
       updatePosition(siegeId, posId, {
         member_id: null,
         is_reserve: true,
-        has_no_assignment: false,
         matched_condition_id: null,
       }),
     onSuccess: () => {

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -135,7 +135,6 @@ function PositionCell({
     mutationFn: (data: {
       member_id?: number | null;
       is_reserve?: boolean;
-      has_no_assignment?: boolean;
     }) => updatePosition(siegeId, position.id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
@@ -162,9 +161,6 @@ function PositionCell({
           RESERVE
         </Badge>
       );
-    }
-    if (position.has_no_assignment) {
-      return <span className="text-xs text-slate-400">N/A</span>;
     }
     if (position.member_id != null) {
       return (
@@ -225,7 +221,6 @@ function PositionCell({
               onClick={() =>
                 mutation.mutate({
                   is_reserve: true,
-                  has_no_assignment: false,
                   member_id: null,
                 })
               }
@@ -238,23 +233,8 @@ function PositionCell({
               size="sm"
               onClick={() =>
                 mutation.mutate({
-                  has_no_assignment: true,
-                  is_reserve: false,
-                  member_id: null,
-                })
-              }
-              disabled={mutation.isPending}
-            >
-              Mark No Assignment
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                mutation.mutate({
                   member_id: null,
                   is_reserve: false,
-                  has_no_assignment: false,
                 })
               }
               disabled={mutation.isPending}
@@ -499,7 +479,6 @@ function BuildingTableRow({
     (p) =>
       !p.is_disabled &&
       !p.is_reserve &&
-      !p.has_no_assignment &&
       p.member_id != null
   ).length;
   const activeCount = allPositions.filter((p) => !p.is_disabled).length;
@@ -805,16 +784,13 @@ export default function BoardPage() {
     (p) =>
       !p.is_disabled &&
       !p.is_reserve &&
-      !p.has_no_assignment &&
       p.member_id != null
   ).length;
   const reserveCount = allPositions.filter((p) => p.is_reserve).length;
-  const noAssignCount = allPositions.filter((p) => p.has_no_assignment).length;
   const emptyCount = allPositions.filter(
     (p) =>
       !p.is_disabled &&
       !p.is_reserve &&
-      !p.has_no_assignment &&
       p.member_id == null
   ).length;
   const disabledCount = allPositions.filter((p) => p.is_disabled).length;
@@ -930,7 +906,6 @@ export default function BoardPage() {
     updatePosition(siegeId, positionId, {
       member_id: memberId,
       is_reserve: false,
-      has_no_assignment: false,
     }).then(() => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
     });
@@ -998,10 +973,6 @@ export default function BoardPage() {
         <span className="text-sm text-slate-600">
           <span className="font-semibold text-amber-600">{reserveCount}</span>{" "}
           reserve
-        </span>
-        <span className="text-sm text-slate-600">
-          <span className="font-semibold text-slate-500">{noAssignCount}</span>{" "}
-          N/A
         </span>
         <span className="text-sm text-slate-600">
           <span className="font-semibold text-orange-600">{emptyCount}</span>{" "}

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -46,7 +46,6 @@ function makePosition(
     member_name: null,
     is_reserve: false,
     is_disabled: false,
-    has_no_assignment: false,
     matched_condition_id: null,
     ...overrides,
   };

--- a/frontend/src/test/pages/BoardPage.test.tsx
+++ b/frontend/src/test/pages/BoardPage.test.tsx
@@ -3,9 +3,9 @@
  *
  * Covers:
  *  - Loading state while board data is fetched
- *  - Summary bar slot counts (assigned / reserve / N/A / empty / disabled)
+ *  - Summary bar slot counts (assigned / reserve / empty / disabled)
  *  - Position cell visual states rendered from board API data
- *  - Context-menu actions: Mark RESERVE, Mark No Assignment, Clear, Assign member
+ *  - Context-menu actions: Mark RESERVE, Clear, Assign member
  *  - MemberBucket search and role-filter interactions
  *  - Locked (siege complete) board — context menu button hidden, auto-fill disabled
  *  - Validation dialog: error-severity rows render with red badge and message
@@ -46,7 +46,6 @@ function makePosition(
     member_name: null,
     is_reserve: false,
     is_disabled: false,
-    has_no_assignment: false,
     matched_condition_id: null,
     ...overrides,
   };
@@ -156,9 +155,8 @@ describe("BoardPage — summary bar", () => {
         member_name: "Aethon",
       }), // assigned
       makePosition({ id: 2, position_number: 2, is_reserve: true }), // reserve
-      makePosition({ id: 3, position_number: 3, has_no_assignment: true }), // N/A
-      makePosition({ id: 4, position_number: 4 }), // empty
-      makePosition({ id: 5, position_number: 5, is_disabled: true }), // disabled
+      makePosition({ id: 3, position_number: 3 }), // empty
+      makePosition({ id: 4, position_number: 4, is_disabled: true }), // disabled
     ];
     setupDefaultHandlers(makeBoard(positions), makeSiege(), [
       makeSiegeMember({ member_id: 7, member_name: "Aethon" }),
@@ -169,10 +167,10 @@ describe("BoardPage — summary bar", () => {
       expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
     );
 
-    // Summary bar contains "5 total"
+    // Summary bar contains "4 total"
     const summaryBar = screen.getByText("total").closest("div")!;
-    expect(within(summaryBar).getByText("5")).toBeInTheDocument();
-    // assigned, reserve, N/A, empty each show '1'; disabled also '1'
+    expect(within(summaryBar).getByText("4")).toBeInTheDocument();
+    // assigned, reserve, empty, disabled each show '1'
     const ones = within(summaryBar).getAllByText("1");
     expect(ones.length).toBeGreaterThanOrEqual(4);
   });
@@ -206,18 +204,6 @@ describe("BoardPage — position cell states", () => {
       expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
     );
     expect(screen.getByText("RESERVE")).toBeInTheDocument();
-  });
-
-  it("renders N/A text for a no-assignment position", async () => {
-    const positions = [makePosition({ id: 1, has_no_assignment: true })];
-    setupDefaultHandlers(makeBoard(positions));
-    renderBoard();
-
-    await waitFor(() =>
-      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
-    );
-    // N/A appears in both the position cell and the summary bar label
-    expect(screen.getAllByText("N/A").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders DISABLED text with strikethrough style for a disabled position", async () => {
@@ -298,42 +284,6 @@ describe("BoardPage — position context menu", () => {
     await waitFor(() => expect(capturedBody).not.toBeNull());
     expect(capturedBody).toMatchObject({
       is_reserve: true,
-      has_no_assignment: false,
-      member_id: null,
-    });
-  });
-
-  it("calls the update endpoint with has_no_assignment=true when Mark No Assignment is clicked", async () => {
-    const user = userEvent.setup();
-    const positions = [makePosition({ id: 56, position_number: 1 })];
-    setupDefaultHandlers(makeBoard(positions));
-
-    let capturedBody: Record<string, unknown> | null = null;
-    server.use(
-      http.put("/api/sieges/42/positions/56", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          makePosition({ id: 56, position_number: 1, has_no_assignment: true })
-        );
-      })
-    );
-
-    renderBoard();
-    await waitFor(() =>
-      expect(screen.queryByText(/loading board/i)).not.toBeInTheDocument()
-    );
-
-    const cell = screen.getByText("1.").closest("div")!;
-    await user.hover(cell);
-    await user.click(cell.querySelector("button")!);
-    await user.click(
-      screen.getByRole("button", { name: /mark no assignment/i })
-    );
-
-    await waitFor(() => expect(capturedBody).not.toBeNull());
-    expect(capturedBody).toMatchObject({
-      has_no_assignment: true,
-      is_reserve: false,
       member_id: null,
     });
   });
@@ -374,7 +324,6 @@ describe("BoardPage — position context menu", () => {
     expect(capturedBody).toMatchObject({
       member_id: null,
       is_reserve: false,
-      has_no_assignment: false,
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #254

### Root cause

`has_no_assignment` was never persisted or returned by the backend. `PositionBoardResponse` does not include the field, and `PositionUpdate` silently ignores it when sent. At runtime the field was always `undefined` (falsy) on every position object received from the API.

As a result:
- The N/A summary-bar tile always showed **0** (locked dead display).
- The in-cell `<span>N/A</span>` fallback branch was **never reachable** at runtime.
- The "Mark No Assignment" context-menu button sent a field the backend silently dropped, making the operation a no-op beyond clearing `member_id`.
- All `has_no_assignment: false` sentinels in mutation payloads were unnecessary.

### Paths removed

| File | What was removed |
|---|---|
| `frontend/src/api/types.ts` | `has_no_assignment` field from `PositionResponse` |
| `frontend/src/api/board.ts` | `has_no_assignment` from `updatePosition` param type |
| `frontend/src/pages/BoardPage.tsx` | In-cell N/A fallback branch; "Mark No Assignment" button; `noAssignCount` computation; N/A summary tile; all `has_no_assignment` references in mutations and slot-count filters |
| `frontend/src/components/PostsTab.tsx` | `has_no_assignment: false` from both mutation calls |
| `frontend/src/test/pages/BoardPage.test.tsx` | N/A cell-state test; "Mark No Assignment" mutation test; `has_no_assignment` from fixtures and mutation body assertions; updated summary-bar test (4 categories, not 5) |
| `frontend/src/test/components/PostsTab.test.tsx` | `has_no_assignment` from position fixture |

### Paths kept (with reason)

| Path | Reason kept |
|---|---|
| `backend/app/services/image_gen.py` lines 123-125, 162-164 | These render `"N/A"` when `pos.is_disabled == True`. `is_disabled` is a live DB column (`NOT NULL`, `default=false`, enforced by DB constraint) used throughout the backend. The PNG correctly displays N/A for disabled positions — this is intentional behavior, not dead code. |
| `scripts/excel-import/import_excel.py` | Out of scope per issue comment; the N/A there is legacy Excel input data handling, not a display path. |

### Test delta

- Frontend Vitest: **114 passed** (was 116 — removed 2 tests: `renders N/A text for a no-assignment position` and `calls the update endpoint with has_no_assignment=true when Mark No Assignment is clicked`)
- Backend pytest: **316 passed** (unchanged; 1 pre-existing failure in `test_config.py` unrelated to this change)

### Verification

- `black --check app/ tests/` — all unchanged
- `ruff check app/ tests/` — all checks passed
- `pytest` (ignore test_schema.py) — 316/317 passed (pre-existing failure)
- `npm run lint` — 0 errors
- `npm run build` — tsc + vite exit 0
- `npm test -- --run` — 114/114 passed

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_