### PR TITLE
docs: fix STATUS.md drift, CLAUDE.md env var gaps, README test instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ pytest
 
 On PR to `main`:
 - **Backend**: black check → ruff → pytest (uses test DB URL from env)
-- **Frontend**: npm ci → eslint → npm build
+- **Frontend**: npm ci → eslint → npm test → npm build
+- **Bot**: pytest
 
 Registry image retention is automated via a scheduled ACR Task (`weekly-purge`) in both registries — release tags (`v*`) are preserved forever; SHA/commit tags beyond the last 10 per repo and untagged manifests older than 7 days are deleted every Sunday at 03:00 UTC.
 
@@ -129,9 +130,15 @@ Copy `.env.example` to `.env`. Required:
 | `DISCORD_GUILD_ID` | backend, bot |
 | `DISCORD_BOT_API_URL` | backend (calls bot) |
 | `DISCORD_BOT_API_KEY` / `BOT_API_KEY` | backend → bot auth |
-| `DISCORD_SIEGE_CHANNEL` | backend (channel to post images) |
-| `DISCORD_SIEGE_IMAGES_CHANNEL` | backend (channel to post image CDN links) |
+| `DISCORD_SIEGE_CHANNEL` | backend (channel to post the text summary after image CDN links are known) |
+| `DISCORD_SIEGE_IMAGES_CHANNEL` | backend (channel where assignment and reserves images are posted) |
 | `ENVIRONMENT` | all (controls debug/docs) |
+| `AUTH_DISABLED` | backend (dev-only login bypass; startup guard blocks `true` outside development) |
+| `SESSION_SECRET` | backend (HS256 JWT signing key; required when auth is enabled) |
+| `DISCORD_REQUIRED_ROLE` | backend (Discord role name required to log in; default `Clan Deputies`; exact, case-sensitive match) |
+| `BOT_SERVICE_TOKEN` | backend (Bearer token for bot→backend calls; startup guard rejects empty string outside development) |
+| `ALLOWED_ORIGINS` | backend (comma-separated CORS allowlist; required for non-localhost deployments) |
+| `VITE_PUBLIC_URL` | frontend (canonical URL used in `<link rel="canonical">` and `og:url` meta tags) |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | backend, bot (optional; telemetry no-op when unset) |
 
 ## Domain Reference

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ cd backend && alembic revision --autogenerate -m "description"
 # Backend
 cd backend && python -m pytest --ignore=tests/test_schema.py -v
 
+# Frontend unit tests (Vitest)
+cd frontend && npm test
+
 # Frontend type check + build
 cd frontend && npm run build
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,20 +2,21 @@
 
 ## Current State
 
-v1.0.0 shipped and v1.0.1 delivered. The application is feature-complete and live at `rslsiege.com`
-(custom domain via Cloudflare Origin Cert). All core backend logic (CRUD, assignment board, validation
+v1.1.0 is the current release (2026-05-08), live at `rslsiege.com` (custom domain via Cloudflare Origin
+Cert). The application is feature-complete. All core backend logic (CRUD, assignment board, validation
 engine, auto-fill, attack day, comparison, Discord bot, image generation, notifications, and Excel import)
 is implemented and covered by 3500+ backend tests. Playwright end-to-end tests cover the full siege
 lifecycle. Vitest component tests cover the assignment board and notification polling. Azure Bicep IaC
 is fully deployed for both dev and prod environments via GitHub Actions CD pipelines.
 
-As of 2026-04-30 (v1.0.1, issue #246), the observability layer is live in both dev and prod: an
+v1.1.0 shipped: in-app changelog dropdown with per-user red-dot indicator (#298), inline duplicate-condition
+indicator on post-assignment radio buttons (#196), stable Posts tab sort by post number (#291), and several
+validation/board fixes (#294, #256, #301). The observability layer has been live since v1.0.1–v1.0.3: an
 Application Insights workbook (6 tiles — request rates, latency p50/p95, exception counts, bot restarts,
 image gen latency, DB query duration p95) plus 5 active alert rules (`alert5xxRate`, `alertLatencyP95`,
 `alertBotRestart`, `alertImageGenSlow`, `alertDbConnectionError`) wired to an email action group.
-SQLAlchemy/asyncpg OTel instrumentation shipped in PR #265; dev verification on 2026-04-30 confirmed
-Pattern A (type `"postgresql"`, no span duplication). The DB tile and alert were deferred from #246 and
-are now wired in PR #270. See RUNBOOK.md §6 for workbook URLs, alert inventory, and acknowledgement policy.
+SQLAlchemy/asyncpg OTel instrumentation shipped in PR #265. See RUNBOOK.md §6 for workbook URLs, alert
+inventory, and acknowledgement policy.
 
 ## Phase Completion
 
@@ -45,8 +46,10 @@ are now wired in PR #270. See RUNBOOK.md §6 for workbook URLs, alert inventory,
 - Discord bot: DM batches with per-member delivery status tracking, channel image posts
 - Playwright image generation: assignments PNG and reserves PNG from headless HTML/CSS
 - Excel import: historical .xlsm files imported as completed siege records
+- In-app changelog dropdown with per-user red-dot new-entry indicator (#298)
+- Inline duplicate-condition indicator on post-assignment radio buttons (#196)
 - 3500+ backend tests covering all routes, business logic, and constraint enforcement
-- CI pipeline: black, ruff, pytest (backend) + ESLint, build (frontend) on every PR
+- CI pipeline: black, ruff, pytest (backend) + ESLint, npm test, build (frontend) + pytest (bot) on every PR
 
 ## Phase 10 — Auth (Complete)
 
@@ -74,8 +77,8 @@ Discord OAuth2 authentication is fully implemented:
 **Post-launch (tracked):**
 - Planner sign-off walkthrough (issue #174)
 - 48-hour post-launch monitoring window (issue #175)
-- Application Insights SDK integration in backend and bot services (still pending)
-- Performance validation: board load target < 2s, image generation target < 5s (still pending)
+- Application Insights SDK integration in backend and bot services — complete; telemetry live as of #245
+- Performance validation: board load target < 2s, image generation target < 5s (item 4 in Post-Launch Activities below)
 
 ## How to Run Locally
 
@@ -91,7 +94,8 @@ Copy `.env.example` to `.env` and fill in required values before starting.
 
 CI via GitHub Actions on every PR to `main`:
 - Backend: black check → ruff → pytest
-- Frontend: npm ci → eslint → npm build
+- Frontend: npm ci → eslint → npm test → npm build
+- Bot: pytest
 
 `deploy.yml` auto-deploys to dev on push to `main` and to prod on `v*` tag push. `infra-deploy.yml` is triggered manually (`workflow_dispatch`) for any Bicep infrastructure changes.
 
@@ -102,6 +106,24 @@ CI via GitHub Actions on every PR to `main`:
 3. ~~Enable Application Insights SDK in backend and bot~~ — complete; telemetry live as of #245
 4. Validate performance: board load < 2s, image generation < 5s
 
-## Active Workstream — Infra Hygiene & Cost (Milestone #6)
+## Recently Completed — Infra Hygiene & Cost (Milestone #6)
 
-Issue #246 (workbook + alerts) is closed. **#257** (SQLAlchemy/asyncpg OTel instrumentation) shipped in PR #265 (commit `9a11733`) and is resolved: dev verification on 2026-04-30 confirmed Pattern A — `type == "postgresql"`, single row per `target`, no span duplication; both instrumentors retained. RUNBOOK.md §6 updated accordingly (PR #269). The two items deferred from #246 pending DB telemetry are now addressed in PR #270: the DB query duration p95 workbook tile (Tile 6) and the DB connection error alert rule (`alertDbConnectionError`, alert 5) are wired and deploy with the next `infra-deploy.yml` run.
+Issues #246 (workbook + alerts), #257 (SQLAlchemy/asyncpg OTel instrumentation), and #270 (DB query
+duration p95 tile + DB connection error alert) are all closed. The observability layer is fully wired:
+Pattern A OTel confirmed, RUNBOOK.md §6 updated, 5 alert rules active. See the Current State section
+above for the full workbook summary.
+
+## Active Workstreams
+
+- **Bug — Validation Rules 3 and 10 leak raw enum / DB id in messages** (#321): render "Magic Tower N"
+  instead of internal values in user-facing warning text.
+- **Bug — Board overflow on tablet / small-laptop screens** (#326): elements become unreachable below
+  ~1200px viewport width.
+- **Design — mom_bot framework cross-cut** (#322): `/me/preferences` endpoints + `X-Acting-Discord-Id`
+  header for Epic 2.5 bot integration.
+- **Design — Inter-component compatibility contracts** (#315, follow-on to #311): per-component versioning
+  discipline and compatibility contract approach.
+- **Infra — `infra-deploy.yml` hybrid trigger** (#290): auto-trigger dev on `infra/**` push; prod remains
+  manual.
+- **Observability follow-ups** (#251, #250, #263): cost anomaly detection, capacity/health alerts,
+  per-alert auto-mitigation policy review.


### PR DESCRIPTION
## Summary

- **`docs/STATUS.md`**: Updated Current State header to reflect v1.1.0 as the current release (was "v1.0.0 shipped and v1.0.1 delivered"); added v1.1.0 feature highlights to What's Working; resolved the Phase 9 "still pending" contradiction (App Insights and performance validation were marked complete in Post-Launch Activities but still said "still pending" in the Phase 9 subsection); renamed the closed Infra Hygiene workstream to "Recently Completed" and added a new Active Workstreams section listing currently open issues (#321, #326, #322, #315, #290, #251, #250, #263); corrected the Deployment CI description to match the actual workflow (adds `npm test` for frontend, adds bot pytest).

- **`CLAUDE.md`**: Added six env vars the codebase reads but the table omitted (`AUTH_DISABLED`, `SESSION_SECRET`, `DISCORD_REQUIRED_ROLE`, `BOT_SERVICE_TOKEN`, `ALLOWED_ORIGINS`, `VITE_PUBLIC_URL`); swapped the descriptions for `DISCORD_SIEGE_CHANNEL` and `DISCORD_SIEGE_IMAGES_CHANNEL` which were backwards (verified against `backend/app/api/notifications.py:415–429`); added `npm test` and a Bot pytest line to the CI section to match the actual `ci.yml` jobs.

- **`README.md`**: Added `cd frontend && npm test` to the Tests section so developers learn the Vitest suite exists and how to run it.

Closes #329

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_