### PR TITLE
fix(ci): replace WIKI_PAT with github.token for wiki publish

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -14,7 +14,7 @@ on:
         default: 'false'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -28,7 +28,7 @@ jobs:
         uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           path: wiki/
-          token: ${{ secrets.WIKI_PAT }}
+          token: ${{ github.token }}
           dry-run: ${{ github.event.inputs.dry_run || 'false' }}
           ignore: |
             .DS_Store


### PR DESCRIPTION
## Root cause

The `WIKI_PAT` secret was scoped to the old `cbeaulieu-gt` org. After the repo was renamed to `glitchwerks/siege-web`, the PAT no longer had write access to `glitchwerks/siege-web.wiki.git`. Every push-triggered run since PR #280 (v4→v5 action bump) has failed at `git push -f origin master` with:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/glitchwerks/siege-web.wiki.git/'
Uncaught Error: Assertion failed   ← zx's ChildProcess exit handler, wrapping the 128 exit code
```

The `Assertion failed` surface in the issue was zx's error formatter obscuring the actual stderr — the real message was one line above it. The wiki clone step succeeded (wiki repos are public, no auth needed for read) which is why the failure was non-obvious.

The last green run (manual dispatch 2026-05-07 02:06 UTC) used the same broken PAT but ran under v4, which used a bash script that emitted a cleaner error. The subsequent failures were all push-triggered runs after the v5 bump landed — same underlying credential problem, newly exposed by zx's error formatting.

## What changed

| | Before | After |
|---|---|---|
| `permissions.contents` | `read` | `write` |
| `token` input | `${{ secrets.WIKI_PAT }}` | `${{ github.token }}` |

`github.token` is always scoped to the current repo, auto-rotates every run, and is what the action defaults to in its own `action.yml`. No secret management required.

## Regression prevention

`github.token` cannot go stale or lose scope on a rename — it's issued fresh per run, bound to the repo the workflow runs in. The `WIKI_PAT` secret can be deleted from the repo settings (Settings → Secrets → Actions → `WIKI_PAT`) once this merges.

## Verification

- `workflow_dispatch` on this branch ran green: https://github.com/glitchwerks/siege-web/actions/runs/25618678737
- Published wiki cloned and grepped — zero `cbeaulieu-gt` references confirmed.

Closes #338

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_