### PR TITLE
feat(posts): inline duplicate-condition indicator on assignment radios

### DIFF
--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -218,28 +218,41 @@ function MemberAssignRow({
           {/* Condition radio buttons (only for matched members with conditions) */}
           {hasConditions && matchedConditions.length > 0 && (
             <div className="mt-1.5 flex flex-wrap gap-2">
-              {matchedConditions.map((c) => (
-                <label
-                  key={c.id}
-                  className="flex cursor-pointer items-center gap-1.5"
-                >
-                  <input
-                    type="radio"
-                    name={`condition-${member.member_id}-${postNumber}`}
-                    value={c.id}
-                    checked={selectedConditionId === c.id}
-                    onChange={() => {
-                      setSelectedConditionId(c.id);
-                      setConfirmPending(false);
-                    }}
-                    className="h-3.5 w-3.5 accent-violet-600"
-                  />
-                  <span className="flex items-center gap-1 text-xs text-slate-700">
-                    <Check className="h-3 w-3 text-green-600" />
-                    {c.description}
-                  </span>
-                </label>
-              ))}
+              {matchedConditions.map((c) => {
+                const dupKey = `${member.member_id}_${c.id}`;
+                const dupBuildingNumber = duplicateMap.get(dupKey);
+                const isInlineDuplicate =
+                  dupBuildingNumber !== undefined &&
+                  dupBuildingNumber !== postNumber;
+                return (
+                  <label
+                    key={c.id}
+                    className="flex cursor-pointer items-center gap-1.5"
+                  >
+                    <input
+                      type="radio"
+                      name={`condition-${member.member_id}-${postNumber}`}
+                      value={c.id}
+                      checked={selectedConditionId === c.id}
+                      onChange={() => {
+                        setSelectedConditionId(c.id);
+                        setConfirmPending(false);
+                      }}
+                      className="h-3.5 w-3.5 accent-violet-600"
+                    />
+                    <span className="flex items-center gap-1 text-xs text-slate-700">
+                      <Check className="h-3 w-3 text-green-600" />
+                      {c.description}
+                    </span>
+                    {isInlineDuplicate && (
+                      <span className="flex items-center gap-0.5 text-xs text-amber-600">
+                        <AlertTriangle className="h-3 w-3 text-amber-500" />
+                        Post {dupBuildingNumber}
+                      </span>
+                    )}
+                  </label>
+                );
+              })}
             </div>
           )}
 

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -10,6 +10,12 @@
  *  2. No pill when matched_condition_id is null
  *  3. No pill when matched_condition_id doesn't match any active condition
  *  4. No pill for reserve slots (is_reserve=true)
+ *
+ * Inline duplicate-condition indicator (issue #196):
+ *  5. Warning icon + "Post N" shown on radio when member+condition already assigned on a different post
+ *  6. No warning icon when member+condition pair has no entry in duplicateMap
+ *  7. No warning icon when duplicateMap entry points to the same post (self-reference)
+ *  8. Post-click confirmation dialog still appears for duplicate cases (additive, not replacement)
  */
 
 import { screen, waitFor } from "@testing-library/react";
@@ -277,5 +283,293 @@ describe("PostsTab — matched condition display", () => {
     // Reserve slots show "RESERVE" but never the condition pill
     expect(screen.getByText("RESERVE")).toBeInTheDocument();
     expect(screen.queryByText("Condition B")).not.toBeInTheDocument();
+  });
+});
+
+// ─── Inline duplicate-condition indicator (issue #196) ─────────────────────────
+
+/**
+ * Board fixture with TWO post buildings so one can act as the "other post"
+ * where the member+condition conflict lives.
+ *
+ * - Post 1 (building_number=1): the post the user is looking at (unassigned)
+ * - Post 2 (building_number=2): already has member 1 assigned with condition 5
+ */
+function makeTwoPostBoard(post2Position: Partial<PositionResponse> = {}): BoardResponse {
+  return {
+    siege_id: 42,
+    buildings: [
+      {
+        id: 20,
+        building_type: "post",
+        building_number: 1,
+        level: 3,
+        is_broken: false,
+        groups: [
+          {
+            id: 200,
+            group_number: 1,
+            slot_count: 1,
+            positions: [makePosition({ id: 1 })],
+          },
+        ],
+      },
+      {
+        id: 21,
+        building_type: "post",
+        building_number: 2,
+        level: 3,
+        is_broken: false,
+        groups: [
+          {
+            id: 201,
+            group_number: 1,
+            slot_count: 1,
+            positions: [
+              makePosition({
+                id: 2,
+                member_id: 1,
+                member_name: "Aethon",
+                matched_condition_id: 5,
+                ...post2Position,
+              }),
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("PostsTab — inline duplicate-condition indicator (#196)", () => {
+  it("shows warning icon and post number on radio when member+condition already assigned on a different post", async () => {
+    const user = userEvent.setup();
+
+    // Post 2 already has member 1 with condition 5.
+    // Post 1 is unassigned; member 1 has condition 5 as a preference.
+    const board = makeTwoPostBoard();
+    const post1 = makePost({
+      id: 1,
+      building_number: 1,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const post2 = makePost({
+      id: 2,
+      building_id: 21,
+      building_number: 2,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const member = makeSiegeMember({ member_id: 1, member_name: "Aethon" });
+
+    server.use(
+      http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+      http.get("/api/sieges/42", () => HttpResponse.json(makeSiege())),
+      http.get("/api/sieges/42/members", () => HttpResponse.json([member])),
+      http.get("/api/post-priorities", () => HttpResponse.json([])),
+      http.get("/api/sieges/42/posts", () => HttpResponse.json([post1, post2])),
+      http.get("/api/sieges/42/members/preferences", () =>
+        HttpResponse.json([
+          { member_id: 1, preferences: [{ id: 5, description: "Great Fortification", stronghold_level: 3 }] },
+        ])
+      )
+    );
+    renderBoard();
+
+    await navigateToPostsTab(user);
+
+    // Expand Post 1
+    await user.click(screen.getByRole("button", { name: /post 1/i }));
+
+    // The inline duplicate indicator should appear next to the radio for "Great Fortification"
+    // showing "Post 2" as the conflicting post — inside a <label> element on the radio button.
+    await waitFor(() => {
+      const postRefs = screen.getAllByText("Post 2");
+      // At least one occurrence must be inside a <label> (the inline indicator on the radio)
+      expect(postRefs.some((el) => el.closest("label") !== null)).toBe(true);
+    });
+  });
+
+  it("does not show warning icon when member+condition pair has no duplicate entry", async () => {
+    const user = userEvent.setup();
+
+    // Post 2 has member 1 with condition 5.
+    // Post 1 has condition 7 (different) — no conflict for member 1 + condition 7.
+    const board = makeTwoPostBoard();
+    const post1 = makePost({
+      id: 1,
+      building_number: 1,
+      active_conditions: [
+        { id: 7, description: "Stone Skin", stronghold_level: 3 },
+      ],
+    });
+    const post2 = makePost({
+      id: 2,
+      building_id: 21,
+      building_number: 2,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const member = makeSiegeMember({ member_id: 1, member_name: "Aethon" });
+
+    server.use(
+      http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+      http.get("/api/sieges/42", () => HttpResponse.json(makeSiege())),
+      http.get("/api/sieges/42/members", () => HttpResponse.json([member])),
+      http.get("/api/post-priorities", () => HttpResponse.json([])),
+      http.get("/api/sieges/42/posts", () => HttpResponse.json([post1, post2])),
+      http.get("/api/sieges/42/members/preferences", () =>
+        HttpResponse.json([
+          { member_id: 1, preferences: [{ id: 7, description: "Stone Skin", stronghold_level: 3 }] },
+        ])
+      )
+    );
+    renderBoard();
+
+    await navigateToPostsTab(user);
+
+    // Expand Post 1
+    await user.click(screen.getByRole("button", { name: /post 1/i }));
+
+    // Radio label with "Stone Skin" should appear (the one inside a <label> element)
+    await waitFor(() => {
+      const labels = screen.getAllByText("Stone Skin");
+      expect(labels.some((el) => el.closest("label") !== null)).toBe(true);
+    });
+    // No "Post N" warning text should be present inside a label (inline indicator)
+    expect(screen.queryAllByText(/^Post \d+$/).filter((el) => el.closest("label") !== null)).toHaveLength(0);
+  });
+
+  it("does not show warning icon when duplicateMap entry matches the same post (self-reference)", async () => {
+    const user = userEvent.setup();
+
+    // Post 1 already has member 1 with condition 5 assigned (same post).
+    // buildDuplicateConditionMap records member_1_condition_5 → building_number=1.
+    // When viewing Post 1's radio for "Great Fortification", the building number
+    // matches → no duplicate, no indicator.
+    const board: BoardResponse = {
+      siege_id: 42,
+      buildings: [
+        {
+          id: 20,
+          building_type: "post",
+          building_number: 1,
+          level: 3,
+          is_broken: false,
+          groups: [
+            {
+              id: 200,
+              group_number: 1,
+              slot_count: 1,
+              positions: [
+                makePosition({
+                  id: 1,
+                  member_id: 1,
+                  member_name: "Aethon",
+                  matched_condition_id: 5,
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const post1 = makePost({
+      id: 1,
+      building_number: 1,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const member = makeSiegeMember({ member_id: 1, member_name: "Aethon" });
+
+    server.use(
+      http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+      http.get("/api/sieges/42", () => HttpResponse.json(makeSiege())),
+      http.get("/api/sieges/42/members", () => HttpResponse.json([member])),
+      http.get("/api/post-priorities", () => HttpResponse.json([])),
+      http.get("/api/sieges/42/posts", () => HttpResponse.json([post1])),
+      http.get("/api/sieges/42/members/preferences", () =>
+        HttpResponse.json([
+          { member_id: 1, preferences: [{ id: 5, description: "Great Fortification", stronghold_level: 3 }] },
+        ])
+      )
+    );
+    renderBoard();
+
+    await navigateToPostsTab(user);
+
+    // Expand Post 1
+    await user.click(screen.getByRole("button", { name: /post 1/i }));
+
+    // Radio label with "Great Fortification" should appear (inside a <label> element)
+    await waitFor(() => {
+      const labels = screen.getAllByText("Great Fortification");
+      expect(labels.some((el) => el.closest("label") !== null)).toBe(true);
+    });
+    // No inline "Post N" warning inside a label (self-reference should not trigger indicator)
+    expect(screen.queryAllByText(/^Post \d+$/).filter((el) => el.closest("label") !== null)).toHaveLength(0);
+  });
+
+  it("post-click amber confirmation dialog still appears when Assign is clicked for a duplicate (additive behavior)", async () => {
+    const user = userEvent.setup();
+
+    // Same two-post setup as test 1: member 1 + condition 5 on post 2.
+    // When user clicks Assign on post 1, the existing handleAssignClick dialog fires.
+    const board = makeTwoPostBoard();
+    const post1 = makePost({
+      id: 1,
+      building_number: 1,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const post2 = makePost({
+      id: 2,
+      building_id: 21,
+      building_number: 2,
+      active_conditions: [
+        { id: 5, description: "Great Fortification", stronghold_level: 3 },
+      ],
+    });
+    const member = makeSiegeMember({ member_id: 1, member_name: "Aethon" });
+
+    server.use(
+      http.get("/api/sieges/42/board", () => HttpResponse.json(board)),
+      http.get("/api/sieges/42", () => HttpResponse.json(makeSiege())),
+      http.get("/api/sieges/42/members", () => HttpResponse.json([member])),
+      http.get("/api/post-priorities", () => HttpResponse.json([])),
+      http.get("/api/sieges/42/posts", () => HttpResponse.json([post1, post2])),
+      http.get("/api/sieges/42/members/preferences", () =>
+        HttpResponse.json([
+          { member_id: 1, preferences: [{ id: 5, description: "Great Fortification", stronghold_level: 3 }] },
+        ])
+      )
+    );
+    renderBoard();
+
+    await navigateToPostsTab(user);
+
+    // Expand Post 1
+    await user.click(screen.getByRole("button", { name: /post 1/i }));
+
+    // Wait for the Assign button to appear
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^assign$/i })).toBeInTheDocument();
+    });
+
+    // Click Assign — should trigger the existing confirmation flow
+    await user.click(screen.getByRole("button", { name: /^assign$/i }));
+
+    // The "Confirm anyway" button from the amber confirmation dialog should appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /confirm anyway/i })
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds an inline `⚠️ Post N` indicator directly on each condition radio button in `MemberAssignRow` when that member+condition pair is already assigned on a **different** post
- The indicator is visible at a glance without clicking anything — uses `AlertTriangle` (amber, `h-3 w-3`) matching the existing warning color treatment
- The existing post-click amber confirmation dialog (`handleAssignClick` → `confirmPending`) is **unchanged** — this change is purely additive

## Implementation notes

The data was already flowing: `duplicateMap` (a `Map<string, number>` keyed by `${member_id}_${condition_id}` → `building_number`) was already passed as a prop to `MemberAssignRow`. The change moves the duplicate lookup from the selected condition only to each individual radio, using:

```ts
const dupKey = `${member.member_id}_${c.id}`;
const dupBuildingNumber = duplicateMap.get(dupKey);
const isInlineDuplicate = dupBuildingNumber !== undefined && dupBuildingNumber !== postNumber;
```

The `dupBuildingNumber !== postNumber` guard prevents the self-reference case from triggering.

## Tests (4 new — `PostsTab.test.tsx`)

1. **Indicator shown** — member+condition assigned on a different post → `Post N` appears inside a `<label>`
2. **Indicator hidden** — no duplicateMap entry for this member+condition → no inline warning
3. **Indicator hidden** — duplicateMap entry points to the same post (self-reference) → no inline warning
4. **Post-click confirmation unchanged** — clicking Assign on a duplicate still shows the amber "Confirm anyway" dialog

Full suite: 161 → 165 tests, 16 files, all green. Prettier + ESLint (0 errors) + `tsc -b && vite build` all pass.

Closes #196

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_