### PR TITLE
ux(post-suggestions): round 1 modal polish from user testing

### DIFF
--- a/backend/app/schemas/post_suggestions.py
+++ b/backend/app/schemas/post_suggestions.py
@@ -31,6 +31,8 @@ class PostSuggestionEntry(BaseModel):
         current_member_name: Display name of the current member, or None.
         current_condition_id: The matched_condition_id currently on the
             position, or None.
+        current_condition_description: Human-readable text of the current
+            matched condition, or None.
         matches_current: True when the suggestion exactly matches the
             existing assignment.  Always False when suggested_member_id is
             None.
@@ -53,6 +55,7 @@ class PostSuggestionEntry(BaseModel):
     current_member_id: int | None
     current_member_name: str | None
     current_condition_id: int | None
+    current_condition_description: str | None
     matches_current: bool
     skip_reason: Literal["no_match", "reserve", "disabled"] | None
 

--- a/backend/app/services/post_suggestions.py
+++ b/backend/app/services/post_suggestions.py
@@ -98,7 +98,8 @@ async def preview_post_suggestions(
             selectinload(Siege.posts)
             .selectinload(Post.building)
             .selectinload(Building.groups)
-            .selectinload(BuildingGroup.positions),
+            .selectinload(BuildingGroup.positions)
+            .selectinload(Position.matched_condition),
             selectinload(Siege.posts).selectinload(Post.active_conditions),
             selectinload(Siege.siege_members)
             .selectinload(SiegeMember.member)
@@ -170,6 +171,13 @@ async def preview_post_suggestions(
         current_member_id = position.member_id
         current_member_name = position.member.name if position.member is not None else None
         current_condition_id = position.matched_condition_id
+        # `getattr` shim so SimpleNamespace test fixtures (which don't
+        # include the relationship) still work alongside real ORM objects
+        # where `matched_condition` is loaded via selectinload above.
+        matched_condition = getattr(position, "matched_condition", None)
+        current_condition_description = (
+            matched_condition.description if matched_condition is not None else None
+        )
 
         if position.is_reserve:
             assignments.append(
@@ -180,6 +188,7 @@ async def preview_post_suggestions(
                     current_member_id=current_member_id,
                     current_member_name=current_member_name,
                     current_condition_id=current_condition_id,
+                    current_condition_description=current_condition_description,
                 )
             )
             continue
@@ -193,6 +202,7 @@ async def preview_post_suggestions(
                     current_member_id=current_member_id,
                     current_member_name=current_member_name,
                     current_condition_id=current_condition_id,
+                    current_condition_description=current_condition_description,
                 )
             )
             continue
@@ -211,6 +221,7 @@ async def preview_post_suggestions(
                     current_member_id=current_member_id,
                     current_member_name=current_member_name,
                     current_condition_id=current_condition_id,
+                    current_condition_description=current_condition_description,
                 )
             )
             continue
@@ -259,6 +270,7 @@ async def preview_post_suggestions(
                 current_member_id=current_member_id,
                 current_member_name=current_member_name,
                 current_condition_id=current_condition_id,
+                current_condition_description=current_condition_description,
                 matches_current=matches_current,
                 skip_reason=None,
             )
@@ -487,6 +499,7 @@ def _null_entry(
     current_member_id: int | None = None,
     current_member_name: str | None = None,
     current_condition_id: int | None = None,
+    current_condition_description: str | None = None,
 ) -> PostSuggestionEntry:
     """Build a PostSuggestionEntry with no suggestion (skipped post).
 
@@ -514,6 +527,7 @@ def _null_entry(
         current_member_id=current_member_id,
         current_member_name=current_member_name,
         current_condition_id=current_condition_id,
+        current_condition_description=current_condition_description,
         matches_current=False,
         skip_reason=skip_reason,
     )

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -267,6 +267,7 @@ export interface PostSuggestionEntry {
   current_member_id: number | null;
   current_member_name: string | null;
   current_condition_id: number | null;
+  current_condition_description: string | null;
   matches_current: boolean;
   skip_reason: PostSuggestionSkipReason | null;
 }

--- a/frontend/src/components/PostSuggestionsModal.tsx
+++ b/frontend/src/components/PostSuggestionsModal.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { Checkbox } from "./ui/checkbox";
+import { priorityLabel, priorityBadgeColor } from "../lib/post-priority";
 
 interface Props {
   open: boolean;
@@ -41,10 +42,7 @@ const SKIP_REASON_LABEL: Record<
   disabled: "Position is disabled",
 };
 
-const STALE_REASON_LABEL: Record<
-  PostSuggestionStaleEntry["reason"],
-  string
-> = {
+const STALE_REASON_LABEL: Record<PostSuggestionStaleEntry["reason"], string> = {
   position_missing: "position was removed",
   position_disabled: "position was disabled",
   position_reserve: "position was set to reserve",
@@ -99,7 +97,10 @@ export default function PostSuggestionsModal({
     onError: (err: unknown) => {
       // Check for structured 409 stale_entries response
       const axiosErr = err as {
-        response?: { status?: number; data?: { detail?: { stale_entries?: PostSuggestionStaleEntry[] } } };
+        response?: {
+          status?: number;
+          data?: { detail?: { stale_entries?: PostSuggestionStaleEntry[] } };
+        };
       };
       if (
         axiosErr.response?.status === 409 &&
@@ -142,9 +143,7 @@ export default function PostSuggestionsModal({
   function handleApply() {
     if (!preview) return;
     const selectedIds = preview.assignments
-      .filter(
-        (e) => e.suggested_member_id !== null && checked[e.position_id]
-      )
+      .filter((e) => e.suggested_member_id !== null && checked[e.position_id])
       .map((e) => e.position_id);
     applyMutation.mutate(selectedIds);
   }
@@ -223,7 +222,7 @@ export default function PostSuggestionsModal({
             <p className="text-sm text-slate-500">Generating suggestions…</p>
           )}
 
-          {/* Assignment table */}
+          {/* Assignment table — sorted by post number for stable scan order */}
           {preview && preview.assignments.length > 0 && (
             <div className="max-h-[28rem] overflow-y-auto rounded-lg border border-slate-200">
               <Table>
@@ -238,81 +237,100 @@ export default function PostSuggestionsModal({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {preview.assignments.map((entry) => {
-                    const isSkipped = entry.suggested_member_id === null;
-                    const isStale = !!staleByPositionId[entry.position_id];
-                    return (
-                      <TableRow
-                        key={entry.position_id}
-                        className={isStale ? "bg-amber-50" : undefined}
-                      >
-                        <TableCell>
-                          <Checkbox
-                            checked={
-                              !isSkipped && !!checked[entry.position_id]
-                            }
-                            disabled={isSkipped}
-                            onCheckedChange={() =>
-                              !isSkipped && toggleCheck(entry.position_id)
-                            }
-                          />
-                        </TableCell>
+                  {[...preview.assignments]
+                    .sort((a, b) => a.building_number - b.building_number)
+                    .map((entry) => {
+                      const isSkipped = entry.suggested_member_id === null;
+                      const isStale = !!staleByPositionId[entry.position_id];
+                      // Row tint:
+                      //   stale (post-409)        → amber
+                      //   suggestion = current    → muted slate (no change)
+                      //   suggestion ≠ current    → emerald (new assignment)
+                      //   skipped                 → default
+                      let rowClass: string | undefined;
+                      if (isStale) {
+                        rowClass = "bg-amber-50";
+                      } else if (isSkipped) {
+                        rowClass = undefined;
+                      } else if (entry.matches_current) {
+                        rowClass = "bg-slate-50 text-slate-500";
+                      } else {
+                        rowClass = "bg-emerald-50";
+                      }
+                      return (
+                        <TableRow key={entry.position_id} className={rowClass}>
+                          <TableCell>
+                            <Checkbox
+                              checked={
+                                !isSkipped && !!checked[entry.position_id]
+                              }
+                              disabled={isSkipped}
+                              onCheckedChange={() =>
+                                !isSkipped && toggleCheck(entry.position_id)
+                              }
+                            />
+                          </TableCell>
 
-                        <TableCell className="font-medium">
-                          {entry.building_number}
-                        </TableCell>
+                          <TableCell className="font-medium">
+                            {entry.building_number}
+                          </TableCell>
 
-                        <TableCell>
-                          <Badge variant="outline">{entry.priority}</Badge>
-                        </TableCell>
-
-                        <TableCell className="text-sm text-slate-600">
-                          {entry.current_member_name ? (
-                            <span>
-                              {entry.current_member_name}
-                              {entry.current_condition_id && (
-                                <span className="ml-1 text-xs text-slate-400">
-                                  (cond #{entry.current_condition_id})
-                                </span>
-                              )}
+                          <TableCell>
+                            <span
+                              className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${priorityBadgeColor(entry.priority)}`}
+                            >
+                              {priorityLabel(entry.priority)}
                             </span>
-                          ) : (
-                            <span className="italic text-slate-400">—</span>
-                          )}
-                        </TableCell>
+                          </TableCell>
 
-                        <TableCell className="text-sm">
-                          {isSkipped ? (
-                            <span className="italic text-slate-400">
-                              {SKIP_REASON_LABEL[entry.skip_reason!]}
-                            </span>
-                          ) : (
-                            <span>
-                              {entry.suggested_member_name}
-                              {entry.suggested_condition_description && (
-                                <span className="ml-1 text-xs text-slate-500">
-                                  ({entry.suggested_condition_description})
-                                </span>
-                              )}
-                            </span>
-                          )}
-                        </TableCell>
+                          {/* Current cell: member name on top, condition smaller below */}
+                          <TableCell className="text-sm">
+                            {entry.current_member_name ? (
+                              <div className="leading-tight">
+                                <div className="text-slate-700">
+                                  {entry.current_member_name}
+                                </div>
+                                {entry.current_condition_description && (
+                                  <div className="text-xs text-slate-400">
+                                    {entry.current_condition_description}
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <span className="italic text-slate-400">—</span>
+                            )}
+                          </TableCell>
 
-                        <TableCell>
-                          {entry.matches_current && (
-                            <Badge variant="outline" className="text-xs text-slate-500">
-                              = current
-                            </Badge>
-                          )}
-                          {isStale && (
-                            <Badge variant="yellow" className="text-xs">
-                              stale
-                            </Badge>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
+                          {/* Suggested cell: same vertical stack, or skip reason */}
+                          <TableCell className="text-sm">
+                            {isSkipped ? (
+                              <span className="italic text-slate-400">
+                                {SKIP_REASON_LABEL[entry.skip_reason!]}
+                              </span>
+                            ) : (
+                              <div className="leading-tight">
+                                <div className="font-medium text-slate-800">
+                                  {entry.suggested_member_name}
+                                </div>
+                                {entry.suggested_condition_description && (
+                                  <div className="text-xs text-slate-500">
+                                    {entry.suggested_condition_description}
+                                  </div>
+                                )}
+                              </div>
+                            )}
+                          </TableCell>
+
+                          <TableCell>
+                            {isStale && (
+                              <Badge variant="yellow" className="text-xs">
+                                stale
+                              </Badge>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                 </TableBody>
               </Table>
             </div>

--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -19,6 +19,7 @@ import type {
 } from "../api/types";
 import { Button } from "./ui/button";
 import PostSuggestionsModal from "./PostSuggestionsModal";
+import { PRIORITY_LABELS, PRIORITY_BADGE_COLORS } from "../lib/post-priority";
 
 // ─── Constants (duplicated from BoardPage to keep this file self-contained) ───
 
@@ -49,20 +50,6 @@ const POWER_LABELS: Record<string, string> = {
   "16_20m": "16-20M",
   "21_25m": "21-25M",
   gt_25m: ">25M",
-};
-
-const PRIORITY_LABELS: Record<number, string> = {
-  0: "Unset",
-  1: "Low",
-  2: "Medium",
-  3: "High",
-};
-
-const PRIORITY_BADGE_COLORS: Record<number, string> = {
-  0: "bg-slate-100 text-slate-400",
-  1: "bg-slate-100 text-slate-600",
-  2: "bg-amber-100 text-amber-700",
-  3: "bg-red-100 text-red-700",
 };
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -738,24 +725,24 @@ export function PostsTab({
       </div>
 
       <div className="space-y-2">
-      {sortedPostBuildings.map((building) => {
-        const post = postByNumber.get(building.building_number);
-        return (
-          <PostRow
-            key={building.id}
-            postBuilding={building}
-            siegeId={siegeId}
-            siegeMembers={siegeMembers}
-            preferenceMap={preferenceMap}
-            duplicateMap={duplicateMap}
-            isLocked={isLocked}
-            postNumber={building.building_number}
-            priority={post?.priority ?? 1}
-            priorityDescription={post?.description ?? null}
-            activeConditions={post?.active_conditions ?? []}
-          />
-        );
-      })}
+        {sortedPostBuildings.map((building) => {
+          const post = postByNumber.get(building.building_number);
+          return (
+            <PostRow
+              key={building.id}
+              postBuilding={building}
+              siegeId={siegeId}
+              siegeMembers={siegeMembers}
+              preferenceMap={preferenceMap}
+              duplicateMap={duplicateMap}
+              isLocked={isLocked}
+              postNumber={building.building_number}
+              priority={post?.priority ?? 1}
+              priorityDescription={post?.description ?? null}
+              activeConditions={post?.active_conditions ?? []}
+            />
+          );
+        })}
       </div>
 
       <PostSuggestionsModal

--- a/frontend/src/lib/post-priority.ts
+++ b/frontend/src/lib/post-priority.ts
@@ -1,0 +1,29 @@
+/**
+ * Post priority constants shared across PostsTab, PostSuggestionsModal,
+ * and any other surface that renders a Post's `priority` field.
+ *
+ * Priority is stored as a raw int on the Post model (not an enum) and
+ * mapped to a display label / badge color here.
+ */
+
+export const PRIORITY_LABELS: Record<number, string> = {
+  0: "Unset",
+  1: "Low",
+  2: "Medium",
+  3: "High",
+};
+
+export const PRIORITY_BADGE_COLORS: Record<number, string> = {
+  0: "bg-slate-100 text-slate-400",
+  1: "bg-slate-100 text-slate-600",
+  2: "bg-amber-100 text-amber-700",
+  3: "bg-red-100 text-red-700",
+};
+
+export function priorityLabel(priority: number): string {
+  return PRIORITY_LABELS[priority] ?? String(priority);
+}
+
+export function priorityBadgeColor(priority: number): string {
+  return PRIORITY_BADGE_COLORS[priority] ?? "bg-slate-100 text-slate-600";
+}

--- a/frontend/src/test/components/PostSuggestionsModal.test.tsx
+++ b/frontend/src/test/components/PostSuggestionsModal.test.tsx
@@ -53,6 +53,7 @@ function makePreview(
         current_member_id: null,
         current_member_name: null,
         current_condition_id: null,
+        current_condition_description: null,
         matches_current: false,
         skip_reason: null,
       },
@@ -68,6 +69,7 @@ function makePreview(
         current_member_id: null,
         current_member_name: null,
         current_condition_id: null,
+        current_condition_description: null,
         matches_current: false,
         skip_reason: "no_match",
       },
@@ -103,9 +105,7 @@ describe("PostSuggestionsModal", () => {
     renderModal();
 
     // Wait for the table to appear (preview request resolves)
-    await waitFor(() =>
-      expect(screen.getByText("Alice")).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
 
     // Row for skipped post
     expect(screen.getByText("No match found")).toBeInTheDocument();
@@ -152,6 +152,7 @@ describe("PostSuggestionsModal", () => {
           current_member_id: null,
           current_member_name: null,
           current_condition_id: null,
+          current_condition_description: null,
           matches_current: false,
           skip_reason: null,
         },
@@ -167,6 +168,7 @@ describe("PostSuggestionsModal", () => {
           current_member_id: null,
           current_member_name: null,
           current_condition_id: null,
+          current_condition_description: null,
           matches_current: false,
           skip_reason: null,
         },
@@ -177,10 +179,13 @@ describe("PostSuggestionsModal", () => {
       http.post("/api/sieges/42/post-suggestions", () =>
         HttpResponse.json(twoSuggestions)
       ),
-      http.post("/api/sieges/42/post-suggestions/apply", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ applied_count: 1 });
-      })
+      http.post(
+        "/api/sieges/42/post-suggestions/apply",
+        async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ applied_count: 1 });
+        }
+      )
     );
 
     const user = userEvent.setup();
@@ -195,15 +200,17 @@ describe("PostSuggestionsModal", () => {
     await user.click(checkboxes[0]);
 
     // Apply — only Bob (103) should be in payload
-    const applyBtn = screen.getByRole("button", { name: /apply selected \(1\)/i });
+    const applyBtn = screen.getByRole("button", {
+      name: /apply selected \(1\)/i,
+    });
     await user.click(applyBtn);
 
     await waitFor(() => {
       expect(capturedBody).not.toBeNull();
     });
 
-    expect((capturedBody!.apply_position_ids as number[])).not.toContain(101);
-    expect((capturedBody!.apply_position_ids as number[])).toContain(103);
+    expect(capturedBody!.apply_position_ids as number[]).not.toContain(101);
+    expect(capturedBody!.apply_position_ids as number[]).toContain(103);
   });
 
   it("apply success invalidates board query and closes modal", async () => {
@@ -241,9 +248,7 @@ describe("PostSuggestionsModal", () => {
         HttpResponse.json(
           {
             detail: {
-              stale_entries: [
-                { position_id: 101, reason: "member_changed" },
-              ],
+              stale_entries: [{ position_id: 101, reason: "member_changed" }],
             },
           },
           { status: 409 }
@@ -298,6 +303,7 @@ describe("PostSuggestionsModal", () => {
                   current_member_id: null,
                   current_member_name: null,
                   current_condition_id: null,
+                  current_condition_description: null,
                   matches_current: false,
                   skip_reason: null,
                 },


### PR DESCRIPTION
## Summary

Five UX changes to the `PostSuggestionsModal` shipped in #335 (closing #197), driven by first-pass user testing. Closes #341. Display-side only — no algorithm or apply-path behavior changes.

## Changes

| # | Change | Files |
|---|---|---|
| 1 | Priority renders as label ("High"/"Medium"/"Low"/"Unset") with the same coloured badge `PostsTab` uses, not the raw integer | `lib/post-priority.ts` (new), `PostsTab.tsx`, `PostSuggestionsModal.tsx` |
| 2 | Rows ordered by post number ascending — display sort only; algorithm still runs in priority order on the backend | `PostSuggestionsModal.tsx` |
| 3 | Replaced the `= current` badge with row tinting: emerald = new assignment, slate = unchanged, amber = stale | `PostSuggestionsModal.tsx` |
| 4 | "Current" cell shows condition **description**, not `cond #N`. New `current_condition_description` field on the response schema; backend selectinloads `Position.matched_condition` to populate it | `schemas/post_suggestions.py`, `services/post_suggestions.py`, `api/types.ts`, `PostSuggestionsModal.tsx` |
| 5 | Both "Current" and "Suggested" cells stack member name (primary) over condition (smaller secondary) to save horizontal space | `PostSuggestionsModal.tsx` |

The priority constants are lifted from `PostsTab.tsx` into `lib/post-priority.ts` so both surfaces stay in sync — `PostsTab` now imports from the shared module.

## Test coverage

- Backend: 31 unit tests (`test_post_suggestions.py`) + 5 integration tests still green; full suite at 365 passing.
- Frontend: 16 component tests (`PostSuggestionsModal.test.tsx` + `PostsTab.test.tsx`) green; fixtures updated to include the new `current_condition_description` field.
- `black --check`, `ruff check`, `eslint`, `prettier --check`, and `npm run build` clean on changed files.

A `getattr(position, "matched_condition", None)` shim keeps the `SimpleNamespace` test fixtures working alongside real ORM objects loaded via `selectinload`.

## Test plan

- [x] Backend lint + tests green locally
- [x] Frontend lint + build + tests green locally
- [ ] Visual smoke: open Suggest modal on a planning siege, confirm row tinting, vertical-stack cells, "High/Medium/Low" badges, post-number ordering, and condition descriptions in both Current and Suggested columns.

Closes #341

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_