### PR TITLE
chore(board): remove dead disabled summary counter

### DIFF
--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -793,8 +793,6 @@ export default function BoardPage() {
       !p.is_reserve &&
       p.member_id == null
   ).length;
-  const disabledCount = allPositions.filter((p) => p.is_disabled).length;
-
   // Per-member assignment counts (all buildings including posts)
   const memberAssignments = useMemo(() => {
     const counts: Record<number, number> = {};
@@ -977,10 +975,6 @@ export default function BoardPage() {
         <span className="text-sm text-slate-600">
           <span className="font-semibold text-orange-600">{emptyCount}</span>{" "}
           empty
-        </span>
-        <span className="text-sm text-slate-600">
-          <span className="font-semibold text-slate-400">{disabledCount}</span>{" "}
-          disabled
         </span>
         {totalScrolls > 0 && (
           <span className="text-sm text-slate-600">

--- a/frontend/src/test/pages/BoardPage.test.tsx
+++ b/frontend/src/test/pages/BoardPage.test.tsx
@@ -3,7 +3,7 @@
  *
  * Covers:
  *  - Loading state while board data is fetched
- *  - Summary bar slot counts (assigned / reserve / empty / disabled)
+ *  - Summary bar slot counts (assigned / reserve / empty)
  *  - Position cell visual states rendered from board API data
  *  - Context-menu actions: Mark RESERVE, Clear, Assign member
  *  - MemberBucket search and role-filter interactions
@@ -170,9 +170,9 @@ describe("BoardPage — summary bar", () => {
     // Summary bar contains "4 total"
     const summaryBar = screen.getByText("total").closest("div")!;
     expect(within(summaryBar).getByText("4")).toBeInTheDocument();
-    // assigned, reserve, empty, disabled each show '1'
+    // assigned, reserve, empty each show '1'
     const ones = within(summaryBar).getAllByText("1");
-    expect(ones.length).toBeGreaterThanOrEqual(4);
+    expect(ones.length).toBeGreaterThanOrEqual(3);
   });
 });
 


### PR DESCRIPTION
## Summary

This is the second half of #256. The N/A counter was removed in PR #294; this PR removes the remaining dead `disabled` counter from the Board summary bar.

**Lines removed from `BoardPage.tsx`:**
- Line 796 (pre-PR): `const disabledCount = allPositions.filter((p) => p.is_disabled).length;`
- Lines 981–984 (pre-PR): the `<span>` wrapper rendering `{disabledCount} disabled` in the summary bar

**`is_disabled` flag preserved:** The `position.is_disabled` flag itself is untouched — it remains load-bearing for drag-drop gating, cell visual differentiation (DISABLED text + strikethrough), and image generation in `backend/app/services/image_gen.py`.

**Test update (`BoardPage.test.tsx`):**
- Summary bar count assertion updated from `>= 4` to `>= 3` (assigned / reserve / empty — disabled counter no longer rendered)
- File header comment updated to drop `/ disabled` from the summary bar coverage line

All 161 frontend tests pass. ESLint clean (0 errors). TypeScript + Vite build succeeds.

Closes #256

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_