### PR TITLE
fix(validation): render friendly building labels in Rule 3/10 messages

### DIFF
--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -33,3 +33,15 @@ class PowerLevel(enum.StrEnum):
 class NotificationBatchStatus(enum.StrEnum):
     pending = "pending"
     completed = "completed"
+
+
+# Human-readable display labels for each BuildingType value.
+# Used in user-facing validation messages so "magic_tower" renders as
+# "Magic Tower" rather than leaking the raw enum string.
+BUILDING_TYPE_LABELS: dict["BuildingType", str] = {
+    BuildingType.stronghold: "Stronghold",
+    BuildingType.mana_shrine: "Mana Shrine",
+    BuildingType.magic_tower: "Magic Tower",
+    BuildingType.defense_tower: "Defense Tower",
+    BuildingType.post: "Post",
+}

--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 from app.models.building import Building
 from app.models.building_group import BuildingGroup
 from app.models.building_type_config import BuildingTypeConfig
-from app.models.enums import BuildingType, MemberRole
+from app.models.enums import BUILDING_TYPE_LABELS, BuildingType, MemberRole
 from app.models.member import Member
 from app.models.position import Position
 from app.models.post import Post
@@ -135,7 +135,7 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                     ValidationIssue(
                         rule=3,
                         message=(
-                            f"Building id={building.id} ({building.building_type}) has number "
+                            f"{BUILDING_TYPE_LABELS[building.building_type]} has number "
                             f"{building.building_number} outside valid range [1, {config.count}]"
                         ),
                         context={
@@ -260,7 +260,8 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                 ValidationIssue(
                     rule=10,
                     message=(
-                        f"{building.building_type} {building.building_number} "
+                        f"{BUILDING_TYPE_LABELS[building.building_type]} "
+                        f"{building.building_number} "
                         f"Group {group.group_number} Position {pos.position_number} "
                         f"is unassigned, not disabled, and not marked reserve"
                     ),

--- a/backend/tests/test_enums.py
+++ b/backend/tests/test_enums.py
@@ -1,0 +1,26 @@
+"""Tests for enum definitions and associated constants in app.models.enums."""
+
+from app.models.enums import BUILDING_TYPE_LABELS, BuildingType
+
+
+def test_building_type_labels_covers_all_values():
+    """Every BuildingType member must have an entry in BUILDING_TYPE_LABELS.
+
+    This is a coverage guard: if a new BuildingType is added without a
+    corresponding label, this test will fail immediately rather than leaking
+    a raw enum value into user-facing messages at runtime.
+    """
+    assert set(BUILDING_TYPE_LABELS.keys()) == set(BuildingType)
+
+
+def test_building_type_labels_are_friendly_strings():
+    """BUILDING_TYPE_LABELS values must be non-empty title-cased display strings.
+
+    Verifies that the label for each BuildingType is a non-empty string that
+    does not match the raw enum value (i.e. underscores replaced, capitalized).
+    """
+    for bt, label in BUILDING_TYPE_LABELS.items():
+        assert isinstance(label, str), f"Label for {bt!r} must be str"
+        assert label, f"Label for {bt!r} must not be empty"
+        assert "_" not in label, f"Label for {bt!r} must not contain underscores, got {label!r}"
+        assert label[0].isupper(), f"Label for {bt!r} must start with uppercase, got {label!r}"

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -382,7 +382,7 @@ async def test_rule2_within_scroll_count():
 
 @pytest.mark.asyncio
 async def test_rule3_invalid_building_number():
-    """Rule 3: building_number=0 for stronghold (valid: 1) → error."""
+    """Rule 3: building_number=0 for stronghold → friendly label, no id= leak."""
     building = _make_building(id=1, building_type=BuildingType.stronghold, building_number=0)
     building.groups = []
     siege = _make_siege()
@@ -392,6 +392,14 @@ async def test_rule3_invalid_building_number():
     result = await svc_validate(session, 1)
     rule3_errors = [e for e in result.errors if e.rule == 3]
     assert len(rule3_errors) >= 1
+    msg = rule3_errors[0].message
+    assert "id=" not in msg, f"Message must not expose raw id, got: {msg!r}"
+    assert "stronghold" not in msg, f"Message must not expose raw enum, got: {msg!r}"
+    assert "Stronghold" in msg, f"Message must show friendly label, got: {msg!r}"
+    assert "0" in msg, f"Message must include the invalid number, got: {msg!r}"
+    # context dict must still carry machine-readable handles
+    assert rule3_errors[0].context["building_id"] == 1
+    assert rule3_errors[0].context["building_type"] == "stronghold"
 
 
 @pytest.mark.asyncio
@@ -650,7 +658,7 @@ async def test_rule10_empty_unresolved_slot():
 
 @pytest.mark.asyncio
 async def test_rule10_message_uses_position_name():
-    """Rule 10 message uses human-readable name, not raw position id."""
+    """Rule 10 message uses friendly building label, not raw enum value."""
     pos = _make_position(
         id=3090, position_number=2, member_id=None, is_disabled=False, is_reserve=False
     )
@@ -667,8 +675,12 @@ async def test_rule10_message_uses_position_name():
     assert len(rule10_warnings) >= 1
     msg = rule10_warnings[0].message
     assert "id=" not in msg, f"Message must not expose raw id, got: {msg!r}"
+    assert "stronghold" not in msg, f"Message must not expose raw enum, got: {msg!r}"
+    assert "Stronghold" in msg, f"Message must show friendly label, got: {msg!r}"
     assert "Group 3" in msg, f"Message must contain group number, got: {msg!r}"
     assert "Position 2" in msg, f"Message must contain position number, got: {msg!r}"
+    # context dict must still carry machine-readable handles
+    assert rule10_warnings[0].context["building_type"] == "stronghold"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #321 — Rules 3 and 10 were leaking internal identifiers in user-facing validation messages. Rule 10 surfaced the raw `BuildingType` enum value (`magic_tower`); Rule 3 surfaced both that enum value AND the `building.id` primary key.

## Changes

- **`backend/app/models/enums.py`** — new `BUILDING_TYPE_LABELS: dict[BuildingType, str]` mapping covers all five values (`Stronghold`, `Mana Shrine`, `Magic Tower`, `Defense Tower`, `Post`).
- **`backend/app/services/validation.py`** — Rule 3 and Rule 10 messages now use the label mapping. Rule 3 also drops the `id=` leak. The `context` dicts on both rules are unchanged so machine-readable consumers stay backward-compatible.
- **`backend/tests/test_enums.py`** (new) — coverage-guard test asserts `set(BUILDING_TYPE_LABELS.keys()) == set(BuildingType)` so future enum additions fail fast without label coverage.
- **`backend/tests/test_validation.py`** — Rule 3 and Rule 10 tests assert the new wording and the absence of the leaked identifiers.

## Out of scope (per issue)

- Rule 11 still hardcodes `"Post {building.building_number}"` — it's filtered to post-only buildings and renders correctly today.
- No `context` dict shape changes.

## Test plan

- [x] `black --check .` clean
- [x] `ruff check .` clean
- [x] `pytest` — 330 passed, 1 pre-existing failure (`test_config.py::TestEnvironmentRequired::test_missing_environment_raises_validation_error`, unrelated to this change)
- [ ] Visual spot-check of the validation panel in the frontend after merge

Closes #321

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_