### PR TITLE
feat: v1.1 polish — login back link, attack-day preview, validation wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Validation Rule 1 (member scroll budget) now correctly counts broken-building assignments toward the limit, restoring the error message in mixed-assignment scenarios (#273)
+- Validation Rule 2 (member scroll budget) now correctly counts broken-building assignments toward the limit, restoring the error message in mixed-assignment scenarios (#273)
 
 ### Infrastructure
 

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -193,7 +193,7 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                     ValidationIssue(
                         rule=7,
                         message=(
-                            f"Post building id={building.id} (number {building.building_number}) "
+                            f"Post {building.building_number} "
                             f"has {len(building.groups)} groups (expected 1)"
                         ),
                         context={"building_id": building.id},
@@ -373,8 +373,9 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                 ValidationIssue(
                     rule=16,
                     message=(
-                        f"Post building id={building.id} (number {building.building_number}) "
-                        f"has only {condition_count} active conditions (minimum recommended: 3)"
+                        f"Post {building.building_number} "
+                        f"has only {condition_count} active conditions "
+                        f"(minimum recommended: 3)"
                     ),
                     context={"building_id": building.id, "condition_count": condition_count},
                 )

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -504,7 +504,7 @@ async def test_rule6_valid_attack_day():
 
 @pytest.mark.asyncio
 async def test_rule7_post_has_multiple_groups():
-    """Rule 7: post building with 2 groups → error."""
+    """Rule 7: post building with 2 groups → error with correct message."""
     building = _make_building(id=1, building_type=BuildingType.post, building_number=1)
     g1 = _make_group(id=1, group_number=1)
     g1.positions = []
@@ -518,6 +518,10 @@ async def test_rule7_post_has_multiple_groups():
     result = await svc_validate(session, 1)
     rule7_errors = [e for e in result.errors if e.rule == 7]
     assert len(rule7_errors) >= 1
+    # Message uses "Post N" — not the internal building.id primary key.
+    assert rule7_errors[0].message == "Post 1 has 2 groups (expected 1)"
+    # context dict is unchanged — building_id is still the machine-readable handle.
+    assert rule7_errors[0].context["building_id"] == 1
 
 
 @pytest.mark.asyncio
@@ -907,7 +911,7 @@ async def test_rule15_non_hh_no_reserve_no_warning():
 
 @pytest.mark.asyncio
 async def test_rule16_post_fewer_than_3_conditions():
-    """Rule 16: post with 1 active condition → warning."""
+    """Rule 16: post with 1 active condition → warning with correct message."""
     cond = _make_condition(id=1)
     post = _make_post(building_id=1, active_conditions=[cond])
 
@@ -924,6 +928,12 @@ async def test_rule16_post_fewer_than_3_conditions():
     result = await svc_validate(session, 1)
     rule16_warnings = [w for w in result.warnings if w.rule == 16]
     assert len(rule16_warnings) >= 1
+    # Message uses "Post N" — not the internal building.id primary key.
+    assert rule16_warnings[0].message == (
+        "Post 1 has only 1 active conditions (minimum recommended: 3)"
+    )
+    # context dict is unchanged — building_id is still the machine-readable handle.
+    assert rule16_warnings[0].context["building_id"] == 1
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, Link } from "react-router-dom";
 import apiClient from "../api/client";
-import { Shield } from "lucide-react";
+import { Shield, ChevronLeft } from "lucide-react";
 
 // Errors that map to a specific transient/technical message (not membership denial).
 const ERROR_MESSAGES: Record<string, string> = {
@@ -83,6 +83,18 @@ export default function LoginPage() {
 
         {/* Sign-in button — happy path, byte-identical behaviour */}
         <div className="space-y-4">
+          {/* Back to Home — always visible; lets users exit without a URL edit */}
+          <div className="text-center">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1 text-sm text-slate-600 transition-colors hover:text-slate-900"
+              data-testid="back-to-home-link"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back to Home
+            </Link>
+          </div>
+
           <button
             onClick={handleLogin}
             disabled={isLoading}

--- a/frontend/src/pages/SiegeMembersPage.tsx
+++ b/frontend/src/pages/SiegeMembersPage.tsx
@@ -423,22 +423,18 @@ export default function SiegeMembersPage() {
               const day2 = preview.assignments
                 .filter((a) => a.attack_day === 2)
                 .sort(byName);
-              const rows = Math.max(day1.length, day2.length);
               return (
                 <div className="grid grid-cols-2 divide-x divide-slate-200 rounded-md border border-slate-200">
                   <div>
                     <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
                       Day 1 ({day1.length})
                     </div>
-                    {Array.from({ length: rows }).map((_, i) => (
+                    {day1.map((a, i) => (
                       <div
                         key={i}
                         className="px-3 py-1.5 text-sm odd:bg-slate-50"
                       >
-                        {day1[i]
-                          ? (nameLookup[day1[i].member_id] ??
-                            `Member ${day1[i].member_id}`)
-                          : ""}
+                        {nameLookup[a.member_id] ?? `Member ${a.member_id}`}
                       </div>
                     ))}
                   </div>
@@ -446,15 +442,12 @@ export default function SiegeMembersPage() {
                     <div className="border-b border-slate-200 px-3 py-2 text-center text-xs font-semibold uppercase tracking-wide text-slate-500">
                       Day 2 ({day2.length})
                     </div>
-                    {Array.from({ length: rows }).map((_, i) => (
+                    {day2.map((a, i) => (
                       <div
                         key={i}
                         className="px-3 py-1.5 text-sm odd:bg-slate-50"
                       >
-                        {day2[i]
-                          ? (nameLookup[day2[i].member_id] ??
-                            `Member ${day2[i].member_id}`)
-                          : ""}
+                        {nameLookup[a.member_id] ?? `Member ${a.member_id}`}
                       </div>
                     ))}
                   </div>

--- a/frontend/src/test/pages/LoginPage.test.tsx
+++ b/frontend/src/test/pages/LoginPage.test.tsx
@@ -135,3 +135,47 @@ describe("LoginPage — rejection reframe", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Back to Home link (#208)
+// ---------------------------------------------------------------------------
+
+describe("LoginPage — back to home link", () => {
+  it("renders a Back to Home link in the normal (happy-path) state", async () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /back to home/i });
+      expect(link).toBeInTheDocument();
+    });
+  });
+
+  it("Back to Home link navigates to /", async () => {
+    renderWithProviders(<LoginPage />, { initialEntries: ["/login"] });
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /back to home/i });
+      expect(link).toHaveAttribute("href", "/");
+    });
+  });
+
+  it("renders Back to Home link when membership is denied (?error=unauthorized)", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=unauthorized"],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /back to home/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders Back to Home link when a technical error is present (?error=service_unavailable)", async () => {
+    renderWithProviders(<LoginPage />, {
+      initialEntries: ["/login?error=service_unavailable"],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /back to home/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/test/pages/SiegeMembersPage.test.tsx
+++ b/frontend/src/test/pages/SiegeMembersPage.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * SiegeMembersPage — Attack Day Preview dialog tests (#243)
+ *
+ * Covers:
+ *  - Symmetric case: both Day 1 and Day 2 have the same number of entries —
+ *    modal renders exact cell counts, no padding.
+ *  - Asymmetric case (bug repro): Day 1 longer than Day 2 — Day 2 column must
+ *    NOT have empty cells padded to match Day 1's row count.
+ *  - Empty Day 2: Day 1 has entries, Day 2 has none — Day 2 column renders
+ *    zero data cells (only its header).
+ *  - Column headers show member counts: "Day 1 (N)" / "Day 2 (N)".
+ */
+
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import SiegeMembersPage from "../../pages/SiegeMembersPage";
+import type { Siege, SiegeMember, AttackDayPreviewResult } from "../../api/types";
+
+// ─── Server lifecycle ──────────────────────────────────────────────────────────
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── Fixture factories ────────────────────────────────────────────────────────
+
+function makeSiege(overrides: Partial<Siege> = {}): Siege {
+  return {
+    id: 99,
+    date: "2026-05-08",
+    status: "planning",
+    defense_scroll_count: 0,
+    computed_scroll_count: 0,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSiegeMember(
+  overrides: Partial<SiegeMember> = {}
+): SiegeMember {
+  return {
+    siege_id: 99,
+    member_id: 1,
+    member_name: "Alpha",
+    member_role: "heavy_hitter",
+    member_power_level: "gt_25m",
+    attack_day: null,
+    has_reserve_set: false,
+    attack_day_override: false,
+    ...overrides,
+  };
+}
+
+function makePreview(
+  day1MemberIds: number[],
+  day2MemberIds: number[]
+): AttackDayPreviewResult {
+  return {
+    assignments: [
+      ...day1MemberIds.map((id) => ({ member_id: id, attack_day: 1 })),
+      ...day2MemberIds.map((id) => ({ member_id: id, attack_day: 2 })),
+    ],
+    expires_at: "2026-05-08T23:59:00Z",
+  };
+}
+
+/** Register per-test MSW handlers for siege + members + attack day preview. */
+function registerHandlers(
+  siege: Siege,
+  members: SiegeMember[],
+  preview: AttackDayPreviewResult
+) {
+  server.use(
+    http.get(`/api/sieges/${siege.id}`, () => HttpResponse.json(siege)),
+    http.get(`/api/sieges/${siege.id}/members`, () =>
+      HttpResponse.json(members)
+    ),
+    http.post(
+      `/api/sieges/${siege.id}/members/auto-assign-attack-day`,
+      () => HttpResponse.json(preview)
+    )
+  );
+}
+
+/** Render SiegeMembersPage routed to /sieges/:id/members. */
+function renderPage(siegeId = 99) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/sieges/:id/members" element={<SiegeMembersPage />} />
+    </Routes>,
+    { initialEntries: [`/sieges/${siegeId}/members`] }
+  );
+}
+
+// ─── Helper: open the preview dialog ─────────────────────────────────────────
+
+async function openPreviewDialog() {
+  const user = userEvent.setup();
+  // Wait for the page to finish loading
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: /auto-assign attack days/i })
+    ).toBeInTheDocument();
+  });
+  await user.click(
+    screen.getByRole("button", { name: /auto-assign attack days/i })
+  );
+  // Wait for the dialog title to confirm the modal is open
+  await waitFor(() => {
+    expect(
+      screen.getByText(/attack day preview/i)
+    ).toBeInTheDocument();
+  });
+  return screen.getByRole("dialog");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SiegeMembersPage — Attack Day Preview dialog (no empty cells)", () => {
+  it("symmetric: both columns render exact cell counts with no padding", async () => {
+    const members = [
+      makeSiegeMember({ member_id: 1, member_name: "Alpha" }),
+      makeSiegeMember({ member_id: 2, member_name: "Beta" }),
+    ];
+    const preview = makePreview([1], [2]);
+    registerHandlers(makeSiege(), members, preview);
+    renderPage();
+
+    const dialog = await openPreviewDialog();
+
+    // Each column should have exactly 1 data cell
+    const allCells = within(dialog).getAllByText(/^(Alpha|Beta)$/);
+    expect(allCells).toHaveLength(2);
+  });
+
+  it("asymmetric (bug repro): Day 1 longer than Day 2 — no empty cells in Day 2", async () => {
+    // 3 Day-1 members, 1 Day-2 member
+    const members = [
+      makeSiegeMember({ member_id: 1, member_name: "Alpha" }),
+      makeSiegeMember({ member_id: 2, member_name: "Beta" }),
+      makeSiegeMember({ member_id: 3, member_name: "Gamma" }),
+      makeSiegeMember({ member_id: 4, member_name: "Delta" }),
+    ];
+    const preview = makePreview([1, 2, 3], [4]);
+    registerHandlers(makeSiege(), members, preview);
+    renderPage();
+
+    const dialog = await openPreviewDialog();
+
+    // Total visible name cells must equal exactly 4 (3 + 1), not 6 (3 + 3 padded)
+    const nameCells = within(dialog).getAllByText(/^(Alpha|Beta|Gamma|Delta)$/);
+    expect(nameCells).toHaveLength(4);
+
+    // Day 2 column should NOT contain any empty cells (rendered as empty string).
+    // The bug rendered 2 extra empty <div> cells in the Day 2 column.
+    // Verify by checking the Day 2 column's child count equals 1 data row.
+    const day2Header = within(dialog).getByText(/day 2 \(\d+\)/i);
+    const day2Column = day2Header.parentElement!;
+    // Children after the header div = data rows. With the bug fix: 1 row only.
+    const dataRows = Array.from(day2Column.children).slice(1); // skip header child
+    expect(dataRows).toHaveLength(1);
+  });
+
+  it("empty Day 2: Day 1 has entries, Day 2 is empty — zero data rows in Day 2 column", async () => {
+    const members = [
+      makeSiegeMember({ member_id: 1, member_name: "Alpha" }),
+      makeSiegeMember({ member_id: 2, member_name: "Beta" }),
+    ];
+    // All assigned to Day 1, none to Day 2
+    const preview = makePreview([1, 2], []);
+    registerHandlers(makeSiege(), members, preview);
+    renderPage();
+
+    const dialog = await openPreviewDialog();
+
+    // Day 1 should have 2 name cells
+    const day1Names = within(dialog).getAllByText(/^(Alpha|Beta)$/);
+    expect(day1Names).toHaveLength(2);
+
+    // Day 2 column should have zero data rows
+    const day2Header = within(dialog).getByText(/day 2 \(\d+\)/i);
+    const day2Column = day2Header.parentElement!;
+    const dataRows = Array.from(day2Column.children).slice(1);
+    expect(dataRows).toHaveLength(0);
+  });
+
+  it("column headers show assignment counts (Day 1 (N) / Day 2 (N))", async () => {
+    const members = [
+      makeSiegeMember({ member_id: 1, member_name: "Alpha" }),
+      makeSiegeMember({ member_id: 2, member_name: "Beta" }),
+      makeSiegeMember({ member_id: 3, member_name: "Gamma" }),
+    ];
+    const preview = makePreview([1, 2], [3]);
+    registerHandlers(makeSiege(), members, preview);
+    renderPage();
+
+    const dialog = await openPreviewDialog();
+
+    expect(within(dialog).getByText(/day 1 \(2\)/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/day 2 \(1\)/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR bundles three v1.1 polish issues into four logical commits. Each issue has tests written before the implementation (TDD — RED → GREEN), verified clean with prettier, eslint, black, and ruff before committing.

## #208 — Add "Back to Home" link on login page

Added a `<Link to="/">` above the Sign in with Discord button in `LoginPage.tsx`. The link is always visible across all three page states (normal, membership-denial, technical-error) so users are never stranded without a way to navigate back. Uses the same `text-slate-600 hover:text-slate-900` link style as the existing self-host link. Four new tests added to `frontend/src/test/pages/LoginPage.test.tsx` (13 total, up from 9).

Verification: prettier clean, 0 eslint errors, 13/13 LoginPage tests pass, 161/161 full frontend suite.

## #243 — Auto Attack Day preview popup empty cells

Removed the `Math.max(day1.length, day2.length)` padding in the Attack Day Preview dialog in `SiegeMembersPage.tsx`. The old code iterated `rows` times for both columns, appending empty `<div>` cells to the shorter column. Now each column iterates only its own array. New test file `frontend/src/test/pages/SiegeMembersPage.test.tsx` covers: symmetric case, asymmetric case (the bug repro — Day 1 longer than Day 2), empty Day 2, and column-header count labels.

Verification: prettier clean, 0 eslint errors, 4/4 new tests pass, 161/161 full frontend suite.

## #301 — Rule 7 and Rule 16 message wording

Rewrote the user-facing validation messages in `backend/app/services/validation.py` to drop the internal `building.id` primary key:

- Rule 7: `"Post building id=N (number M) has X groups (expected 1)"` → `"Post M has X groups (expected 1)"`
- Rule 16: `"Post building id=N (number M) has only X active conditions (minimum recommended: 3)"` → `"Post M has only X active conditions (minimum recommended: 3)"`

The `context` dict (`building_id`) is unchanged. Both existing tests updated to assert the new message text and confirm `context["building_id"]` is still set.

Verification: black clean, ruff clean, 2/2 targeted tests pass, 328/329 full backend suite (1 pre-existing failure in `test_config.py::test_missing_environment_raises_validation_error` — confirmed failing on `main` before this branch).

## CHANGELOG.md cosmetic fix

Corrected a wrong rule number in the v1.0.3 entry for #273: "Rule 1" → "Rule 2". The scroll-budget rule is Rule 2; Rule 1 is the all-assigned-members-must-be-active rule.

---

Closes #208
Closes #243
Closes #301

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*