### PR TITLE
ci: pin third-party workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]
     if: failure() && github.event_name == 'pull_request'
-    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
     secrets: inherit
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]
     if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@1528c7cde177d9e0d1593976f5824323ec169571 # v2.6.1
     secrets: inherit
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fix:
-    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
     secrets: inherit
     with:
       auto_apply: true

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   fix:
-    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/ci-failure.yaml@1528c7cde177d9e0d1593976f5824323ec169571 # v2.6.1
     secrets: inherit
     with:
       auto_apply: true

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@1528c7cde177d9e0d1593976f5824323ec169571 # v2.6.1
     with:
       authorized_users: cbeaulieu-gt
     secrets: inherit

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   review:
-    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
     with:
       authorized_users: cbeaulieu-gt
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,5 +18,5 @@ permissions:
 
 jobs:
   respond:
-    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,5 +18,5 @@ permissions:
 
 jobs:
   respond:
-    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@89ade69f511f1b2634ea4bc2c7d4998dcbcfda50 # v2.6.1
+    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@1528c7cde177d9e0d1593976f5824323ec169571 # v2.6.1
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -224,12 +224,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-api-dev
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-api-dev
@@ -249,12 +249,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-frontend-dev
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-frontend-dev
@@ -269,12 +269,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-bot-dev
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-bot-dev
@@ -306,12 +306,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-api-prod
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-api-prod
@@ -335,12 +335,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-frontend-prod
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-frontend-prod
@@ -359,12 +359,12 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy siege-web-bot-prod
-        uses: azure/container-apps-deploy-action@v2
+        uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
         with:
           resourceGroup: ${{ vars.RESOURCE_GROUP }}
           containerAppName: siege-web-bot-prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -224,7 +224,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -249,7 +249,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -306,7 +306,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -335,7 +335,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -359,7 +359,7 @@ jobs:
 
     steps:
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -173,7 +173,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -238,7 +238,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -236,7 +236,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Azure
-        uses: azure/login@v3
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Publish wiki/ to GitHub Wiki
-        uses: Andrew-Chen-Wang/github-wiki-action@v5
+        uses: Andrew-Chen-Wang/github-wiki-action@64efa0a9436db17670a2259e0ac249d6f08bb352 # v5
         with:
           path: wiki/
           token: ${{ github.token }}


### PR DESCRIPTION
## Summary

- SHA-pin third-party workflow actions used by wiki publishing, Azure deploy, infra deploy, and shared Claude reusable workflows.
- Add Dependabot monitoring for GitHub Actions so future SHA updates surface as PRs.
- Leave first-party `actions/*` references on version tags because this issue targets third-party mutable tags.

Fixes #340.

## Test plan

- [x] Parsed all `.github/workflows/*.yml` and `.github/dependabot.yml` with PyYAML.
- [x] Scanned workflows to confirm no remaining `azure/*@v*`, `glitchwerks/github-actions*@v*`, or `Andrew-Chen-Wang/*@v*` third-party mutable tag references.
- [x] Ran `git diff --check`.
