### PR TITLE
chore: sweep glitchwerks/siege-web -> glitchwerks/rsl-siege-manager

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/glitchwerks/siege-web/issues/new?labels=question
+    url: https://github.com/glitchwerks/rsl-siege-manager/issues/new?labels=question
     about: For questions (not bugs), open an Issue with the Question label. GitHub Discussions is not currently enabled on this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,8 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vitest component tests for the assignment board (`BoardPage`) and notification polling (`SiegeSettingsPage`)
 - CI on every PR to `main`: black + ruff + pytest (backend); ESLint + build (frontend)
 
-[1.1.0]: https://github.com/glitchwerks/siege-web/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/glitchwerks/siege-web/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/glitchwerks/siege-web/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/glitchwerks/siege-web/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/glitchwerks/siege-web/releases/tag/v1.0.0
+[1.1.0]: https://github.com/glitchwerks/rsl-siege-manager/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/glitchwerks/rsl-siege-manager/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/glitchwerks/rsl-siege-manager/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/glitchwerks/rsl-siege-manager/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/glitchwerks/rsl-siege-manager/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Data flow:
 
 See `docs/superpowers/plans/discord-auth-plan.md` for the canonical auth spec.
 
-Project state lives on GitHub — current release in [Releases](https://github.com/glitchwerks/siege-web/releases), active workstreams in [Milestones](https://github.com/glitchwerks/siege-web/milestones), open work in [Issues](https://github.com/glitchwerks/siege-web/issues), recent changes in `CHANGELOG.md`. Do not maintain a local status doc.
+Project state lives on GitHub — current release in [Releases](https://github.com/glitchwerks/rsl-siege-manager/releases), active workstreams in [Milestones](https://github.com/glitchwerks/rsl-siege-manager/milestones), open work in [Issues](https://github.com/glitchwerks/rsl-siege-manager/issues), recent changes in `CHANGELOG.md`. Do not maintain a local status doc.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Siege Assignment Web App
 
-[![CI](https://img.shields.io/github/actions/workflow/status/glitchwerks/siege-web/ci.yml?branch=main&label=CI&logo=github)](https://github.com/glitchwerks/siege-web/actions/workflows/ci.yml)
-[![Deploy](https://img.shields.io/github/actions/workflow/status/glitchwerks/siege-web/deploy.yml?branch=main&label=deploy&logo=github)](https://github.com/glitchwerks/siege-web/actions/workflows/deploy.yml)
-[![Latest release](https://img.shields.io/github/v/release/glitchwerks/siege-web?label=release&logo=github&color=blue)](https://github.com/glitchwerks/siege-web/releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/glitchwerks/rsl-siege-manager/ci.yml?branch=main&label=CI&logo=github)](https://github.com/glitchwerks/rsl-siege-manager/actions/workflows/ci.yml)
+[![Deploy](https://img.shields.io/github/actions/workflow/status/glitchwerks/rsl-siege-manager/deploy.yml?branch=main&label=deploy&logo=github)](https://github.com/glitchwerks/rsl-siege-manager/actions/workflows/deploy.yml)
+[![Latest release](https://img.shields.io/github/v/release/glitchwerks/rsl-siege-manager?label=release&logo=github&color=blue)](https://github.com/glitchwerks/rsl-siege-manager/releases/latest)
 [![Live site](https://img.shields.io/badge/live-rslsiege.com-success?logo=cloudflare&logoColor=white)](https://rslsiege.com)
 
 🌐 **Live site:** <https://rslsiege.com>
@@ -39,7 +39,7 @@ Get a populated local UI running in under 5 minutes — no Discord setup require
 
 ```bash
 # 1. Clone and enter the repo
-git clone https://github.com/glitchwerks/siege-web.git
+git clone https://github.com/glitchwerks/rsl-siege-manager.git
 cd siege-web
 
 # 2. Copy the example env (auth is disabled by default for local dev)
@@ -146,12 +146,12 @@ The in-app changelog dropdown reads from `CHANGELOG.md` at the repo root. Parsin
 
 ## Run it yourself
 
-Full self-host guides live in the [project wiki](https://github.com/glitchwerks/siege-web/wiki):
+Full self-host guides live in the [project wiki](https://github.com/glitchwerks/rsl-siege-manager/wiki):
 
-- **[Self-Host on Any VPS](https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS)** — any Linux host that runs Docker, with Caddy for free TLS and an optional Cloudflare Tunnel path if you can't open ports. The portable path — no cloud account required.
-- **[Self-Host on Azure](https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure)** — Container Apps + Key Vault + PostgreSQL Flexible Server, with a GitHub Actions deploy pipeline. The managed, hands-off path.
+- **[Self-Host on Any VPS](https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Any-VPS)** — any Linux host that runs Docker, with Caddy for free TLS and an optional Cloudflare Tunnel path if you can't open ports. The portable path — no cloud account required.
+- **[Self-Host on Azure](https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure)** — Container Apps + Key Vault + PostgreSQL Flexible Server, with a GitHub Actions deploy pipeline. The managed, hands-off path.
 
-New to the project? Start at **[Getting Started](https://github.com/glitchwerks/siege-web/wiki/Getting-Started)** in the wiki.
+New to the project? Start at **[Getting Started](https://github.com/glitchwerks/rsl-siege-manager/wiki/Getting-Started)** in the wiki.
 
 ## Deploy Environments
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Get a populated local UI running in under 5 minutes — no Discord setup require
 ```bash
 # 1. Clone and enter the repo
 git clone https://github.com/glitchwerks/rsl-siege-manager.git
-cd siege-web
+cd rsl-siege-manager
 
 # 2. Copy the example env (auth is disabled by default for local dev)
 cp .env.example .env

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## Where to ask
 
-**Bugs and unexpected behavior** — open a [GitHub Issue](https://github.com/glitchwerks/siege-web/issues/new/choose) using the bug report template. Include reproduction steps, your environment, and any relevant logs.
+**Bugs and unexpected behavior** — open a [GitHub Issue](https://github.com/glitchwerks/rsl-siege-manager/issues/new/choose) using the bug report template. Include reproduction steps, your environment, and any relevant logs.
 
 **Questions and how-to** — open a GitHub Issue with the `question` label. GitHub Discussions is not currently enabled on this repository; Issues are the right place for Q&A until it is.
 

--- a/docs/mockups/mockup-landing.html
+++ b/docs/mockups/mockup-landing.html
@@ -49,7 +49,7 @@
       </a>
       <!-- Right: GitHub + Sign in -->
       <div class="flex items-center gap-3">
-        <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener noreferrer"
+        <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener noreferrer"
            class="text-slate-500 hover:text-slate-900 transition-colors p-1.5 rounded-md hover:bg-slate-100"
            aria-label="View on GitHub">
           <!-- Lucide Github SVG -->
@@ -302,7 +302,7 @@
           PostgreSQL · Key Vault · Application Insights · Log Analytics
         </p>
         <div class="text-center">
-          <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener noreferrer"
+          <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener noreferrer"
              class="inline-flex items-center gap-1.5 text-sm text-slate-600 hover:text-slate-900 transition-colors border border-slate-300 rounded-md px-4 py-2 hover:bg-slate-50">
             View architecture on GitHub
             <!-- Lucide ExternalLink SVG -->
@@ -396,9 +396,9 @@
           </p>
           <p class="text-slate-700">
             <span class="text-slate-400 font-medium w-20 inline-block">GitHub</span>
-            <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener noreferrer"
+            <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener noreferrer"
                class="text-violet-600 hover:underline">
-              github.com/glitchwerks/siege-web
+              github.com/glitchwerks/rsl-siege-manager
             </a>
           </p>
         </div>

--- a/docs/self-host/anywhere.md
+++ b/docs/self-host/anywhere.md
@@ -1,3 +1,3 @@
 # Self-Host on Any VPS
 
-This page has moved to the project wiki: **https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS**
+This page has moved to the project wiki: **https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Any-VPS**

--- a/docs/self-host/azure.md
+++ b/docs/self-host/azure.md
@@ -1,3 +1,3 @@
 # Self-Host on Azure
 
-This page has moved to the project wiki: **https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure**
+This page has moved to the project wiki: **https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure**

--- a/docs/superpowers/plans/2026-04-08-discord-auth-implementation.md
+++ b/docs/superpowers/plans/2026-04-08-discord-auth-implementation.md
@@ -1,6 +1,6 @@
 # Discord OAuth2 Authentication — Implementation Plan
 
-> **Status: COMPLETED (2026-03)** — Discord OAuth2 is shipped and live. This file is a historical record of the implementation plan. For the canonical ongoing spec, see [`discord-auth-plan.md`](./discord-auth-plan.md). For current project status, see [GitHub Releases](https://github.com/glitchwerks/siege-web/releases) and [open Issues](https://github.com/glitchwerks/siege-web/issues).
+> **Status: COMPLETED (2026-03)** — Discord OAuth2 is shipped and live. This file is a historical record of the implementation plan. For the canonical ongoing spec, see [`discord-auth-plan.md`](./discord-auth-plan.md). For current project status, see [GitHub Releases](https://github.com/glitchwerks/rsl-siege-manager/releases) and [open Issues](https://github.com/glitchwerks/rsl-siege-manager/issues).
 
 > ~~**For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.~~ *(Historical — this plan is complete; do not re-execute.)*
 

--- a/docs/superpowers/plans/2026-05-08-component-versioning.md
+++ b/docs/superpowers/plans/2026-05-08-component-versioning.md
@@ -1,6 +1,6 @@
 # Component Versioning Plan (Issue #311)
 
-> Refs: https://github.com/glitchwerks/siege-web/issues/311
+> Refs: https://github.com/glitchwerks/rsl-siege-manager/issues/311
 > Drafted: 2026-05-08
 > Status: greenlit — 2× inquisitor passes resolved; ready for Phase 1 implementation
 

--- a/docs/superpowers/plans/2026-05-09-post-suggestions.md
+++ b/docs/superpowers/plans/2026-05-09-post-suggestions.md
@@ -12,7 +12,7 @@ Three architectural choices were locked in via clarifying questions:
 2. **First available position per post** — each post building has one group; the suggestion targets the first non-disabled, non-reserve position. If none available, the post is skipped.
 3. **Top-of-tab toolbar + Dialog** — new toolbar above the post list with a "Suggest Assignments" button; opens a Dialog modeled after `DiscordSyncModal`.
 
-GitHub Issue: [#197](https://github.com/glitchwerks/siege-web/issues/197) (existing, no new issue needed).
+GitHub Issue: [#197](https://github.com/glitchwerks/rsl-siege-manager/issues/197) (existing, no new issue needed).
 
 ---
 

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -191,7 +191,7 @@ export default function LandingPage() {
           {/* GitHub icon + Sign in */}
           <div className="flex items-center gap-3">
             <a
-              href="https://github.com/glitchwerks/siege-web"
+              href="https://github.com/glitchwerks/rsl-siege-manager"
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-md p-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
@@ -345,7 +345,7 @@ export default function LandingPage() {
 
             <div className="text-center">
               <a
-                href="https://github.com/glitchwerks/siege-web"
+                href="https://github.com/glitchwerks/rsl-siege-manager"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 px-4 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900"
@@ -385,7 +385,7 @@ export default function LandingPage() {
                   UI with zero Discord setup.
                 </p>
                 <a
-                  href="https://github.com/glitchwerks/siege-web#quick-start"
+                  href="https://github.com/glitchwerks/rsl-siege-manager#quick-start"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-slate-300 px-4 py-2 text-center text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
@@ -414,7 +414,7 @@ export default function LandingPage() {
                   containers. No cloud bill.
                 </p>
                 <a
-                  href="https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS"
+                  href="https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Any-VPS"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-violet-400 px-4 py-2 text-center text-sm font-medium text-violet-700 transition-colors hover:bg-violet-50"
@@ -438,7 +438,7 @@ export default function LandingPage() {
                   hands-off infrastructure.
                 </p>
                 <a
-                  href="https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure"
+                  href="https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-block rounded-md border border-slate-300 px-4 py-2 text-center text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
@@ -487,12 +487,12 @@ export default function LandingPage() {
                   GitHub
                 </span>
                 <a
-                  href="https://github.com/glitchwerks/siege-web"
+                  href="https://github.com/glitchwerks/rsl-siege-manager"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-violet-600 hover:underline"
                 >
-                  github.com/glitchwerks/siege-web
+                  github.com/glitchwerks/rsl-siege-manager
                 </a>
               </p>
             </div>

--- a/frontend/src/test/components/LandingPage.test.tsx
+++ b/frontend/src/test/components/LandingPage.test.tsx
@@ -111,11 +111,11 @@ describe("LandingPage (anonymous user)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("self-host-anywhere-link")).toHaveAttribute(
         "href",
-        "https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Any-VPS",
+        "https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Any-VPS",
       );
       expect(screen.getByTestId("self-host-azure-link")).toHaveAttribute(
         "href",
-        "https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure",
+        "https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure",
       );
     });
   });
@@ -125,7 +125,7 @@ describe("LandingPage (anonymous user)", () => {
     await waitFor(() => {
       expect(screen.getByText("higgsbp")).toBeInTheDocument();
       const ghLink = screen.getByRole("link", {
-        name: /github.com\/glitchwerks\/siege-web/i,
+        name: /github.com\/glitchwerks\/rsl-siege-manager/i,
       });
       expect(ghLink).toBeInTheDocument();
     });

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,7 +2,7 @@
 
 Azure Bicep templates for the Siege Assignment System.
 
-> For a complete end-to-end deployment walkthrough (prerequisites, resource-group setup, secret population, GitHub Actions wiring, DNS, and smoke test), see the [Self-Host on Azure wiki page](https://github.com/glitchwerks/siege-web/wiki/Self-Host-on-Azure).
+> For a complete end-to-end deployment walkthrough (prerequisites, resource-group setup, secret population, GitHub Actions wiring, DNS, and smoke test), see the [Self-Host on Azure wiki page](https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure).
 
 ## Resources provisioned
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -14,7 +14,7 @@ Not currently. The app is built around Discord OAuth2 for sign-in and a Discord 
 
 ### How do I report a bug or ask for a feature?
 
-Open a [GitHub Issue](https://github.com/glitchwerks/siege-web/issues) on the main repo.
+Open a [GitHub Issue](https://github.com/glitchwerks/rsl-siege-manager/issues) on the main repo.
 
 ## Self-hosting
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -13,7 +13,7 @@ That is the entire dependency list. Python, Node.js, and a Discord bot token are
 
 ```bash
 git clone https://github.com/glitchwerks/rsl-siege-manager.git
-cd siege-web
+cd rsl-siege-manager
 cp .env.example .env
 docker-compose up --build
 ```

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -12,7 +12,7 @@ That is the entire dependency list. Python, Node.js, and a Discord bot token are
 ## Clone, configure, run
 
 ```bash
-git clone https://github.com/glitchwerks/siege-web.git
+git clone https://github.com/glitchwerks/rsl-siege-manager.git
 cd siege-web
 cp .env.example .env
 docker-compose up --build
@@ -24,6 +24,6 @@ When the logs settle, open http://localhost:5173. The app loads with 25 demo mem
 
 - **Host it for your clan:** [Self-Host on Any VPS](Self-Host-on-Any-VPS) (start here — no cloud account needed) or [Self-Host on Azure](Self-Host-on-Azure) (managed path).
 - **Something unexpected?** Check the [FAQ](FAQ).
-- **Want to contribute?** The [main repo's README](https://github.com/glitchwerks/siege-web#readme) has the dev loop, test commands, and linting setup.
+- **Want to contribute?** The [main repo's README](https://github.com/glitchwerks/rsl-siege-manager#readme) has the dev loop, test commands, and linting setup.
 
 > **Auth note:** when running with real Discord OAuth (`AUTH_DISABLED=false`), only clan members who hold the configured Discord role (default: `Clan Deputies`) can log in. Set `DISCORD_REQUIRED_ROLE` in your `.env` to match the role name used in your server.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -29,4 +29,4 @@ Clan leaders and planners who coordinate siege building assignments for their gu
 
 ## About this wiki
 
-This wiki is mirrored from the `wiki/` folder in the [main repo](https://github.com/glitchwerks/siege-web). To edit a page, open a PR against `wiki/<Page-Name>.md` — direct edits through the wiki web UI will be overwritten on the next publish. Pull requests are reviewed, merged to `main`, and auto-published by a GitHub Action within a minute or two.
+This wiki is mirrored from the `wiki/` folder in the [main repo](https://github.com/glitchwerks/rsl-siege-manager). To edit a page, open a PR against `wiki/<Page-Name>.md` — direct edits through the wiki web UI will be overwritten on the next publish. Pull requests are reviewed, merged to `main`, and auto-published by a GitHub Action within a minute or two.

--- a/wiki/Self-Host-on-Any-VPS.md
+++ b/wiki/Self-Host-on-Any-VPS.md
@@ -88,7 +88,7 @@ The app uses Discord OAuth2 for user login. Only the backend's `/api/auth/callba
 SSH into your server and run:
 
 ```bash
-git clone https://github.com/glitchwerks/siege-web.git
+git clone https://github.com/glitchwerks/rsl-siege-manager.git
 cd siege-web
 cp .env.example .env.production
 ```
@@ -556,7 +556,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d backend
 
 ## 10. Day-two ops
 
-For incident playbooks, log queries, secret rotation, and rollback procedures, see [RUNBOOK.md in the main repo](https://github.com/glitchwerks/siege-web/blob/main/docs/RUNBOOK.md).
+For incident playbooks, log queries, secret rotation, and rollback procedures, see [RUNBOOK.md in the main repo](https://github.com/glitchwerks/rsl-siege-manager/blob/main/docs/RUNBOOK.md).
 
 ### Updating to a new version
 

--- a/wiki/Self-Host-on-Any-VPS.md
+++ b/wiki/Self-Host-on-Any-VPS.md
@@ -89,7 +89,7 @@ SSH into your server and run:
 
 ```bash
 git clone https://github.com/glitchwerks/rsl-siege-manager.git
-cd siege-web
+cd rsl-siege-manager
 cp .env.example .env.production
 ```
 
@@ -414,7 +414,7 @@ On a clean database, the first `alembic upgrade head` creates all tables from sc
 ### Start the stack
 
 ```bash
-cd siege-web
+cd rsl-siege-manager
 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 
@@ -561,7 +561,7 @@ For incident playbooks, log queries, secret rotation, and rollback procedures, s
 ### Updating to a new version
 
 ```bash
-cd siege-web
+cd rsl-siege-manager
 git pull origin main
 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 ```

--- a/wiki/Self-Host-on-Azure.md
+++ b/wiki/Self-Host-on-Azure.md
@@ -56,7 +56,7 @@ This is the managed, hands-off path. Azure handles TLS, scaling, secret rotation
 
 ## 2. Fork the repo and configure GitHub
 
-1. Fork `glitchwerks/siege-web` on GitHub (or clone it into your own org).
+1. Fork `glitchwerks/rsl-siege-manager` on GitHub (or clone it into your own org).
 2. The deploy pipeline reads from two GitHub Environments (`dev` and `prod`). You'll populate them with secrets and variables in Step 7 — for now, just note that they need to exist.
 
 ---
@@ -455,7 +455,7 @@ Run through this checklist after the first deploy (and after any infra change):
 
 ## 10. Day-two operations
 
-For ongoing operations (log queries, secret rotation, rollbacks, database restores, scaling), see [RUNBOOK.md in the main repo](https://github.com/glitchwerks/siege-web/blob/main/docs/RUNBOOK.md). That document assumes your environment is already deployed and uses `siege-rg-prod` and the actual resource names from your deployment.
+For ongoing operations (log queries, secret rotation, rollbacks, database restores, scaling), see [RUNBOOK.md in the main repo](https://github.com/glitchwerks/rsl-siege-manager/blob/main/docs/RUNBOOK.md). That document assumes your environment is already deployed and uses `siege-rg-prod` and the actual resource names from your deployment.
 
 ### Quick reference: update a secret
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -14,4 +14,4 @@
 
 ---
 
-[GitHub repo](https://github.com/glitchwerks/siege-web) · [Issues](https://github.com/glitchwerks/siege-web/issues)
+[GitHub repo](https://github.com/glitchwerks/rsl-siege-manager) · [Issues](https://github.com/glitchwerks/rsl-siege-manager/issues)


### PR DESCRIPTION
## Summary

Mechanical sweep replacing every `glitchwerks/siege-web` URL reference with `glitchwerks/rsl-siege-manager` across the repo, completing the rename tracked in #349. The repo was renamed from `siege-web` → `rsl-siege-manager` to align with in-app branding ("RSL Siege Manager"). GitHub's redirect kept old URLs working, but cleanup eliminates the redirect dependency.

## Scope

- 44 occurrences across 20 files updated.
- Touches: frontend `LandingPage.tsx` + its test, README badges, wiki pages, docs, plan files, mockup HTML, infra README, SUPPORT, CHANGELOG, CLAUDE.md, issue-template config.
- **Out of scope (deliberately preserved):** Azure resource names with the `siege-web-` prefix (`siege-web-dev`, `siege-web-prod`, Container Apps, ACR registry names). Those are independent of the GitHub repo name.

## Verification

- [x] `git grep glitchwerks/siege-web` → zero hits
- [x] `git grep siege-web-` still matches Azure resource names (sanity)
- [x] `npm test` (frontend Vitest) passes — `LandingPage.test.tsx` URL assertions match new component
- [x] `npm run lint` passes
- [x] `npm run build` passes (TS type check)

## Test plan

- [ ] CI green
- [ ] After merge: README badges still render (shields.io re-resolves the new path)
- [ ] After merge: wiki auto-publish action runs cleanly

Closes #349

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_