### PR TITLE
feat(suggest): expiry countdown + optimal-status chip (closes #363, closes #364)

### DIFF
--- a/frontend/src/components/PostSuggestionsModal.tsx
+++ b/frontend/src/components/PostSuggestionsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   RefreshCw,
@@ -467,6 +467,65 @@ function StateStaleConflict({
   );
 }
 
+// ─── Expiry countdown hook ────────────────────────────────────────────────────
+
+interface ExpiryCountdown {
+  secondsLeft: number;
+  formatted: string;
+  expired: boolean;
+}
+
+/**
+ * Returns a live countdown derived from an ISO timestamp.
+ * Updates every second; clears the interval on unmount or when expiresAt changes.
+ */
+function useExpiryCountdown(expiresAt: string | undefined): ExpiryCountdown {
+  const computeSecondsLeft = () => {
+    if (!expiresAt) return 0;
+    return Math.max(
+      0,
+      Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
+    );
+  };
+
+  const [secondsLeft, setSecondsLeft] = useState<number>(computeSecondsLeft);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    // Reset immediately when expiresAt changes
+    setSecondsLeft(computeSecondsLeft());
+
+    if (!expiresAt) return;
+
+    intervalRef.current = setInterval(() => {
+      const next = Math.max(
+        0,
+        Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
+      );
+      setSecondsLeft(next);
+      if (next === 0 && intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresAt]);
+
+  const minutes = Math.floor(secondsLeft / 60);
+  const secs = secondsLeft % 60;
+  const formatted = `${minutes}:${String(secs).padStart(2, "0")}`;
+  const expired = secondsLeft === 0;
+
+  return { secondsLeft, formatted, expired };
+}
+
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export default function PostSuggestionsModal({
@@ -486,6 +545,9 @@ export default function PostSuggestionsModal({
   >(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [filter, setFilter] = useState<OutcomeFilter>("all");
+
+  const { formatted: countdownFormatted, expired: previewExpired } =
+    useExpiryCountdown(preview?.expires_at);
 
   const previewMutation = useMutation({
     mutationFn: () => previewPostSuggestions(siegeId),
@@ -513,6 +575,9 @@ export default function PostSuggestionsModal({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
       queryClient.invalidateQueries({ queryKey: ["posts", siegeId] });
+      queryClient.invalidateQueries({
+        queryKey: ["post-suggestions-status", siegeId],
+      });
       handleClose();
     },
     onError: (err: unknown) => {
@@ -658,9 +723,21 @@ export default function PostSuggestionsModal({
               Suggest post assignments
             </DialogTitle>
             <p className="mt-0.5 text-xs text-slate-500">
-              {preview
-                ? `${totalCount} posts reviewed · matching against post conditions`
-                : "Generating suggestions…"}
+              {preview ? (
+                <>
+                  {totalCount} posts reviewed · matching against post
+                  conditions{" "}
+                  {previewExpired ? (
+                    <span className="ml-1 inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-amber-100 text-amber-800 ring-1 ring-inset ring-amber-200">
+                      Preview expired
+                    </span>
+                  ) : (
+                    <>· expires in {countdownFormatted}</>
+                  )}
+                </>
+              ) : (
+                "Generating suggestions…"
+              )}
             </p>
           </div>
           <Button
@@ -831,7 +908,14 @@ export default function PostSuggestionsModal({
                 <div className="flex items-center justify-between gap-4 border-t border-slate-100 bg-slate-50 px-6 py-3">
                   <p className="text-sm text-slate-600">
                     {totalSelected === 0 ? (
-                      <span className="text-slate-400">Nothing selected.</span>
+                      <span className="text-slate-400">
+                        Nothing selected.
+                        {previewExpired && (
+                          <span className="ml-1 text-slate-500">
+                            Click Regenerate to refresh.
+                          </span>
+                        )}
+                      </span>
                     ) : (
                       <>
                         Apply{" "}
@@ -847,6 +931,11 @@ export default function PostSuggestionsModal({
                           {selectedReplace} replacement
                           {selectedReplace === 1 ? "" : "s"}
                         </span>
+                        {previewExpired && (
+                          <span className="ml-2 text-slate-500">
+                            Click Regenerate to refresh.
+                          </span>
+                        )}
                       </>
                     )}
                   </p>
@@ -857,10 +946,12 @@ export default function PostSuggestionsModal({
                     <Button
                       onClick={() => handleApply()}
                       disabled={
-                        totalSelected === 0 || applyMutation.isPending
+                        totalSelected === 0 ||
+                        applyMutation.isPending ||
+                        previewExpired
                       }
                       className={cn(
-                        totalSelected === 0 && "opacity-40"
+                        (totalSelected === 0 || previewExpired) && "opacity-40"
                       )}
                     >
                       {applyMutation.isPending

--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -10,7 +10,7 @@ import {
   BookmarkCheck,
 } from "lucide-react";
 import { getPosts } from "../api/posts";
-import { getSiegeMemberPreferences } from "../api/sieges";
+import { getSiegeMemberPreferences, previewPostSuggestions } from "../api/sieges";
 import { updatePosition } from "../api/board";
 import type {
   BuildingResponse,
@@ -639,6 +639,33 @@ export function PostsTab({
     queryFn: () => getPosts(siegeId),
   });
 
+  // Optimal-status chip query (issue #364)
+  const {
+    data: suggestStatus,
+    isLoading: statusLoading,
+    isError: statusError,
+  } = useQuery({
+    queryKey: ["post-suggestions-status", siegeId],
+    queryFn: () => previewPostSuggestions(siegeId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const chipStatus = (() => {
+    if (statusLoading) return "loading" as const;
+    if (statusError || !suggestStatus) return "errored" as const;
+    const actionable = suggestStatus.assignments.filter((a) => !a.skip_reason);
+    if (actionable.every((a) => a.matches_current)) return "optimal" as const;
+    return "suggestions" as const;
+  })();
+
+  const suggestionCount = (() => {
+    if (!suggestStatus) return 0;
+    return suggestStatus.assignments.filter(
+      (a) => !a.skip_reason && !a.matches_current
+    ).length;
+  })();
+
   // Build preference map: member_id → array of condition ids
   const preferenceMap = useMemo(() => {
     const map = new Map<number, number[]>();
@@ -712,8 +739,43 @@ export function PostsTab({
 
   return (
     <>
-      {/* Toolbar — Suggest Assignments button */}
+      {/* Toolbar — optimal-status chip + Suggest Assignments button */}
       <div className="mb-3 flex items-center gap-2">
+        {/* Optimal-status chip (issue #364) */}
+        {chipStatus === "optimal" && (
+          <button
+            type="button"
+            onClick={() => setSuggestModalOpen(true)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-emerald-50 text-emerald-800 ring-emerald-200 hover:bg-emerald-100 transition-colors"
+          >
+            <Check className="h-3 w-3" aria-hidden="true" />
+            Optimal
+          </button>
+        )}
+        {chipStatus === "suggestions" && (
+          <button
+            type="button"
+            onClick={() => setSuggestModalOpen(true)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-amber-50 text-amber-800 ring-amber-200 hover:bg-amber-100 transition-colors"
+          >
+            {suggestionCount} suggestion{suggestionCount === 1 ? "" : "s"}
+          </button>
+        )}
+        {chipStatus === "loading" && (
+          <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200">
+            Checking…
+          </span>
+        )}
+        {chipStatus === "errored" && (
+          <button
+            type="button"
+            onClick={() => setSuggestModalOpen(true)}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200 hover:bg-slate-100 transition-colors"
+            title="Couldn't compute (click Suggest to check)"
+          >
+            ?
+          </button>
+        )}
         <Button
           variant="outline"
           size="sm"

--- a/frontend/src/test/components/PostSuggestionsModal.test.tsx
+++ b/frontend/src/test/components/PostSuggestionsModal.test.tsx
@@ -15,6 +15,8 @@
  * 10. Loading state shows the spinner copy.
  * 11. Non-409 error shows the generic error banner.
  * 12. "Apply remaining N" re-issues apply with only non-stale IDs.
+ * 13. Expiry countdown renders given a fixed expires_at (~5 min in the future).
+ * 14. Apply button disables when expiry hits zero; "Preview expired" chip appears.
  */
 
 import { screen, waitFor, within } from "@testing-library/react";
@@ -80,7 +82,9 @@ function makePreview(
         skip_reason: "no_match",
       },
     ],
-    expires_at: "2026-05-09T13:00:00",
+    // Always set expiry 10 minutes in the future so the Apply button stays enabled
+    // in tests that don't exercise the expiry path.
+    expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
     ...overrides,
   };
 }
@@ -604,5 +608,53 @@ describe("PostSuggestionsModal", () => {
     expect(
       secondApplyBody!.apply_position_ids as number[]
     ).not.toContain(101);
+  });
+
+  it("expiry countdown renders given a fixed expires_at (~5 minutes in the future)", async () => {
+    // Set expires_at to exactly 5 minutes from now
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () =>
+        HttpResponse.json(makePreview({ expires_at: expiresAt }))
+      )
+    );
+
+    renderModal();
+
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    // Countdown should appear in the form "expires in M:SS"
+    // Allow for 4:59 or 5:00 (render timing may consume a second)
+    await waitFor(() => {
+      const subtitle = screen.getByText(/expires in \d+:\d{2}/i);
+      expect(subtitle).toBeInTheDocument();
+    });
+  });
+
+  it("Apply button disables and Preview expired chip appears when expiry hits zero", async () => {
+    // Use an expires_at in the past so the hook computes secondsLeft=0 immediately.
+    // This avoids needing fake timers to advance past the TTL.
+    const expiresAt = new Date(Date.now() - 5000).toISOString();
+
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () =>
+        HttpResponse.json(makePreview({ expires_at: expiresAt }))
+      )
+    );
+
+    renderModal();
+
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+
+    // With expires_at in the past, the countdown is already at 0 on first render.
+    // Apply button should be disabled.
+    await waitFor(() => {
+      const applyBtn = screen.getByRole("button", { name: /apply/i });
+      expect(applyBtn).toBeDisabled();
+    });
+
+    // "Preview expired" chip should be visible in the header.
+    expect(screen.getByText("Preview expired")).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -32,6 +32,7 @@ import type {
   SiegeMember,
   Siege,
   Post,
+  PostSuggestionPreviewResult,
 } from "../../api/types";
 
 // ─── Server lifecycle ──────────────────────────────────────────────────────────
@@ -602,5 +603,177 @@ describe("PostsTab — Suggest Assignments toolbar", () => {
 
     const btn = screen.getByRole("button", { name: /suggest assignments/i });
     expect(btn).toBeDisabled();
+  });
+});
+
+// ─── Optimal-status chip (issue #364) ────────────────────────────────────────
+
+function makePostPreviewResult(
+  overrides: Partial<PostSuggestionPreviewResult> = {}
+): PostSuggestionPreviewResult {
+  return {
+    assignments: [],
+    expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeOptimalAssignment(positionId: number) {
+  return {
+    post_id: positionId,
+    building_number: positionId,
+    priority: 1,
+    position_id: positionId,
+    suggested_member_id: 1,
+    suggested_member_name: "Aethon",
+    suggested_condition_id: 5,
+    suggested_condition_description: "Great Fortification",
+    current_member_id: 1,
+    current_member_name: "Aethon",
+    current_condition_id: 5,
+    current_condition_description: "Great Fortification",
+    matches_current: true,
+    skip_reason: null as null,
+  };
+}
+
+function makeSuggestionAssignment(positionId: number) {
+  return {
+    post_id: positionId,
+    building_number: positionId,
+    priority: 1,
+    position_id: positionId,
+    suggested_member_id: 2,
+    suggested_member_name: "Bob",
+    suggested_condition_id: 5,
+    suggested_condition_description: "Great Fortification",
+    current_member_id: null,
+    current_member_name: null,
+    current_condition_id: null,
+    current_condition_description: null,
+    matches_current: false,
+    skip_reason: null as null,
+  };
+}
+
+describe("PostsTab — optimal-status chip (#364)", () => {
+  it("chip renders Optimal when every actionable assignment matches_current", async () => {
+    const user = userEvent.setup();
+
+    setupHandlers(makePostBoard(), makeSiege(), [], [makePost()]);
+    // The status query hits the preview endpoint (POST)
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () =>
+        HttpResponse.json(
+          makePostPreviewResult({
+            assignments: [makeOptimalAssignment(101), makeOptimalAssignment(102)],
+          })
+        )
+      )
+    );
+
+    renderBoard();
+    await navigateToPostsTab(user);
+
+    // Chip should show "Optimal" (or "✓ Optimal")
+    await waitFor(() => {
+      expect(screen.getByText(/optimal/i)).toBeInTheDocument();
+    });
+
+    // Should use an emerald styling cue — chip is a button
+    const chip = screen.getByRole("button", { name: /optimal/i });
+    expect(chip.className).toMatch(/emerald/);
+  });
+
+  it("chip renders suggestion count when suggestions are available", async () => {
+    const user = userEvent.setup();
+
+    setupHandlers(makePostBoard(), makeSiege(), [], [makePost()]);
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () =>
+        HttpResponse.json(
+          makePostPreviewResult({
+            assignments: [
+              makeSuggestionAssignment(101),
+              makeSuggestionAssignment(102),
+            ],
+          })
+        )
+      )
+    );
+
+    renderBoard();
+    await navigateToPostsTab(user);
+
+    // Chip should show count of non-optimal actionable assignments: "2 suggestion(s)"
+    await waitFor(() => {
+      expect(screen.getByText(/2 suggestion/i)).toBeInTheDocument();
+    });
+
+    // Should use an amber styling cue
+    const chip = screen.getByRole("button", { name: /suggestion/i });
+    expect(chip.className).toMatch(/amber/);
+  });
+
+  it("chip flips to Optimal after a successful apply", async () => {
+    const user = userEvent.setup();
+
+    // The preview endpoint is called by both the chip query (on mount) and the modal
+    // mutation (on open). We track calls: calls 1-2 → suggestions; call 3+ → optimal.
+    // Call 1: chip query initial mount
+    // Call 2: modal mutation on open
+    // Call 3: chip query after invalidation from apply success
+    let previewCallCount = 0;
+    setupHandlers(makePostBoard(), makeSiege(), [], [makePost()]);
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () => {
+        previewCallCount++;
+        if (previewCallCount <= 2) {
+          // Initial chip + modal: has suggestions
+          return HttpResponse.json(
+            makePostPreviewResult({
+              assignments: [makeSuggestionAssignment(101)],
+            })
+          );
+        }
+        // After apply invalidation: optimal
+        return HttpResponse.json(
+          makePostPreviewResult({
+            assignments: [makeOptimalAssignment(101)],
+          })
+        );
+      }),
+      http.post("/api/sieges/42/post-suggestions/apply", () =>
+        HttpResponse.json({ applied_count: 1 })
+      )
+    );
+
+    renderBoard();
+    await navigateToPostsTab(user);
+
+    // Chip initially shows suggestions
+    await waitFor(() => {
+      expect(screen.getByText(/suggestion/i)).toBeInTheDocument();
+    });
+
+    // Open modal via Suggest button
+    const suggestBtn = screen.getByRole("button", {
+      name: /suggest assignments/i,
+    });
+    await user.click(suggestBtn);
+
+    // Wait for modal to load (the modal fires its own preview mutation)
+    await waitFor(() => {
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+
+    // Click Apply in the modal
+    const applyBtn = screen.getByRole("button", { name: /apply/i });
+    await user.click(applyBtn);
+
+    // After apply, modal closes and chip should flip to Optimal
+    await waitFor(() => {
+      expect(screen.getByText(/optimal/i)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Issue #363 — Preview-expiry countdown in modal header

Adds a `useExpiryCountdown(expiresAt)` hook (inline in PostSuggestionsModal) that ticks down every second from the `expires_at` ISO timestamp already present in `PostSuggestionPreviewResult`. The header subtitle now reads `· expires in 4:42` while the timer runs. When `secondsLeft` reaches zero, the countdown is replaced by an amber "Preview expired" chip, the Apply button is disabled, and a helper line ("Click Regenerate to refresh.") appears in the footer. Filter tiles, table, and Regenerate all remain interactive. Regenerating resets the hook cleanly via the `useEffect` dep on `expires_at`. The interval is cleared on unmount via cleanup.

## Issue #364 — Optimal-status chip in PostsTab toolbar

Adds a `useQuery` call in PostsTab against the existing `previewPostSuggestions` endpoint (key `["post-suggestions-status", siegeId]`, 5 min stale time, no window-focus refetch). Computes chip state as `optimal | suggestions | loading | errored` from the actionable assignments. Renders a small chip — emerald for optimal, amber for has-suggestions, slate for the other two — immediately to the left of the "Suggest Assignments" button; clicking it opens the modal. In `PostSuggestionsModal.applyMutation.onSuccess`, `invalidateQueries(["post-suggestions-status", siegeId])` is added alongside the existing board/posts invalidations so the chip flips to "Optimal" immediately after a successful apply.

## Tests

- `PostSuggestionsModal.test.tsx`: +2 tests (was 12, now 14) — countdown renders given a fixed `expires_at`; Apply disables and "Preview expired" chip appears when expiry is in the past.
- `PostsTab.test.tsx`: +3 tests (was 10, now 13) — chip renders "Optimal"; chip shows suggestion count; chip flips to Optimal after apply.
- All 184 tests passing; 0 lint errors; prettier clean; build `✓`.

Closes #363
Closes #364

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_