### PR TITLE
fix(ui): clear space for dialog close button in Post Suggestions header (closes #357)

### DIFF
--- a/frontend/src/components/PostSuggestionsModal.tsx
+++ b/frontend/src/components/PostSuggestionsModal.tsx
@@ -668,7 +668,7 @@ export default function PostSuggestionsModal({
             size="sm"
             onClick={() => previewMutation.mutate()}
             disabled={previewMutation.isPending}
-            className="ml-4 shrink-0 text-xs"
+            className="ml-4 mr-8 shrink-0 text-xs"
           >
             <RefreshCw
               className={cn(


### PR DESCRIPTION
The shared `DialogContent` primitive renders an absolute-positioned close (X) at `right-4 top-4`. The Regenerate button in the Post Suggestions modal header had no clearance for it, causing the two to visually overlap. Adding `mr-8` to the Regenerate button's className pushes it 32px left so the X sits cleanly in its reserved space.

Closes #357

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_