### PR TITLE
docs: reframe wiki + README around comprehensive-utility positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@
 
 🌐 **Live site:** <https://rslsiege.com>
 
-Web application for managing Raid Shadow Legends clan siege assignments. Replaces the manual Discord/Excel workflow with a unified web UI backed by a relational database.
+A comprehensive web utility for coordinating Raid Shadow Legends clan siege assignments — validated, automated, Discord-native, and self-hostable.
+
+## Features
+
+- **Validated assignments** — 16 rule checks catch overlaps, capacity errors, and misplacements before you post.
+- **One-click auto-fill** — preview a complete assignment for any empty positions, then commit exactly what you saw.
+- **Attack-day logic** — pinned members count toward Day 2 thresholds automatically; no manual bookkeeping.
+- **Discord-native sign-in and notifications** — OAuth2 login gated by Discord role, async DM batches with delivery tracking, and assignment images posted to your siege channels.
+- **Generated assignment images** — server-rendered PNGs of the full board, posted directly to Discord (no screenshots, no manual cropping).
+- **Self-hostable** — runs on any Docker host or a managed Azure stack. Open source, MIT licensed, no SaaS dependency.
 
 ## Architecture
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Get a populated local instance of RSL Siege Manager running in under 5 minutes. No Discord account needed — the default dev profile runs in demo mode with pre-seeded data and authentication disabled.
+Get a populated local instance of RSL Siege Manager running in under 5 minutes. No Discord account needed — demo mode ships pre-seeded data and lets you explore every screen before you decide to host it for your clan.
 
 ## What you need
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,10 +1,23 @@
 # RSL Siege Manager
 
-A web app for managing Raid Shadow Legends clan siege assignments. Replaces the Discord-plus-Excel workflow with a unified web UI backed by a relational database. Open source, self-hostable, and free.
+A comprehensive web utility for coordinating Raid Shadow Legends clan siege assignments — validated, automated, and Discord-native.
+
+Clan leaders and planners use RSL Siege Manager to build, validate, and publish siege building assignments without leaving a browser. The app handles validation, auto-fill, attack-day logic, and Discord delivery end to end. Self-hostable, MIT licensed, and free to run.
+
+## What it does
+
+| Feature | What it does |
+|---|---|
+| **Validated assignments** | 16 rule checks catch overlaps, misplacements, and capacity errors before posting. |
+| **Auto-fill** | Preview and commit assignments for empty positions in one click; what you see is exactly what gets saved. |
+| **Attack-day logic** | Pinned members count toward Day 2 thresholds automatically; no manual bookkeeping. |
+| **Discord-native** | OAuth2 sign-in, role-gated access, DM notifications, and assignment-image posts to your siege channels. |
+| **Generated assignment images** | Server-rendered PNGs of the full board, posted directly to Discord (no screenshots, no manual cropping). |
+| **Self-hostable** | Runs on any Docker host or a managed Azure stack. Open source, MIT licensed, no SaaS dependency. |
 
 ## Who this is for
 
-Clan leaders and planners who coordinate siege building assignments for their guild, plus developers curious about the stack (React + FastAPI + a Discord bot sidecar).
+Clan leaders and planners who coordinate siege building assignments for their guild — anyone who wants validated, automated, Discord-native tooling for the weekly siege cycle. Developers curious about the stack (React + FastAPI + a Discord bot sidecar) will find the codebase approachable too.
 
 ## Start here
 


### PR DESCRIPTION
## Summary

Reframes the project's two main discovery surfaces — `wiki/Home.md` and `README.md` — away from "Excel app replacement" framing and toward a comprehensive-utility pitch led by what the app does for a clan.

## Changes

- `wiki/Home.md` — new tagline, short positioning paragraph, and a 2-column "What it does" feature grid covering validated assignments, auto-fill, attack-day logic, Discord-native UX, generated assignment images, and self-host options. "Who this is for" tightened so clan leaders are the lead audience. Sidebar links and the "About this wiki" footer are unchanged.
- `README.md` — replaces the one-line "Replaces the manual Discord/Excel workflow" lead with a tagline plus a new `## Features` bullet section above `## Architecture`. Everything from `## Architecture` onward is byte-identical to main.
- `wiki/Getting-Started.md` — minor intro polish so demo mode reads as a try-before-you-host feature, not just an auth bypass. All install steps unchanged.

## Out of scope

- `wiki/FAQ.md`, `wiki/Self-Host-on-Any-VPS.md`, `wiki/Self-Host-on-Azure.md`, `wiki/_Sidebar.md` — no replacement framing was present, so no change.
- In-app marketing copy.
- `CHANGELOG.md` — positioning copy isn't a behavior change.

## Test plan

- [ ] PR markdown preview: `wiki/Home.md` tagline reads as a single concrete value statement; feature grid renders as a 2-col table; "Start here" links resolve.
- [ ] PR markdown preview: `README.md` Features section renders as bullets with bold lead-ins; badges and live-site banner unchanged at top; `## Architecture` and below unchanged.
- [ ] After merge: GitHub Wiki at https://github.com/glitchwerks/siege-web/wiki reflects the new `Home.md` within ~1–2 minutes (auto-publish action).
- [ ] After merge: Issue #344 auto-closes via the `Closes #344` keyword.

Closes #344

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_