### PR TITLE
fix(ci): bump claude-pr-review reusable workflow pin to v2.4.1

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.1
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps the `claude-pr-review` reusable workflow pin from `@v2.4.0` to `@v2.4.1`.
- One-line YAML change in `.github/workflows/claude-pr-review.yml`.

## Why

The previous bump to `@v2.4.0` (#297) did **not** fix the shadow quality-gate `marker_missing` failure. PR #298 (the first review run on v2.4.0) confirmed it: `claude-pr-review/quality-gate-shadow` still posted `state=error / description=marker_missing`.

Root cause turned out to be upstream and orthogonal to the producer/consumer skew originally diagnosed in #296: the `v2.4.0` tag in `glitchwerks/github-actions` was placed on a stale commit whose workflow pinned an old `claude-runtime-review` container digest — built before [glitchwerks/github-actions#228](https://github.com/glitchwerks/github-actions/pull/228) added the structured-marker emission directive to the review persona. The bad pin landed because PR #238's branch was based on a pre-promote state of `main`, and the merge stomped a runtime promote ~2 days old. `main` was re-promoted minutes later, but `v2.4.0` was tagged before the re-promote.

`v2.4.1` ([release notes](https://github.com/glitchwerks/github-actions/releases/tag/v2.4.1)) retargets `main` HEAD — pinning `claude-runtime-review@sha256:0db0d558…`, the correct post-#228 image that emits the marker.

## Test plan

- [ ] CI completes without workflow-validation startup failures
- [ ] Once merged, the next PR review run posts `claude-pr-review/quality-gate-shadow` with `state=success` (or legitimate `state=failure` on a review with BLOCKING/MAJOR markers) — not `state=error / marker_missing`

## Related

- Prior bump that didn't fix it: #296, #297
- Upstream diagnosis: glitchwerks/github-actions#242
- Upstream fix: glitchwerks/github-actions release [v2.4.1](https://github.com/glitchwerks/github-actions/releases/tag/v2.4.1)

Fixes #299

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_