### PR TITLE
fix(ci): bump claude-pr-review reusable workflow pin to v2.4.0

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.3.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps the `claude-pr-review` reusable workflow pin from `@v2.3.0` to `@v2.4.0` to fix `marker_missing` errors on the new shadow quality-gate.
- One-line YAML change in `.github/workflows/claude-pr-review.yml`.

## Why

Every PR review since `glitchwerks/github-actions#238` merged has produced `claude-pr-review/quality-gate-shadow` with `state=error / marker_missing` (#294, #293, #291). The authoritative `quality-gate` is fine — only the shadow gate is failing.

Producer/consumer skew is the cause:

- v2.3.0's overlay container (`sha256:46d16c22…`) was built **before** #238 and does not contain the persona update that emits the `<!-- claude-pr-review-summary-v1` marker block.
- The shadow gate code (which consumes that marker) ships in v2.4.0 — but it runs against v2.3.0 PRs anyway, because the composite action inside the reusable workflow is fetched via floating `pr-review@v2`.
- Result: the new consumer reads from the old producer, never finds the marker, and reports `marker_missing`.

v2.4.0 carries the post-#238 overlay digest (`sha256:0db0d558…`) whose persona emits the marker, restoring the shadow gate to the producer/consumer pairing it was designed against.

## Test plan

- [ ] CI completes without workflow-validation startup failures
- [ ] Once merged, the next PR review run posts `claude-pr-review/quality-gate-shadow` with `state=success` (or `state=failure` on a review that legitimately contains BLOCKING/MAJOR markers) — not `state=error / marker_missing`

Fixes #296

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_