### PR TITLE
ci: run ci.yml on push to main so the CI badge reports status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Adds `push: branches: [main]` to `.github/workflows/ci.yml` triggers so the CI status badge added in #334 has `head_branch=main` runs to report on.

## Why the badge was empty

shields.io filters workflow runs by `?branch=main`, which under the hood matches `head_branch`. PR-triggered runs have `head_branch = <source-branch>`, never `main`. With `ci.yml` triggering only on `pull_request`, there were zero matching runs — confirmed via:

```
$ gh api 'repos/glitchwerks/siege-web/actions/workflows/ci.yml/runs?branch=main'
{ "total_count": 0, "workflow_runs": [] }
```

## Why a push trigger is the right fix

- **Accurate badge**: one run per merge into main, so the badge always reflects the current state of `main`.
- **PR-pair race-condition net**: catches the case where two PRs each pass individually but break together after both merge — a real failure mode the PR-only trigger misses.
- **Concurrency safe**: existing `concurrency: group: ci-${{ github.head_ref || github.run_id }}` already handles `push` events correctly (`head_ref` is empty → falls back to `run_id`, so each push gets its own group with no cancellation).

## Cost

~1 extra CI run per merged PR. Single-digit minutes of runner time per merge.

## Test plan

- [ ] CI passes on this PR (the workflow itself parses cleanly)
- [ ] After merge, `gh api 'repos/.../runs?branch=main'` returns at least one run
- [ ] Badge in README renders with passing/failing status, not "no status"

Closes #336

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_