### PR TITLE
docs(changelog): backfill v1.0.1–v1.0.3 sections and populate [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- In-app changelog dropdown in the top bar with a per-user red-dot indicator that surfaces `CHANGELOG.md` content; bell icon, latest entry first, mark-seen persists across sessions (#298)
+
+### Fixed
+
+- Posts tab now sorts by Post # rather than priority — list order stays stable when priorities are edited (#291)
+- Removed the dead "N/A" summary tile and unreachable `has_no_assignment` code paths from the assignment board (#294)
+- `bootstrap-db.ps1` now calls the canonical `scripts/seed.py` (the legacy `backend/seed.py` was incomplete); regression tests added (#293)
+
+### Infrastructure
+
+- `RUNBOOK.md` extended with a Deploys & Drift section and a hybrid-trigger decision: dev auto-triggers infra deploys on `infra/**` changes, prod remains manual to prevent drift (#289)
+
+## [1.0.3] - 2026-05-07
+
+### Added
+
+- DB dependency p95 latency tile and PostgreSQL connection-failure alert added to the Application Insights workbook (#271)
+
+### Fixed
+
+- Validation Rule 1 (member scroll budget) now correctly counts broken-building assignments toward the limit, restoring the error message in mixed-assignment scenarios (#273)
+
+### Infrastructure
+
+- Bicep `assert` precondition validation for `enableCustomDomain` — misconfigurations (missing cert, wrong scope) now fail at template-evaluation time rather than mid-deploy (#287)
+- Behavior-tier Bicep API bumps: PostgreSQL Flexible Server (preview → GA), Container Apps (2024-03-01 → 2025-07-01), Scheduled Query Rules (2023-12-01 → 2026-03-01); validated via what-if (#285)
+
+## [1.0.2] - 2026-04-30
+
+### Added
+
+- SQLAlchemy + asyncpg instrumented via OpenTelemetry — database queries now surface as dependencies in Application Insights (#265)
+
+### Infrastructure
+
+- Observability runbook finalized: alert inventory, autoMitigate policy, and workbook portal links added to `RUNBOOK.md` for on-call use (#264)
+
+## [1.0.1] - 2026-04-29
+
+### Added
+
+- Application Insights workbook with 5 tiles (request volume, latency p50/p95, error rate, bot restarts, image generation duration) and 4 alert rules for production health (#260)
+- Scheduled weekly ACR Task (`weekly-purge`, Sundays 03:00 UTC): keeps the last 10 SHA-tagged images per repo, deletes untagged manifests older than 7 days, retains all `v*` release tags forever (#247)
+
+### Fixed
+
+- App Insights telemetry pipeline: `OTEL_SERVICE_NAME` is now set and FastAPI routes are explicitly instrumented, so spans reach Application Insights as expected (#248)
+- Alert rules no longer auto-mitigate — autoMitigate disabled on all four alert rules, so on-call must manually acknowledge when alerts fire (Azure rejected the prior `autoMitigate: true` + action-suppression combo) (#262)
+
 ## [1.0.0] - 2026-04-17
 
 ### Added
@@ -72,5 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vitest component tests for the assignment board (`BoardPage`) and notification polling (`SiegeSettingsPage`)
 - CI on every PR to `main`: black + ruff + pytest (backend); ESLint + build (frontend)
 
-[Unreleased]: https://github.com/glitchwerks/siege-web/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/glitchwerks/siege-web/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/glitchwerks/siege-web/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/glitchwerks/siege-web/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/glitchwerks/siege-web/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/glitchwerks/siege-web/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

- Inserts `## [1.0.1]`, `## [1.0.2]`, and `## [1.0.3]` sections for releases that shipped via `v*` tags but were never documented in `CHANGELOG.md`
- Populates the `## [Unreleased]` section with the post-v1.0.3 delta (issues #289, #291, #293, #294, #298)
- Updates footer link references from the stale `v1.0.0...HEAD` range to the correct five-entry set (`v1.0.3...HEAD` plus compare links for each patch release)

This provides the content that the in-app changelog dropdown (shipped in #298) reads from — without these sections the dropdown was rendering an empty `[Unreleased]` block and no patch history at all.

The `## [1.0.0]` section is untouched.

Closes #303

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*