### PR TITLE
feat(auth): rate-limit login/callback endpoints

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -16,6 +16,7 @@ from app.config import JWT_ALGORITHM, settings
 from app.db.session import get_db
 from app.dependencies.auth import AuthenticatedUser, get_current_user
 from app.models.member import Member
+from app.rate_limit import limiter
 from app.services.bot_client import bot_client
 
 logger = logging.getLogger(__name__)
@@ -72,11 +73,17 @@ async def _check_guild_membership(discord_id: str) -> dict:
 
 
 @router.get("/login")
-async def login(response: Response) -> dict:
+@limiter.limit(lambda: settings.auth_login_rate_limit)
+async def login(request: Request, response: Response) -> dict:
     """Initiate Discord OAuth2 flow.
 
     Generates a CSRF state token, stores it in a short-lived cookie, and
     returns the Discord authorization URL for the frontend to redirect to.
+
+    Rate-limited per client IP via AUTH_LOGIN_RATE_LIMIT (default 10/minute).
+    The limit is read lazily from ``settings`` so env-var overrides and test
+    monkeypatches take effect without reloading the module.  The ``request``
+    parameter is required by slowapi's decorator.
     """
     state = secrets.token_hex(32)
     params = urlencode(
@@ -101,6 +108,7 @@ async def login(response: Response) -> dict:
 
 
 @router.get("/callback")
+@limiter.limit(lambda: settings.auth_callback_rate_limit)
 async def callback(
     code: str,
     state: str,
@@ -112,6 +120,8 @@ async def callback(
     Validates CSRF state, exchanges the authorization code for an access token,
     fetches the Discord user profile, verifies guild membership via the bot
     sidecar, matches to a Member record, and issues a signed JWT session cookie.
+
+    Rate-limited per client IP via AUTH_CALLBACK_RATE_LIMIT (default 5/minute).
     """
     # 1. Validate state (CSRF)
     stored_state = request.cookies.get("oauth_state", "")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -122,6 +122,9 @@ async def callback(
     sidecar, matches to a Member record, and issues a signed JWT session cookie.
 
     Rate-limited per client IP via AUTH_CALLBACK_RATE_LIMIT (default 5/minute).
+    The limit is read lazily from ``settings`` so env-var overrides and test
+    monkeypatches take effect without reloading the module.  The ``request``
+    parameter is required by slowapi's decorator.
     """
     # 1. Validate state (CSRF)
     stored_state = request.cookies.get("oauth_state", "")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,12 @@ class Settings(BaseSettings):
     # e.g. "https://rslsiege.com" or "https://rslsiege.com,https://www.rslsiege.com".
     allowed_origins: str = "http://localhost:5173"
 
+    # Rate-limit strings for the auth endpoints.  These accept any slowapi-
+    # parseable rate string, e.g. "10/minute", "5/second", "100/hour".
+    # See: https://limits.readthedocs.io/en/stable/string-notation.html
+    auth_login_rate_limit: str = "10/minute"
+    auth_callback_rate_limit: str = "5/minute"
+
 
 settings = Settings()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+"""FastAPI application factory and middleware wiring."""
+
 import logging
 from contextlib import asynccontextmanager
 
@@ -30,6 +32,7 @@ from app.config import settings
 from app.db.session import engine
 from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
+from app.rate_limit import RateLimitExceeded, _rate_limit_exceeded_handler, limiter
 from app.telemetry import configure_telemetry
 
 logging.basicConfig(
@@ -69,6 +72,11 @@ app = FastAPI(
     redoc_url=None,
     lifespan=lifespan,
 )
+
+# Register rate limiter — must come before routes are added so that the
+# limiter state is available on app.state when endpoint decorators fire.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Configure telemetry AFTER the app object is created so that
 # FastAPIInstrumentor can wrap it, and after the engine is imported so that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,7 +32,7 @@ from app.config import settings
 from app.db.session import engine
 from app.dependencies.auth import get_current_user
 from app.middleware import RequestLoggingMiddleware
-from app.rate_limit import RateLimitExceeded, _rate_limit_exceeded_handler, limiter
+from app.rate_limit import RateLimitExceeded, limiter, rate_limit_exceeded_handler
 from app.telemetry import configure_telemetry
 
 logging.basicConfig(
@@ -76,7 +76,7 @@ app = FastAPI(
 # Register rate limiter — must come before routes are added so that the
 # limiter state is available on app.state when endpoint decorators fire.
 app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # Configure telemetry AFTER the app object is created so that
 # FastAPIInstrumentor can wrap it, and after the engine is imported so that

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -38,6 +38,10 @@ def _get_client_ip(request: Request) -> str:
     """
     forwarded_for = request.headers.get("X-Forwarded-For", "")
     if forwarded_for:
+        # Cap before splitting — defense-in-depth against pathologically long
+        # headers; ASGI servers already cap total header size, but this keeps
+        # our split O(1) if anything upstream changes.
+        forwarded_for = forwarded_for[:8192]
         # Leftmost entry is written by the trusted ingress proxy.
         return forwarded_for.split(",")[0].strip()
     return get_remote_address(request)

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -3,16 +3,39 @@
 This module owns the single ``Limiter`` instance that is registered on
 ``app.state`` in ``app.main``.  Keeping it here breaks the circular-import
 that would arise if ``app.api.auth`` tried to import from ``app.main``.
+
+The module also exposes:
+
+- ``_get_client_ip`` — XFF-aware IP extractor with IP validation and a
+  throttled production trust-model warning.
+- ``rate_limit_exceeded_handler`` — custom async 429 handler that sets a
+  ``Retry-After`` header derived from the rate-limit window, without relying
+  on slowapi's private API.  The only public contracts we rely on from
+  slowapi are ``Limiter`` and ``RateLimitExceeded``; the
+  ``>=0.1.9,<0.2`` pin in ``requirements.txt`` is still good hygiene as
+  defense-in-depth (minor upgrades may rename even public symbols), but we
+  no longer import ``_rate_limit_exceeded_handler``.
 """
 
+import ipaddress
+import logging
+import time
 import uuid
 
 from fastapi import Request
-from slowapi import Limiter, _rate_limit_exceeded_handler  # noqa: F401 — re-exported
+from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded  # noqa: F401 — re-exported
 from slowapi.util import get_remote_address
+from starlette.responses import JSONResponse, Response
 
 from app.config import settings
+
+# Module-level logger — records appear under "app.rate_limit".
+logger = logging.getLogger(__name__)
+
+# Rate-limit the production XFF-absent warning so it does not flood logs.
+_last_xff_absent_warning: float = 0.0
+_XFF_WARN_INTERVAL_SECS: float = 60.0
 
 
 def _get_client_ip(request: Request) -> str:
@@ -21,9 +44,21 @@ def _get_client_ip(request: Request) -> str:
     Reads the *leftmost* value from the ``X-Forwarded-For`` header, which is
     the IP the Azure Container Apps ingress appended as the true origin.
     Client-supplied values further to the right in the header chain are
-    ignored because they can be trivially spoofed.  Falls back to the ASGI
-    transport remote address when the header is absent (e.g. local dev with
-    no proxy).
+    ignored because they can be trivially spoofed.
+
+    The leftmost candidate is validated with :func:`ipaddress.ip_address`.
+    If the value is not a valid IP address (e.g. an attacker-injected string),
+    the function falls through to the ASGI transport remote address so that:
+
+    - Garbage strings cannot be used as shared-bucket keys to collude with
+      other attackers.
+    - Rotating unique garbage values cannot generate a fresh rate-limit bucket
+      on every request (unlimited bypass).
+
+    Falls back to the ASGI transport remote address when the header is absent
+    (e.g. local dev with no proxy).  In production, absence of the header
+    triggers a throttled WARNING because it suggests direct backend access
+    that bypasses Container Apps ingress.
 
     Trust assumption: exactly one trusted reverse-proxy hop (Container Apps
     ingress) prepends the real client IP as the leftmost entry.  If your
@@ -34,16 +69,39 @@ def _get_client_ip(request: Request) -> str:
         request: The incoming FastAPI/Starlette request.
 
     Returns:
-        A string representation of the client IP address.
+        A string representation of the client IP address to use as the
+        rate-limit bucket key.
     """
+    global _last_xff_absent_warning
+
     forwarded_for = request.headers.get("X-Forwarded-For", "")
     if forwarded_for:
         # Cap before splitting — defense-in-depth against pathologically long
         # headers; ASGI servers already cap total header size, but this keeps
         # our split O(1) if anything upstream changes.
         forwarded_for = forwarded_for[:8192]
-        # Leftmost entry is written by the trusted ingress proxy.
-        return forwarded_for.split(",")[0].strip()
+        leftmost = forwarded_for.split(",")[0].strip()
+        try:
+            ipaddress.ip_address(leftmost)
+            return leftmost
+        except ValueError:
+            # Invalid IP in XFF — fall through to the ASGI remote address so
+            # that garbage values cannot escape or manipulate rate-limit buckets.
+            pass
+    else:
+        # XFF absent — warn in production since direct backend access bypassing
+        # Container Apps ingress indicates a misconfiguration.  The warning is
+        # throttled to at most once per 60 s to avoid log flooding.
+        if settings.environment == "production":
+            now = time.monotonic()
+            if now - _last_xff_absent_warning >= _XFF_WARN_INTERVAL_SECS:
+                _last_xff_absent_warning = now
+                logger.warning(
+                    "X-Forwarded-For absent in production request — trust "
+                    "model assumes Container Apps ingress is in front. "
+                    "Direct backend access may indicate misconfiguration."
+                )
+
     return get_remote_address(request)
 
 
@@ -70,6 +128,100 @@ def _rate_limit_key(request: Request) -> str:
         # Unique per request — no bucket ever fills up.
         return f"bypass-{uuid.uuid4()}"
     return _get_client_ip(request)
+
+
+def _parse_retry_after_seconds(detail: str) -> int | None:
+    """Parse a slowapi rate-limit detail string into a window size in seconds.
+
+    slowapi's ``RateLimitExceeded.detail`` is the human-readable rate string
+    such as ``"10 per 1 minute"`` or ``"5 per 1 second"``.  This function
+    extracts the window duration and converts it to seconds so it can be used
+    as a conservative ``Retry-After`` upper bound when the accurate countdown
+    from ``get_window_stats`` is unavailable.
+
+    Args:
+        detail: The rate-limit detail string from ``RateLimitExceeded.detail``.
+
+    Returns:
+        The window duration in whole seconds, or ``None`` if the string could
+        not be parsed.
+    """
+    _unit_to_seconds: dict[str, int] = {
+        "second": 1,
+        "minute": 60,
+        "hour": 3600,
+        "day": 86400,
+    }
+    lower = detail.lower()
+    for unit, secs in _unit_to_seconds.items():
+        if unit in lower:
+            # Look for an optional multiplier immediately before the unit,
+            # e.g. "10 per 2 minute" → multiplier 2, result 120.
+            parts = lower.split(unit)[0].split()
+            if parts:
+                try:
+                    multiplier = int(parts[-1])
+                    return multiplier * secs
+                except ValueError:
+                    return secs
+            return secs
+    return None
+
+
+async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
+    """Return a JSON 429 response with a ``Retry-After`` header.
+
+    Replaces slowapi's private ``_rate_limit_exceeded_handler`` so we own
+    the response format and guarantee a ``Retry-After`` header without
+    depending on slowapi internals.
+
+    The ``Retry-After`` value is derived in two steps:
+
+    1. **Via slowapi's header injection** — if
+       ``request.state.view_rate_limit`` is populated (normal path), we
+       delegate to ``request.app.state.limiter._inject_headers`` which calls
+       ``get_window_stats`` for an accurate per-window countdown.
+    2. **Fallback parsing** — if injection fails or the header is still
+       absent, we parse the rate-limit detail string (e.g. ``"10 per 1
+       minute"``) and use the window size as a conservative upper bound.
+       If parsing also fails we fall back to ``60`` seconds.
+
+    The only slowapi public contracts used here are ``Limiter``,
+    ``RateLimitExceeded``, and ``_inject_headers`` (semi-private but stable
+    across 0.1.x; the ``<0.2`` version pin provides defense-in-depth).
+
+    Args:
+        request: The incoming Starlette/FastAPI request that triggered the
+            rate limit.
+        exc: The :class:`~slowapi.errors.RateLimitExceeded` exception raised
+            by slowapi.
+
+    Returns:
+        A :class:`~starlette.responses.JSONResponse` with status 429 and a
+        ``Retry-After`` header.
+    """
+    response: Response = JSONResponse(
+        {"detail": f"Rate limit exceeded: {exc.detail}"},
+        status_code=429,
+    )
+
+    # Attempt to inject accurate rate-limit headers (including Retry-After)
+    # via slowapi's header-injection helper.  Guarded so we never hard-fail
+    # if the state attribute or limiter reference is absent.
+    try:
+        view_rate_limit = getattr(request.state, "view_rate_limit", None)
+        if view_rate_limit is not None:
+            response = request.app.state.limiter._inject_headers(response, view_rate_limit)
+    except Exception:
+        # Storage unreachable or injection failed — fall through to fallback.
+        pass
+
+    # Guarantee Retry-After is present even when injection did not set it.
+    if "Retry-After" not in response.headers:
+        retry_secs: int = _parse_retry_after_seconds(str(exc.detail)) or 60
+        response.headers["Retry-After"] = str(retry_secs)
+
+    return response
 
 
 # Single application-wide Limiter instance.  Registered on ``app.state`` and

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -1,0 +1,73 @@
+"""Rate-limiting utilities shared across the application.
+
+This module owns the single ``Limiter`` instance that is registered on
+``app.state`` in ``app.main``.  Keeping it here breaks the circular-import
+that would arise if ``app.api.auth`` tried to import from ``app.main``.
+"""
+
+import uuid
+
+from fastapi import Request
+from slowapi import Limiter, _rate_limit_exceeded_handler  # noqa: F401 — re-exported
+from slowapi.errors import RateLimitExceeded  # noqa: F401 — re-exported
+from slowapi.util import get_remote_address
+
+from app.config import settings
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract the real client IP from X-Forwarded-For for rate bucketing.
+
+    Reads the *leftmost* value from the ``X-Forwarded-For`` header, which is
+    the IP the Azure Container Apps ingress appended as the true origin.
+    Client-supplied values further to the right in the header chain are
+    ignored because they can be trivially spoofed.  Falls back to the ASGI
+    transport remote address when the header is absent (e.g. local dev with
+    no proxy).
+
+    Trust assumption: exactly one trusted reverse-proxy hop (Container Apps
+    ingress) prepends the real client IP as the leftmost entry.  If your
+    deployment adds additional upstream proxies, shift the index right
+    accordingly.
+
+    Args:
+        request: The incoming FastAPI/Starlette request.
+
+    Returns:
+        A string representation of the client IP address.
+    """
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        # Leftmost entry is written by the trusted ingress proxy.
+        return forwarded_for.split(",")[0].strip()
+    return get_remote_address(request)
+
+
+def _rate_limit_key(request: Request) -> str:
+    """Composite key function that honours the AUTH_DISABLED bypass.
+
+    When ``AUTH_DISABLED=true`` (dev/test mode) each request receives a
+    unique UUID bucket so rate-limit counters never accumulate — effectively
+    disabling limiting without touching the ``Limiter.enabled`` flag (which
+    is set at construction time and therefore insensitive to monkeypatching
+    in tests).
+
+    When auth is enabled, delegates to ``_get_client_ip`` for normal
+    IP-based bucketing.
+
+    Args:
+        request: The incoming FastAPI/Starlette request.
+
+    Returns:
+        A string key used by slowapi to group requests into rate-limit
+        buckets.
+    """
+    if settings.auth_disabled:
+        # Unique per request — no bucket ever fills up.
+        return f"bypass-{uuid.uuid4()}"
+    return _get_client_ip(request)
+
+
+# Single application-wide Limiter instance.  Registered on ``app.state`` and
+# used as a decorator in ``app.api.auth``.
+limiter: Limiter = Limiter(key_func=_rate_limit_key)

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -19,6 +19,7 @@ The module also exposes:
 
 import ipaddress
 import logging
+import threading
 import time
 import uuid
 
@@ -34,8 +35,18 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 # Rate-limit the production XFF-absent warning so it does not flood logs.
+# A threading.Lock (not asyncio.Lock) is required because _get_client_ip is
+# called from slowapi's synchronous key_func, which FastAPI runs in a thread
+# pool — there is no event loop in scope on those threads.
+_xff_warning_lock: threading.Lock = threading.Lock()
 _last_xff_absent_warning: float = 0.0
+_last_xff_invalid_warning: float = 0.0
 _XFF_WARN_INTERVAL_SECS: float = 60.0
+
+# Maximum number of characters of an invalid XFF value to include in the
+# warning log.  Caps user-controlled data to prevent log injection or
+# oversized log lines.
+_XFF_LOG_VALUE_MAX_CHARS: int = 64
 
 
 def _get_client_ip(request: Request) -> str:
@@ -55,6 +66,9 @@ def _get_client_ip(request: Request) -> str:
     - Rotating unique garbage values cannot generate a fresh rate-limit bucket
       on every request (unlimited bypass).
 
+    In production, an invalid XFF value triggers a throttled WARNING so that
+    attackers probing with malformed headers are visible in logs.
+
     Falls back to the ASGI transport remote address when the header is absent
     (e.g. local dev with no proxy).  In production, absence of the header
     triggers a throttled WARNING because it suggests direct backend access
@@ -65,6 +79,12 @@ def _get_client_ip(request: Request) -> str:
     deployment adds additional upstream proxies, shift the index right
     accordingly.
 
+    Thread safety: both throttle timestamps are guarded by
+    ``_xff_warning_lock`` (a :class:`threading.Lock`) because this function
+    is invoked from slowapi's synchronous ``key_func``, which FastAPI
+    dispatches via a thread pool.  ``asyncio.Lock`` would be incorrect here
+    as there is no event loop on those threads.
+
     Args:
         request: The incoming FastAPI/Starlette request.
 
@@ -72,7 +92,7 @@ def _get_client_ip(request: Request) -> str:
         A string representation of the client IP address to use as the
         rate-limit bucket key.
     """
-    global _last_xff_absent_warning
+    global _last_xff_absent_warning, _last_xff_invalid_warning
 
     forwarded_for = request.headers.get("X-Forwarded-For", "")
     if forwarded_for:
@@ -86,16 +106,42 @@ def _get_client_ip(request: Request) -> str:
             return leftmost
         except ValueError:
             # Invalid IP in XFF — fall through to the ASGI remote address so
-            # that garbage values cannot escape or manipulate rate-limit buckets.
-            pass
+            # that garbage values cannot escape or manipulate rate-limit
+            # buckets.  Log a throttled WARNING in production so that
+            # attackers probing with malformed headers leave a trace.
+            if settings.environment == "production":
+                should_log = False
+                with _xff_warning_lock:
+                    now = time.monotonic()
+                    if now - _last_xff_invalid_warning >= _XFF_WARN_INTERVAL_SECS:
+                        _last_xff_invalid_warning = now
+                        should_log = True
+                if should_log:
+                    # Truncate user-controlled data before logging to prevent
+                    # log injection and oversized lines.
+                    preview = leftmost[:_XFF_LOG_VALUE_MAX_CHARS]
+                    suffix = "[truncated]" if len(leftmost) > _XFF_LOG_VALUE_MAX_CHARS else ""
+                    logger.warning(
+                        "Invalid X-Forwarded-For value in production request"
+                        " — falling back to remote address."
+                        " value_preview=%s%s",
+                        preview,
+                        suffix,
+                    )
     else:
-        # XFF absent — warn in production since direct backend access bypassing
-        # Container Apps ingress indicates a misconfiguration.  The warning is
-        # throttled to at most once per 60 s to avoid log flooding.
+        # XFF absent — warn in production since direct backend access
+        # bypassing Container Apps ingress indicates a misconfiguration.
+        # The warning is throttled to at most once per 60 s to avoid log
+        # flooding.  The lock prevents the read-compare-write from racing
+        # when multiple thread-pool workers enter simultaneously.
         if settings.environment == "production":
-            now = time.monotonic()
-            if now - _last_xff_absent_warning >= _XFF_WARN_INTERVAL_SECS:
-                _last_xff_absent_warning = now
+            should_log = False
+            with _xff_warning_lock:
+                now = time.monotonic()
+                if now - _last_xff_absent_warning >= _XFF_WARN_INTERVAL_SECS:
+                    _last_xff_absent_warning = now
+                    should_log = True
+            if should_log:
                 logger.warning(
                     "X-Forwarded-For absent in production request — trust "
                     "model assumes Container Apps ingress is in front. "

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ azure-monitor-opentelemetry>=1.6
 opentelemetry-instrumentation-fastapi>=0.50b0
 opentelemetry-instrumentation-sqlalchemy>=0.50b0
 opentelemetry-instrumentation-asyncpg>=0.50b0
+slowapi>=0.1.9

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,7 @@ azure-monitor-opentelemetry>=1.6
 opentelemetry-instrumentation-fastapi>=0.50b0
 opentelemetry-instrumentation-sqlalchemy>=0.50b0
 opentelemetry-instrumentation-asyncpg>=0.50b0
-slowapi>=0.1.9
+# Upper bound guards against _rate_limit_exceeded_handler being renamed or
+# removed — that leading-underscore symbol is private API with no stability
+# guarantee beyond the current minor series.
+slowapi>=0.1.9,<0.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,7 +14,9 @@ azure-monitor-opentelemetry>=1.6
 opentelemetry-instrumentation-fastapi>=0.50b0
 opentelemetry-instrumentation-sqlalchemy>=0.50b0
 opentelemetry-instrumentation-asyncpg>=0.50b0
-# Upper bound guards against _rate_limit_exceeded_handler being renamed or
-# removed — that leading-underscore symbol is private API with no stability
-# guarantee beyond the current minor series.
+# Upper bound is defense-in-depth: we no longer import _rate_limit_exceeded_handler
+# (replaced by our own rate_limit_exceeded_handler in app/rate_limit.py), so
+# the only public contracts we rely on are Limiter and RateLimitExceeded.
+# Minor upgrades within 0.1.x may still rename these symbols; the pin keeps
+# CI deterministic.
 slowapi>=0.1.9,<0.2

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -9,6 +9,8 @@ Covers:
 - Garbage XFF values do NOT create unique per-request buckets
 - 429 response includes a Retry-After header
 - Production warning fires when XFF absent; silent in development
+- Thread-safety: absent-XFF warning fires exactly once under concurrency
+- Invalid XFF in production logs a throttled warning; silent in development
 
 Rate limits are driven by env-tunable settings.  For tests we override them
 to a tight "2/minute" value so we only need 3 rapid requests to trigger a
@@ -17,21 +19,22 @@ to a tight "2/minute" value so we only need 3 rapid requests to trigger a
 
 import logging
 import secrets
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request as StarletteRequest
 
 import app.rate_limit as _rate_limit_module
 from app.main import app
-from app.rate_limit import limiter
+from app.rate_limit import _get_client_ip, limiter
 
 
 @pytest.fixture(autouse=True)
 def reset_rate_limit_state():
     """Reset per-test rate-limit state before each test.
 
-    Resets two pieces of module-level state so tests cannot bleed into
-    each other:
+    Resets module-level state so tests cannot bleed into each other:
 
     1. ``limiter._storage`` — the in-memory bucket store.  Tests that
        share the same fallback IP (127.0.0.1 / "testclient") would
@@ -41,9 +44,14 @@ def reset_rate_limit_state():
        production XFF-absent warning.  Without this reset, a
        production-warning test run immediately after another one would
        suppress the warning (throttle not yet expired) and fail.
+
+    3. ``_last_xff_invalid_warning`` — the throttle timestamp for the
+       invalid-XFF production warning (Finding #2).  Same rationale as
+       above.
     """
     limiter._storage.reset()
     _rate_limit_module._last_xff_absent_warning = 0.0
+    _rate_limit_module._last_xff_invalid_warning = 0.0
     yield
 
 
@@ -419,3 +427,162 @@ async def test_missing_xff_in_development_does_not_log_warning(monkeypatch, capl
     assert (
         len(warning_records) == 0
     ), f"Expected no XFF warning in development, got: {warning_records}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: thread-safety of _last_xff_absent_warning (Finding #1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatch, caplog):
+    """Concurrent requests with no XFF in production fire the warning once.
+
+    _last_xff_absent_warning is read-compared-written by multiple threads
+    simultaneously (slowapi calls the sync key_func from a thread pool).
+    Without a threading.Lock those threads can all observe the old timestamp
+    and all decide to log — the throttle degrades to "sometimes fires extra
+    times".  With the lock, exactly one thread wins the write and the rest
+    skip, so exactly one warning is emitted no matter how many concurrent
+    requests arrive within the 60-second window.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "production")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    N = 20  # threads contending simultaneously
+
+    def _call_get_client_ip() -> None:
+        """Invoke _get_client_ip directly with a no-XFF request."""
+        # Build a minimal Starlette Request with no XFF header so the
+        # absent-XFF production code path is exercised on each thread.
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "client": ("127.0.0.1", 9000),
+        }
+        req = StarletteRequest(scope)
+        _get_client_ip(req)
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        with ThreadPoolExecutor(max_workers=N) as pool:
+            futures = [pool.submit(_call_get_client_ip) for _ in range(N)]
+            for f in futures:
+                f.result()  # surface any exceptions
+
+    absent_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "X-Forwarded-For absent" in r.message
+    ]
+    assert len(absent_warnings) == 1, (
+        f"Expected exactly 1 absent-XFF warning under {N} concurrent threads, "
+        f"got {len(absent_warnings)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: invalid-XFF warning in production (Finding #2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_xff_in_production_logs_warning(monkeypatch, caplog):
+    """Invalid X-Forwarded-For in production emits a WARNING via rate_limit logger.
+
+    When the leftmost XFF value is not a valid IP address and the environment
+    is production, the code must log a throttled WARNING so that attackers
+    probing with malformed headers leave a trace in the logs.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "production")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await _get(
+                client,
+                LOGIN_URL,
+                headers={"X-Forwarded-For": "not-a-valid-ip"},
+            )
+
+    invalid_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "Invalid X-Forwarded-For" in r.message
+    ]
+    assert (
+        len(invalid_warnings) >= 1
+    ), "Expected at least one WARNING about invalid X-Forwarded-For in production"
+
+
+@pytest.mark.asyncio
+async def test_invalid_xff_in_development_does_not_log_warning(monkeypatch, caplog):
+    """Invalid X-Forwarded-For in development must NOT emit a warning.
+
+    Direct / tool access with malformed headers is common in local dev and
+    CI; logging would be noise.  The warning must only fire in production.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await _get(
+                client,
+                LOGIN_URL,
+                headers={"X-Forwarded-For": "not-a-valid-ip"},
+            )
+
+    invalid_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "Invalid X-Forwarded-For" in r.message
+    ]
+    assert (
+        len(invalid_warnings) == 0
+    ), f"Expected no invalid-XFF warning in development, got: {invalid_warnings}"
+
+
+@pytest.mark.asyncio
+async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, caplog):
+    """Rapid invalid-XFF requests in production log the warning only once.
+
+    The invalid-XFF warning must be throttled with the same 60-second window
+    as the absent-XFF warning: no matter how many requests arrive with
+    malformed X-Forwarded-For values within the window, only one WARNING is
+    emitted.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "production")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            for _ in range(5):
+                await _get(
+                    client,
+                    LOGIN_URL,
+                    headers={"X-Forwarded-For": "bad-ip-value"},
+                )
+
+    invalid_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "Invalid X-Forwarded-For" in r.message
+    ]
+    assert len(invalid_warnings) == 1, (
+        f"Expected exactly 1 throttled invalid-XFF warning for 5 rapid "
+        f"requests, got {len(invalid_warnings)}"
+    )

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -5,18 +5,47 @@ Covers:
 - /api/auth/callback 429s on the (N+1)th request within the window
 - AUTH_DISABLED=true suppresses all rate limiting
 - X-Forwarded-For header is the bucket key (different IPs = independent)
+- Invalid XFF value falls back to remote-address bucket
+- Garbage XFF values do NOT create unique per-request buckets
+- 429 response includes a Retry-After header
+- Production warning fires when XFF absent; silent in development
 
 Rate limits are driven by env-tunable settings.  For tests we override them
 to a tight "2/minute" value so we only need 3 rapid requests to trigger a
 429 — no real-time waiting required.
 """
 
+import logging
 import secrets
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+import app.rate_limit as _rate_limit_module
 from app.main import app
+from app.rate_limit import limiter
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limit_state():
+    """Reset per-test rate-limit state before each test.
+
+    Resets two pieces of module-level state so tests cannot bleed into
+    each other:
+
+    1. ``limiter._storage`` — the in-memory bucket store.  Tests that
+       share the same fallback IP (127.0.0.1 / "testclient") would
+       otherwise see residual counts from earlier tests.
+
+    2. ``_last_xff_absent_warning`` — the throttle timestamp for the
+       production XFF-absent warning.  Without this reset, a
+       production-warning test run immediately after another one would
+       suppress the warning (throttle not yet expired) and fail.
+    """
+    limiter._storage.reset()
+    _rate_limit_module._last_xff_absent_warning = 0.0
+    yield
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -207,4 +236,186 @@ async def test_xff_pathological_header_parses_to_leftmost_ip(monkeypatch):
         status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": long_xff})
         # With a generous 100/minute limit and a unique-looking first IP this
         # should succeed — the key point is no exception is raised by the cap.
-        assert status == 200, f"Expected 200 for long XFF header, got {status}"
+        assert status == 200, f"Expected 200 (no exception raised from long XFF), got {status}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: XFF validation (Finding #1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_garbage_xff_falls_back_to_remote_address_bucket(monkeypatch):
+    """Garbage XFF value falls back to the ASGI remote-address bucket.
+
+    Sending ``X-Forwarded-For: not-an-ip`` must NOT create a unique bucket
+    for the garbage string.  Instead the fallback remote-address bucket
+    ('testclient' / 127.0.0.1) is used, so repeated garbage-XFF requests
+    accumulate in the same bucket and eventually hit the rate limit.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Two requests with garbage XFF fill the remote-address bucket.
+        for _ in range(2):
+            status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "not-an-ip"})
+            assert status == 200, f"Expected 200 before limit, got {status}"
+
+        # Third request with garbage XFF hits the rate limit (same remote-address
+        # bucket — garbage did NOT escape into its own fresh bucket).
+        status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "not-an-ip"})
+        assert status == 429, (
+            f"Expected 429 — garbage XFF must not create a fresh per-request "
+            f"bucket, got {status}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_different_garbage_xff_values_share_remote_address_bucket(monkeypatch):
+    """Different garbage XFF strings all resolve to the same remote-address bucket.
+
+    An attacker who rotates ``X-Forwarded-For`` values through unique garbage
+    strings must NOT bypass the limiter by getting a fresh bucket each time.
+    All garbage values share the fallback remote-address bucket.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Exhaust the bucket with distinct garbage values.
+        garbage_headers = ["not-an-ip", "shared-bucket", "totally-fake"]
+        for h in garbage_headers[:2]:
+            status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": h})
+            assert status == 200, f"Expected 200 before limit, got {status}"
+
+        # A third distinct garbage value still hits the limit —
+        # same remote-address fallback bucket.
+        status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": garbage_headers[2]})
+        assert status == 429, (
+            f"Expected 429 — different garbage XFF values must not each get their "
+            f"own fresh bucket, got {status}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_valid_xff_still_buckets_by_ip(monkeypatch):
+    """Valid XFF IP values are still used as the bucket key (regression guard).
+
+    Ensures the garbage-XFF fallback path does not accidentally affect
+    requests that carry a legitimate X-Forwarded-For value.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Exhaust the bucket for IP A.
+        for _ in range(2):
+            await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.1"})
+        status_a = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.1"})
+        assert status_a == 429, "IP A should be rate-limited"
+
+        # IP B is a completely separate bucket — should not be affected.
+        status_b = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.2"})
+        assert status_b == 200, f"IP B must have its own fresh bucket, got {status_b}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: custom 429 handler — Retry-After header (Finding #2 / #4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_response_includes_retry_after_header(monkeypatch):
+    """A 429 response must include a Retry-After header with a positive integer.
+
+    Verifies that our custom rate-limit-exceeded handler sets the header so
+    clients know when they can retry without polling.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Exhaust the limit.
+        for _ in range(2):
+            await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "2.3.4.5"})
+
+        # Trigger the 429 and capture the full response.
+        resp = await client.get(LOGIN_URL, headers={"X-Forwarded-For": "2.3.4.5"})
+        assert resp.status_code == 429, f"Expected 429, got {resp.status_code}"
+
+        retry_after = resp.headers.get("Retry-After")
+        assert retry_after is not None, "Retry-After header must be present on 429"
+        assert (
+            retry_after.isdigit()
+        ), f"Retry-After must be a plain integer string, got {retry_after!r}"
+        assert int(retry_after) > 0, f"Retry-After must be a positive integer, got {retry_after}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: production warning when XFF absent (Finding #3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
+    """XFF absent in production emits a WARNING via the rate_limit logger.
+
+    Ensures the warning fires exactly once for a request that arrives without
+    X-Forwarded-For when ENVIRONMENT=production, signalling potential
+    misconfiguration (direct backend access bypassing Container Apps ingress).
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "production")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            # No X-Forwarded-For header — simulates direct backend access.
+            await _get(client, LOGIN_URL)
+
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message
+    ]
+    assert (
+        len(warning_records) >= 1
+    ), "Expected at least one WARNING about missing X-Forwarded-For in production"
+
+
+@pytest.mark.asyncio
+async def test_missing_xff_in_development_does_not_log_warning(monkeypatch, caplog):
+    """XFF absent in development must NOT emit the production trust-model warning.
+
+    Direct access without a proxy is normal in local dev — the warning would
+    be noise and should be suppressed when ENVIRONMENT != production.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            await _get(client, LOGIN_URL)
+
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message
+    ]
+    assert (
+        len(warning_records) == 0
+    ), f"Expected no XFF warning in development, got: {warning_records}"

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -1,0 +1,175 @@
+"""Tests for rate limiting on the Discord OAuth2 auth endpoints.
+
+Covers:
+- /api/auth/login  429s on the (N+1)th request within the window
+- /api/auth/callback 429s on the (N+1)th request within the window
+- AUTH_DISABLED=true suppresses all rate limiting
+- X-Forwarded-For header is the bucket key (different IPs = independent)
+
+Rate limits are driven by env-tunable settings.  For tests we override them
+to a tight "2/minute" value so we only need 3 rapid requests to trigger a
+429 — no real-time waiting required.
+"""
+
+import secrets
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+LOGIN_URL = "/api/auth/login"
+CALLBACK_URL = "/api/auth/callback"
+
+# A minimal valid callback request — state validation will reject it, but we
+# just need to reach the rate-limiter layer.  We use "wrong-state" so the
+# handler redirects to /login?error=invalid_state (302), which is fine for
+# rate-limit tests; we only care about the *absence* of a 429 before the
+# limit is reached and its *presence* afterwards.
+_STATE = secrets.token_hex(32)
+CALLBACK_PARAMS = {"code": "auth-code", "state": "mismatch-state"}
+
+
+async def _get(client: AsyncClient, url: str, headers: dict | None = None) -> int:
+    """Send a GET and return the status code."""
+    return (await client.get(url, headers=headers or {})).status_code
+
+
+# ---------------------------------------------------------------------------
+# Tests: /api/auth/login rate limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limit_triggers_429(monkeypatch):
+    """11th rapid request to /api/auth/login returns 429.
+
+    The limit is overridden to "2/minute" via monkeypatch so the test does
+    not need to wait for a real one-minute window.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # First two requests should succeed (limit is 2/minute)
+        for _ in range(2):
+            status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "1.2.3.4"})
+            assert status == 200, f"Expected 200 before limit, got {status}"
+
+        # Third request must be rate-limited
+        status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "1.2.3.4"})
+        assert status == 429, f"Expected 429 after limit exceeded, got {status}"
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limit_independent_per_ip(monkeypatch):
+    """Two different X-Forwarded-For IPs have independent rate-limit buckets."""
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Exhaust the limit for IP A
+        for _ in range(2):
+            await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.1"})
+        status_a = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.1"})
+        assert status_a == 429, "IP A should be rate-limited"
+
+        # IP B is a fresh bucket — first request should succeed
+        status_b = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "10.0.0.2"})
+        assert status_b == 200, f"IP B should not be rate-limited, got {status_b}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: /api/auth/callback rate limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_callback_rate_limit_triggers_429(monkeypatch):
+    """6th rapid request to /api/auth/callback returns 429.
+
+    Limit overridden to "2/minute" for speed.  The handler returns 302
+    (invalid_state redirect) for valid-rate requests; we only care that
+    the (limit+1)th response is 429.
+    """
+    monkeypatch.setattr("app.config.settings.auth_callback_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set("oauth_state", _STATE)
+
+        # First two requests hit the handler (returns 302 invalid_state)
+        for _ in range(2):
+            resp = await client.get(
+                CALLBACK_URL,
+                params=CALLBACK_PARAMS,
+                headers={"X-Forwarded-For": "5.5.5.5"},
+            )
+            assert (
+                resp.status_code == 302
+            ), f"Expected 302 before rate limit, got {resp.status_code}"
+
+        # Third request must be rate-limited
+        resp = await client.get(
+            CALLBACK_URL,
+            params=CALLBACK_PARAMS,
+            headers={"X-Forwarded-For": "5.5.5.5"},
+        )
+        assert resp.status_code == 429, f"Expected 429 after limit exceeded, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: AUTH_DISABLED bypass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_no_429_when_auth_disabled(monkeypatch):
+    """When AUTH_DISABLED=true, 50 rapid requests to /login never return 429."""
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", True)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for i in range(50):
+            status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": "9.9.9.9"})
+            assert status != 429, f"Got unexpected 429 on request {i + 1}"
+
+
+@pytest.mark.asyncio
+async def test_callback_no_429_when_auth_disabled(monkeypatch):
+    """When AUTH_DISABLED=true, 50 rapid requests to /callback never return 429."""
+    monkeypatch.setattr("app.config.settings.auth_callback_rate_limit", "2/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", True)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set("oauth_state", _STATE)
+        for i in range(50):
+            resp = await client.get(
+                CALLBACK_URL,
+                params=CALLBACK_PARAMS,
+                headers={"X-Forwarded-For": "9.9.9.9"},
+            )
+            assert resp.status_code != 429, f"Got unexpected 429 on request {i + 1}"

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -46,7 +46,7 @@ async def _get(client: AsyncClient, url: str, headers: dict | None = None) -> in
 
 @pytest.mark.asyncio
 async def test_login_rate_limit_triggers_429(monkeypatch):
-    """11th rapid request to /api/auth/login returns 429.
+    """3rd rapid request to /api/auth/login returns 429 when limit is 2/minute.
 
     The limit is overridden to "2/minute" via monkeypatch so the test does
     not need to wait for a real one-minute window.
@@ -96,7 +96,7 @@ async def test_login_rate_limit_independent_per_ip(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_callback_rate_limit_triggers_429(monkeypatch):
-    """6th rapid request to /api/auth/callback returns 429.
+    """3rd rapid request to /api/auth/callback returns 429 when limit is 2/minute.
 
     Limit overridden to "2/minute" for speed.  The handler returns 302
     (invalid_state redirect) for valid-rate requests; we only care that
@@ -173,3 +173,38 @@ async def test_callback_no_429_when_auth_disabled(monkeypatch):
                 headers={"X-Forwarded-For": "9.9.9.9"},
             )
             assert resp.status_code != 429, f"Got unexpected 429 on request {i + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: X-Forwarded-For header cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_xff_pathological_header_parses_to_leftmost_ip(monkeypatch):
+    """Pathologically long X-Forwarded-For header is handled without error.
+
+    Constructs a header that far exceeds 8192 characters and verifies that
+    the rate-limiter correctly extracts the leftmost IP (the real client IP
+    written by the trusted ingress proxy), even after the 8 KB cap truncates
+    the tail of the header.
+    """
+    monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.environment", "development")
+    monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
+    monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    # Build a header where the leftmost entry is a real IP followed by enough
+    # padding to exceed 8192 bytes.  After truncation the split still yields
+    # the leftmost IP as the bucket key, so the request must not 429.
+    leftmost_ip = "1.2.3.4"
+    filler = ", 10.0.0.1" * 1000  # well over 8 KB
+    long_xff = f"{leftmost_ip}{filler}"
+    assert len(long_xff) > 8192, "Precondition: header must exceed the cap"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        status = await _get(client, LOGIN_URL, headers={"X-Forwarded-For": long_xff})
+        # With a generous 100/minute limit and a unique-looking first IP this
+        # should succeed — the key point is no exception is raised by the cap.
+        assert status == 200, f"Expected 200 for long XFF header, got {status}"


### PR DESCRIPTION
## Summary

- Adds `slowapi>=0.1.9` rate limiting to `/api/auth/login` (default 10/minute) and `/api/auth/callback` (default 5/minute)
- Limits are env-tunable via `AUTH_LOGIN_RATE_LIMIT` and `AUTH_CALLBACK_RATE_LIMIT` (any slowapi-parseable rate string, e.g. `"5/second"`, `"100/hour"`)
- When `AUTH_DISABLED=true`, rate limiting is bypassed automatically so dev and test workflows are not throttled

## X-Forwarded-For trust assumption

Client IP bucketing reads the **leftmost** value from `X-Forwarded-For`, which is the IP the Azure Container Apps ingress appended as the true origin. Arbitrary client-supplied values further right in the header chain are ignored (they can be spoofed). Falls back to the ASGI remote address when the header is absent. This assumes exactly one trusted reverse-proxy hop (Container Apps ingress) prepends the real client IP.

## Implementation notes

- `app/rate_limit.py` — new module owning the `Limiter` singleton, extracted to break the circular import that would arise if `app/api/auth.py` imported from `app/main.py`
- `@limiter.limit(lambda: settings.auth_login_rate_limit)` — limit string is read lazily so `monkeypatch.setattr` in tests and runtime env-var overrides both work without reloading the module
- `AUTH_DISABLED` bypass uses a per-request UUID bucket key so counters never accumulate rather than touching `limiter.enabled` (which is evaluated at construction time)

## Tests

5 new tests in `backend/tests/test_auth_rate_limit.py`:

- `test_login_rate_limit_triggers_429` — 3rd request at `2/minute` returns 429
- `test_login_rate_limit_independent_per_ip` — two different `X-Forwarded-For` IPs use independent buckets
- `test_callback_rate_limit_triggers_429` — 3rd request at `2/minute` returns 429
- `test_login_no_429_when_auth_disabled` — 50 requests with `AUTH_DISABLED=true` never return 429
- `test_callback_no_429_when_auth_disabled` — 50 requests with `AUTH_DISABLED=true` never return 429

Test count: 366 → 371 passed (same 1 pre-existing failure in `test_config.py` unrelated to this PR).

Closes #153

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_