### PR TITLE
docs(readme): add status badges and live-site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Siege Assignment Web App
 
+[![CI](https://img.shields.io/github/actions/workflow/status/glitchwerks/siege-web/ci.yml?branch=main&label=CI&logo=github)](https://github.com/glitchwerks/siege-web/actions/workflows/ci.yml)
+[![Deploy](https://img.shields.io/github/actions/workflow/status/glitchwerks/siege-web/deploy.yml?branch=main&label=deploy&logo=github)](https://github.com/glitchwerks/siege-web/actions/workflows/deploy.yml)
+[![Latest release](https://img.shields.io/github/v/release/glitchwerks/siege-web?label=release&logo=github&color=blue)](https://github.com/glitchwerks/siege-web/releases/latest)
+[![Live site](https://img.shields.io/badge/live-rslsiege.com-success?logo=cloudflare&logoColor=white)](https://rslsiege.com)
+
+🌐 **Live site:** <https://rslsiege.com>
+
 Web application for managing Raid Shadow Legends clan siege assignments. Replaces the manual Discord/Excel workflow with a unified web UI backed by a relational database.
 
 ## Architecture


### PR DESCRIPTION
## Summary

Adds a four-badge row and a prominent live-site link to the top of `README.md`:

| Badge | Source |
| --- | --- |
| **CI** | `ci.yml` workflow status on `main` (shields.io) |
| **Deploy** | `deploy.yml` workflow status on `main` (shields.io) |
| **Latest release** | GitHub Releases — auto-updates (shields.io) |
| **Live site** | Custom badge linking to <https://rslsiege.com> |

Also sets the GitHub repo Homepage URL to `https://rslsiege.com` (was empty) — done out-of-band via `gh repo edit --homepage`, not in the diff.

## Why

Badges give contributors and visitors at-a-glance signal on CI/deploy health and current version. The live URL belonged in both the README and the repo metadata; previously the only place `rslsiege.com` appeared was `infra/main.prod.bicepparam`. Followup to the audit work in #329 / #331.

## Test plan

- [ ] Render the README on the PR diff page — badges should load (not show broken-image icons)
- [ ] Click each badge — CI/Deploy go to the workflow runs page, release goes to /releases/latest, live-site goes to rslsiege.com
- [ ] Repo About panel shows the homepage link

Closes #333

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_