### PR TITLE
chore(workflows): bump claude-pr-review @v2.4.1 -> @v2.5.0 (#313)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.4.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.5.0
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `glitchwerks/github-actions/.github/workflows/claude-pr-review.yml` pin from `@v2.4.1` to `@v2.5.0`.
- v2.5.0 lands the W3 marker post-processor (glitchwerks/github-actions#247, closed glitchwerks/github-actions#242). The post-processor synthesizes the `<!-- claude-pr-review-summary-v1` HTML-comment marker from the prose review body when the LLM omits it, fixing the `marker_missing` shadow-gate failures.

Closes #313

## Phase 0 spike

The selector design in v2.5.0 was validated by the Phase 0 verification spike at https://github.com/glitchwerks/github-actions/pull/246#issuecomment-4409961575 — 9/9 natural-data trials passed against siege-web's own historical runs (PRs #309, #307, #298, #293, #291). 3/4 synthetic stress trials passed; the one synthetic failure (S3) is structurally impossible due to the `cancel-in-progress: true` concurrency block on the upstream workflow.

## Test plan

- [x] Diff shows exactly one line changed (workflow pin).
- [ ] After merge, the next `claude-pr-review` run on a siege-web PR shows the synthesis log line `Marker synthesized and appended: critical=N high=N medium=N low=N` and the shadow gate posts `success` (label `agree:clean` or `agree:blocking`) rather than `error / marker_missing`.
- [ ] Authoritative `claude-pr-review/quality-gate` behavior unchanged.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
