### PR TITLE
fix(deploy): stage CHANGELOG.md into frontend Docker context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
       - name: Build frontend image
         run: docker build -f frontend/Dockerfile -t siege-frontend:ci ./frontend
 
+      - name: Clean up staged CHANGELOG.md
+        if: always()
+        run: rm -f frontend/CHANGELOG.md
+
 
   claude-lint-fix:
     name: Claude Lint Fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,25 @@ jobs:
         run: pytest tests/ -v
 
 
+  # Regression check for #302: verifies the frontend Docker build succeeds when
+  # CHANGELOG.md is staged into the build context (mirrors what deploy.yml does).
+  # Runs on every PR so this exact failure mode is caught before merge.
+  frontend-docker-build:
+    name: Frontend Docker build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Stage CHANGELOG.md into frontend build context
+        run: cp CHANGELOG.md frontend/CHANGELOG.md
+
+      - name: Build frontend image
+        run: docker build -f frontend/Dockerfile -t siege-frontend:ci ./frontend
+
+
   claude-lint-fix:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,13 @@ jobs:
       - name: Log in to ACR
         run: az acr login --name ${{ vars.ACR_NAME }}
 
+      # CHANGELOG.md lives at the repo root, outside the ./frontend build context.
+      # Stage it in so the changelog-plugin can resolve it inside Docker.
+      # (Only needed for the frontend image; the other matrix legs are unaffected.)
+      - name: Stage CHANGELOG.md into frontend build context
+        if: matrix.service == 'siege-frontend'
+        run: cp CHANGELOG.md frontend/CHANGELOG.md
+
       - name: Build and push ${{ matrix.service }}
         run: |
           IMAGE=${{ vars.ACR_LOGIN_SERVER }}/${{ matrix.service }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,6 +193,10 @@ jobs:
             ${{ matrix.context }}
           docker push "${IMAGE}:${{ github.sha }}"
 
+      - name: Clean up staged CHANGELOG.md
+        if: matrix.service == 'siege-frontend' && always()
+        run: rm -f frontend/CHANGELOG.md
+
       - name: Push to prod ACR
         if: vars.PROD_ACR_NAME != ''
         run: |

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -3,3 +3,7 @@ test-results/
 playwright-report/
 blob-report/
 playwright/.cache/
+
+# Staged copy used by Docker build context (see deploy.yml + changelog-plugin.ts).
+# The canonical CHANGELOG.md lives at the repo root.
+CHANGELOG.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,9 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm ci
 
+# CHANGELOG.md must be staged from the repo root into this build context before
+# `docker build` runs. In CI this is done by the "Stage CHANGELOG.md into frontend
+# build context" step in .github/workflows/deploy.yml (see frontend/src/build/changelog-plugin.ts).
 COPY . .
 RUN npm run build
 

--- a/frontend/src/build/changelog-plugin.ts
+++ b/frontend/src/build/changelog-plugin.ts
@@ -31,6 +31,33 @@ import { resolve } from "path";
 import type { Plugin, ResolvedConfig } from "vite";
 import { parseChangelog } from "./changelog-parser";
 
+/**
+ * Locate CHANGELOG.md by searching candidate paths in priority order.
+ *
+ * Dev: `__dirname` = `<repo>/frontend/src/build/` → `../../../` hits the repo root.
+ * Docker: build context is `./frontend/` (copied to `/app/`), so the repo root path
+ * won't exist; instead CHANGELOG.md is staged into `frontend/` → `../../` from here.
+ * The first path that exists wins; if none exist the caller throws a descriptive error.
+ *
+ * @param dirname - Directory to resolve candidates from (typically `__dirname`).
+ * @param checker - Optional override for `existsSync`; used in tests to avoid I/O.
+ */
+export function findChangelogPath(
+  dirname: string,
+  checker: (p: string) => boolean = existsSync
+): string | undefined {
+  const candidatePaths = changelogCandidatePaths(dirname);
+  return candidatePaths.find((p) => checker(p));
+}
+
+/** All candidate paths tried by findChangelogPath, for error messages. */
+export function changelogCandidatePaths(dirname: string): string[] {
+  return [
+    resolve(dirname, "../../../CHANGELOG.md"),
+    resolve(dirname, "../../CHANGELOG.md"),
+  ];
+}
+
 const VIRTUAL_MODULE_ID = "virtual:changelog";
 const RESOLVED_VIRTUAL_MODULE_ID = "\0" + VIRTUAL_MODULE_ID;
 
@@ -62,17 +89,16 @@ export function changelogPlugin(): Plugin {
         return undefined;
       }
 
-      // Locate CHANGELOG.md at the repo root.
-      // __dirname resolves to frontend/src/build/ at runtime in Node (CJS).
-      // In ESM Vite plugin context we use import.meta.url — but Vite compiles
-      // plugins under Node CJS, so we use path.resolve relative to this file.
-      // The path chain: frontend/src/build/ → ../../.. → repo root.
-      const changelogPath = resolve(__dirname, "../../../CHANGELOG.md");
+      // Locate CHANGELOG.md — search candidate paths so both dev (repo root via
+      // traversal) and Docker (file staged into the frontend build context) work.
+      const changelogPath = findChangelogPath(__dirname);
 
-      if (!existsSync(changelogPath)) {
+      if (!changelogPath) {
+        const tried = changelogCandidatePaths(__dirname);
         throw new Error(
-          `[changelog-plugin] CHANGELOG.md not found at "${changelogPath}". ` +
-            "Ensure the file exists at the repository root."
+          `[changelog-plugin] CHANGELOG.md not found at any of: ${tried.join(", ")}. ` +
+            "Ensure the file exists at the repository root, or — for Docker builds — " +
+            "that it has been staged into the frontend build context."
         );
       }
 

--- a/frontend/src/test/build/changelog-plugin.test.ts
+++ b/frontend/src/test/build/changelog-plugin.test.ts
@@ -35,6 +35,15 @@ describe("findChangelogPath — dev path", () => {
     const result = findChangelogPath(DEV_DIRNAME, (p) => p === devCandidate);
     expect(result).toBe(devCandidate);
   });
+
+  it("returns the dev candidate when both candidate files exist (dev wins)", () => {
+    // Both paths exist — Array.find returns the first match, which is the dev
+    // (three-level) path. This test documents the priority and guards against
+    // a future refactor that replaces Array.find with something unordered.
+    const devCandidate = resolve(DEV_DIRNAME, "../../../CHANGELOG.md");
+    const result = findChangelogPath(DEV_DIRNAME, () => true);
+    expect(result).toBe(devCandidate);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/test/build/changelog-plugin.test.ts
+++ b/frontend/src/test/build/changelog-plugin.test.ts
@@ -1,0 +1,96 @@
+/**
+ * changelog-plugin unit tests — path resolution
+ *
+ * Covers the findChangelogPath / changelogCandidatePaths helpers that were
+ * introduced to fix the Docker build context failure (#302).
+ *
+ * findChangelogPath accepts an optional `checker` argument (injected existsSync).
+ * Tests pass a stub so no filesystem I/O occurs and search-order logic is explicit.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "path";
+import {
+  findChangelogPath,
+  changelogCandidatePaths,
+} from "../../build/changelog-plugin";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Fake dirname representing the dev layout: <repo>/frontend/src/build/ */
+const DEV_DIRNAME = "/repo/frontend/src/build";
+
+/** Fake dirname representing the Docker layout: /app/src/build/ */
+const DOCKER_DIRNAME = "/app/src/build";
+
+// ---------------------------------------------------------------------------
+// Tests: dev path resolves first
+// ---------------------------------------------------------------------------
+
+describe("findChangelogPath — dev path", () => {
+  it("returns the dev candidate when only the dev path exists", () => {
+    const devCandidate = resolve(DEV_DIRNAME, "../../../CHANGELOG.md");
+    const result = findChangelogPath(DEV_DIRNAME, (p) => p === devCandidate);
+    expect(result).toBe(devCandidate);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Docker path resolves as fallback
+// ---------------------------------------------------------------------------
+
+describe("findChangelogPath — docker path", () => {
+  it("returns the docker candidate when the dev path is absent", () => {
+    // Simulate Docker context: /app/src/build — the three-level traversal yields
+    // /CHANGELOG.md (absent); two-level gives /app/CHANGELOG.md (present).
+    const devCandidate = resolve(DOCKER_DIRNAME, "../../../CHANGELOG.md");
+    const dockerCandidate = resolve(DOCKER_DIRNAME, "../../CHANGELOG.md");
+
+    const result = findChangelogPath(
+      DOCKER_DIRNAME,
+      (p) => p !== devCandidate && p === dockerCandidate
+    );
+    expect(result).toBe(dockerCandidate);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: both missing → returns undefined
+// ---------------------------------------------------------------------------
+
+describe("findChangelogPath — both paths missing", () => {
+  it("returns undefined when neither candidate exists", () => {
+    const result = findChangelogPath(DEV_DIRNAME, () => false);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: error message contains both candidate paths
+// ---------------------------------------------------------------------------
+
+describe("changelogCandidatePaths — error message coverage", () => {
+  it("returns exactly two candidate paths", () => {
+    const paths = changelogCandidatePaths(DEV_DIRNAME);
+    expect(paths).toHaveLength(2);
+  });
+
+  it("first candidate is the three-level traversal (dev path)", () => {
+    const paths = changelogCandidatePaths(DEV_DIRNAME);
+    expect(paths[0]).toBe(resolve(DEV_DIRNAME, "../../../CHANGELOG.md"));
+  });
+
+  it("second candidate is the two-level traversal (docker path)", () => {
+    const paths = changelogCandidatePaths(DEV_DIRNAME);
+    expect(paths[1]).toBe(resolve(DEV_DIRNAME, "../../CHANGELOG.md"));
+  });
+
+  it("both candidate paths end with CHANGELOG.md", () => {
+    const paths = changelogCandidatePaths(DEV_DIRNAME);
+    for (const p of paths) {
+      expect(p.endsWith("CHANGELOG.md")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the frontend Docker build failure first seen in run [25563373994](https://github.com/glitchwerks/siege-web/actions/runs/25563373994) (commit `181e240`, merge of #298):

```
[vite-plugin-changelog] CHANGELOG.md not found at "/CHANGELOG.md".
```

The changelog Vite plugin used a single three-level path traversal (`frontend/src/build/ → ../../../ → repo root`). In Docker the build context is `./frontend/` (copied to `/app/`), so the traversal resolved to `/CHANGELOG.md` — which does not exist inside the container.

## Files changed

| File | What & Why |
|---|---|
| `frontend/src/build/changelog-plugin.ts` | Replace single-path lookup with a two-candidate search: dev path first (`../../../`), then Docker-staged path (`../../`). Extract `findChangelogPath` and `changelogCandidatePaths` helpers with an injectable `checker` arg for testability. Loud-failure behavior preserved — error message now lists both paths tried. |
| `.github/workflows/deploy.yml` | Add "Stage CHANGELOG.md into frontend build context" step (`if: matrix.service == 'siege-frontend'`) immediately before the Docker build step. Mirrors exactly what a developer must do locally when building `./frontend` as the context. The api and bot matrix legs are unaffected. |
| `frontend/.gitignore` | Ignore the staged `CHANGELOG.md` copy so it can never be accidentally committed. The canonical file lives at the repo root. |
| `.github/workflows/ci.yml` | Add `frontend-docker-build` job that runs on every PR: stages `CHANGELOG.md` then runs `docker build -f frontend/Dockerfile ./frontend`. Catches this exact failure mode before merge. ~30s cost per PR, high signal. |
| `frontend/src/test/build/changelog-plugin.test.ts` | 7 new tests for path-resolution helpers: dev path wins, docker fallback when dev absent, both missing → `undefined`, candidate list length/shape/values. |

## Test plan

- [x] `npx prettier --check src/build/changelog-plugin.ts src/test/build/changelog-plugin.test.ts` — passes
- [x] `npm run lint` — 0 errors (6 pre-existing warnings unchanged)
- [x] `npm run test -- src/test/build/` — 29 tests pass (22 parser + 7 new plugin)
- [x] `npm run test` — 152 tests pass, 0 failures
- [x] `npm run build` (local dev path) — succeeds, 1804 modules transformed
- [x] `cp CHANGELOG.md frontend/CHANGELOG.md && docker build -f frontend/Dockerfile -t siege-frontend:test ./frontend` — **Docker build succeeds** (the primary fix verified)
- [x] `rm frontend/CHANGELOG.md` — staged copy cleaned up (gitignored, not committed)

Closes #302

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_