### PR TITLE
chore(workflows): bump claude-pr-review @v2.5.0 -> @v2.5.1 (#318)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.5.0
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.5.1
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `glitchwerks/github-actions/.github/workflows/claude-pr-review.yml` pin from `@v2.5.0` to `@v2.5.1`.
- v2.5.1 hotfixes glitchwerks/github-actions#248: the prose-regex on the authoritative and shadow `claude-pr-review/quality-gate` was matching resolved-finding section headers (`#### ✅ 🔴 Critical (BLOCKING) - FIXED`) the same as fresh findings, blocking PRs whose findings were all fixed.
- siege-web's bug exposure was latent (no multi-pass-with-prior-critical scenario has run here yet), but the regression is structural — closing it before it bites.

Closes #318

## Verification upstream

The v2.5.1 fix was verified end-to-end on the actual reproduction case (`glitchwerks/claude-configs#466`):

- Pre-fix run (`@v2.5.0`): `quality-gate: failure — 1 severity marker(s) matched`, `quality-gate-shadow: agree:blocking`.
- Post-fix run (`@v2.5.1`, run id `25583085162`): `quality-gate: pass — No Critical or High-Priority findings`, `quality-gate-shadow: agree:clean`, synthesis log line `Marker synthesized and appended: critical=0 high=0 medium=0 low=0`.

A direct empirical replay against the saved bug-reproducing comment body produced `BLOCKER_HITS=1` under `@v2.5.0` and `BLOCKER_HITS=0` under `@v2.5.1`.

## Test plan

- [x] Diff is exactly one line (workflow pin).
- [ ] Next `claude-pr-review` run on this PR (or any future siege-web PR) shows the synthesis log line and the gate clears (`agree:clean`) on a clean review.
- [ ] Authoritative gate behavior on fresh single-pass reviews unchanged from v2.5.0.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
