### PR TITLE
fix(ci): skip secret-dependent infra-ci steps on fork PRs (closes #350)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
   claude-lint-fix:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]
-    if: failure() && github.event_name == 'pull_request'
+    if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     uses: glitchwerks/github-actions/.github/workflows/claude-lint-fix.yml@v2.6.1
     secrets: inherit
     with:

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app-token
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -92,7 +92,7 @@ jobs:
           done
 
       - name: Post failure comment
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v9
         with:
           # Use App token on PRs (enables @claude triggering); fall back to GITHUB_TOKEN on other events
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app-token
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -134,7 +134,7 @@ jobs:
         run: az bicep build --file infra/main.bicep --outfile /tmp/main.json
 
       - name: Post failure comment
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token || github.token }}
@@ -157,12 +157,13 @@ jobs:
   infra-validate-dev:
     name: ARM Preflight Validation (dev)
     needs: infra-build
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
 
     steps:
       - name: Mint GitHub App token
         id: app-token
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -221,12 +222,13 @@ jobs:
   infra-what-if-dev:
     name: What-if Change Impact (dev)
     needs: infra-validate-dev
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
 
     steps:
       - name: Mint GitHub App token
         id: app-token
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Summary

Fork-contributor PRs were failing `infra-ci.yml` immediately because `actions/create-github-app-token` received an empty `app-id` input — GitHub Actions does not pass repository secrets to `pull_request` runs from forks. Similarly, `azure/login` received empty `AZURE_CREDENTIALS`. This PR adds fork-aware gating so those jobs and steps gracefully skip instead of hard-failing.

## Changes

**`.github/workflows/infra-ci.yml`** — 6 step edits + 2 job-level additions:

- `infra-lint` — `Mint GitHub App token` step: added `&& !github.event.pull_request.head.repo.fork` guard; `Post failure comment` step: same extension (lint/build themselves still run on forks)
- `infra-build` — same pair of step guards as `infra-lint`
- `infra-validate-dev` — new job-level `if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork` (entire job skipped on fork PRs; `workflow_call` and `workflow_dispatch` runs are preserved by the `!= 'pull_request'` half); `Mint GitHub App token` step also guarded
- `infra-what-if-dev` — same job-level `if:` + step guard as `infra-validate-dev`

**`.github/workflows/ci.yml`** — 1 line edit:

- `claude-lint-fix` job `if:` extended with `&& !github.event.pull_request.head.repo.fork`

## Effect

| Job | Fork PR before | Fork PR after |
|---|---|---|
| Bicep Lint | ❌ fails (empty APP_ID) | ✅ passes (token step skipped) |
| Bicep Build | ❌ fails (empty APP_ID) | ✅ passes (token step skipped) |
| ARM Preflight Validation | ❌ fails (empty AZURE_CREDENTIALS) | ⏭ skipped |
| What-if Change Impact | ❌ fails (empty AZURE_CREDENTIALS) | ⏭ skipped |
| Claude Lint Fix | ❌ fails (empty secrets) | ⏭ skipped |

This also unblocks PR #343 once it is rebased and re-run against this change.

Closes #350

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_