### PR TITLE
fix(ci): bump claude-pr-review reusable workflow pin to v2.4.2

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.2
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps the `claude-pr-review` reusable workflow pin from `@v2.4.1` to `@v2.4.2`.
- One-line YAML change in `.github/workflows/claude-pr-review.yml`.

## Why

Prior bumps to `@v2.4.0` (#297) and `@v2.4.1` (#300) did not fix the shadow `quality-gate-shadow` `marker_missing` failure. The actual root cause turned out to be upstream and structural:

GitHub Actions overrides `HOME=/github/home` in container jobs, discarding the runtime image's baked `HOME=/opt/claude`. The fresh CLI installed by `claude-code-action@v1` then reads its user-level CLAUDE.md from `$HOME/.claude/CLAUDE.md` — a path that did not exist by default. The persona at `/opt/claude/.claude/CLAUDE.md` was never read. Net effect: the runtime overlay personas have never actually been the system prompt since container jobs were introduced; the marker the shadow gate looks for was never emitted.

Upstream `v2.4.2` ([release notes](https://github.com/glitchwerks/github-actions/releases/tag/v2.4.2)) adds a persona-install pre-step that copies the baked persona to the CLI's expected location, immediately before every `claude-code-action@v1` invocation across all three runtime overlays.

## Test plan

- [ ] CI completes without workflow-validation startup failures
- [ ] Once merged, the next PR review run posts `claude-pr-review/quality-gate-shadow` with `state=success` (or legitimate `state=failure` on a review with BLOCKING/MAJOR markers) — not `state=error / marker_missing`

## Related

- Prior bumps that didn't fix it: #296, #297, #299, #300
- Upstream diagnosis: glitchwerks/github-actions#242
- Upstream fix: glitchwerks/github-actions#243
- Upstream release: glitchwerks/github-actions [v2.4.2](https://github.com/glitchwerks/github-actions/releases/tag/v2.4.2)

Fixes #304

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_