### PR TITLE
[DO NOT MERGE] test: verify github-actions Option A persona fix

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@issue-242-option-a
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This is verification scaffolding only. It will be closed without merge once the test result is captured.

## Purpose

Per the MAJOR-severity reviewer finding on `glitchwerks/github-actions#244` (the Option A `APPEND_SYSTEM_PROMPT` persona-injection fix), we should test the fix against a consumer repo before cutting a release. Opening this PR triggers a `claude-pr-review` run that resolves the reusable workflow at the unreleased branch ref `glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@issue-242-option-a`.

## What to look for

| Outcome | Meaning |
|---|---|
| `claude-pr-review/quality-gate-shadow` = `success` | Option A works (clean review, no severity findings) — fix verified |
| `claude-pr-review/quality-gate-shadow` = `failure` (legitimate description, not `marker_missing`) | Option A works — persona is loaded and emitted the marker; the gate is just flagging severity findings in the prose |
| `claude-pr-review/quality-gate-shadow` = `error / marker_missing` | Option A also failed; sixth-hypothesis territory upstream |

## Cleanup

This PR will be **closed without merge**. Issue #308 will close alongside it. The real bump (siege-web `@v2.4.1` → `@v2.4.3`) lands later under a separate issue once Option A is verified and released upstream.

## Related

- Upstream fix: glitchwerks/github-actions#242, glitchwerks/github-actions#244
- Verification tracking: #308

Refs #308

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_