### PR TITLE
feat: distinguish no_conditions from no_match in post suggestions (closes #366)

### DIFF
--- a/backend/app/schemas/post_suggestions.py
+++ b/backend/app/schemas/post_suggestions.py
@@ -38,8 +38,10 @@ class PostSuggestionEntry(BaseModel):
             None.
         skip_reason: Set when suggested_member_id is None.  Indicates why
             the post was skipped:
-            - "no_match": no candidate member whose preferences intersect
-              the post's active conditions.
+            - "no_conditions": the post has zero active conditions so no
+              member can ever match (user must configure the post first).
+            - "no_match": conditions exist but no candidate member's
+              preferences intersect the post's active conditions.
             - "reserve": target position has is_reserve=True.
             - "disabled": target position has is_disabled=True.
     """
@@ -57,7 +59,7 @@ class PostSuggestionEntry(BaseModel):
     current_condition_id: int | None
     current_condition_description: str | None
     matches_current: bool
-    skip_reason: Literal["no_match", "reserve", "disabled"] | None
+    skip_reason: Literal["no_conditions", "no_match", "reserve", "disabled"] | None
 
 
 class PostSuggestionPreviewResult(BaseModel):

--- a/backend/app/services/post_suggestions.py
+++ b/backend/app/services/post_suggestions.py
@@ -207,6 +207,20 @@ async def preview_post_suggestions(
             )
             continue
 
+        if not post.active_conditions:
+            assignments.append(
+                _null_entry(
+                    post,
+                    position_id=position.id,
+                    skip_reason="no_conditions",
+                    current_member_id=current_member_id,
+                    current_member_name=current_member_name,
+                    current_condition_id=current_condition_id,
+                    current_condition_description=current_condition_description,
+                )
+            )
+            continue
+
         post_condition_ids: set[int] = {c.id for c in post.active_conditions}
 
         # Build candidate list: members whose preferences intersect post conditions.
@@ -514,7 +528,7 @@ def _null_entry(
     Args:
         post: Post ORM object (or SimpleNamespace in tests).
         position_id: The target position id (0 if no position exists).
-        skip_reason: One of "no_match", "reserve", "disabled".
+        skip_reason: One of "no_conditions", "no_match", "reserve", "disabled".
         current_member_id: Existing member assignment, if any.
         current_member_name: Existing member name, if any.
         current_condition_id: Existing matched condition, if any.

--- a/backend/tests/test_post_suggestions.py
+++ b/backend/tests/test_post_suggestions.py
@@ -298,6 +298,100 @@ async def test_preview_disabled_position_produces_skip_reason_disabled():
 
 
 # ---------------------------------------------------------------------------
+# Section: No-conditions skip (issue #366)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_post_with_no_active_conditions_produces_skip_reason_no_conditions():
+    """Issue #366: post with empty active_conditions → skip_reason='no_conditions'.
+
+    When a post has zero active conditions the algorithm cannot match any
+    member — but this is distinct from no_match (which means conditions
+    exist but no member qualifies).  The correct response is no_conditions
+    so the user knows to configure the post rather than add eligible members.
+    """
+    member = _make_member(id=1, name="Alice", preferences=[_make_condition(id=10)])
+    sm = _make_siege_member(member)
+    pos = _make_position(id=101)
+    grp = _make_group([pos])
+    bld = _make_building(id=5, building_number=1, groups=[grp])
+    # active_conditions intentionally empty
+    post = _make_post(id=20, building=bld, priority=1, active_conditions=[])
+    siege = _make_siege(posts=[post], siege_members=[sm])
+
+    result = await _preview(siege)
+
+    assert len(result.assignments) == 1
+    entry = result.assignments[0]
+    assert entry.suggested_member_id is None
+    assert entry.skip_reason == "no_conditions"
+
+
+@pytest.mark.asyncio
+async def test_preview_post_with_conditions_but_no_matching_member_still_no_match():
+    """Issue #366: no_match is unchanged when conditions exist but no member qualifies.
+
+    Regression guard — the no_conditions early-exit must not absorb cases
+    where conditions are present but the member pool is simply disjoint.
+    """
+    cond_post = _make_condition(id=10, description="Post cond")
+    cond_member = _make_condition(id=20, description="Member cond")
+    member = _make_member(id=1, name="Bob", preferences=[cond_member])
+    sm = _make_siege_member(member)
+    pos = _make_position(id=102)
+    grp = _make_group([pos])
+    bld = _make_building(id=6, building_number=2, groups=[grp])
+    post = _make_post(id=21, building=bld, priority=1, active_conditions=[cond_post])
+    siege = _make_siege(posts=[post], siege_members=[sm])
+
+    result = await _preview(siege)
+
+    entry = result.assignments[0]
+    assert entry.suggested_member_id is None
+    assert entry.skip_reason == "no_match"
+
+
+@pytest.mark.asyncio
+async def test_preview_mixed_no_conditions_no_match_and_assigned_in_one_preview():
+    """Issue #366: all three outcomes coexist without conflation.
+
+    One post has no conditions → no_conditions.
+    One post has conditions but no qualifying member → no_match.
+    One post has a match → assigned.
+    This proves the three cases are distinct in the output.
+    """
+    shared_cond = _make_condition(id=10, description="Shared cond")
+    other_cond = _make_condition(id=20, description="Other cond")
+    member = _make_member(id=1, name="Alice", preferences=[shared_cond])
+    sm = _make_siege_member(member)
+
+    # Post A: no conditions → no_conditions
+    pos_a = _make_position(id=101)
+    bld_a = _make_building(id=1, building_number=1, groups=[_make_group([pos_a])])
+    post_a = _make_post(id=10, building=bld_a, priority=1, active_conditions=[])
+
+    # Post B: conditions present but disjoint from member → no_match
+    pos_b = _make_position(id=102)
+    bld_b = _make_building(id=2, building_number=2, groups=[_make_group([pos_b])])
+    post_b = _make_post(id=11, building=bld_b, priority=2, active_conditions=[other_cond])
+
+    # Post C: condition matches Alice → assigned
+    pos_c = _make_position(id=103)
+    bld_c = _make_building(id=3, building_number=3, groups=[_make_group([pos_c])])
+    post_c = _make_post(id=12, building=bld_c, priority=3, active_conditions=[shared_cond])
+
+    siege = _make_siege(posts=[post_a, post_b, post_c], siege_members=[sm])
+    result = await _preview(siege)
+
+    by_post = {e.post_id: e for e in result.assignments}
+    assert by_post[10].skip_reason == "no_conditions"
+    assert by_post[11].skip_reason == "no_match"
+    assert by_post[12].suggested_member_id == 1
+    assert by_post[12].skip_reason is None
+
+
+# ---------------------------------------------------------------------------
 # Section: Priority ordering (AC #3)
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -253,7 +253,11 @@ export interface MemberRoleInfo {
 }
 
 // Post Suggestions
-export type PostSuggestionSkipReason = "no_match" | "reserve" | "disabled";
+export type PostSuggestionSkipReason =
+  | "no_conditions"
+  | "no_match"
+  | "reserve"
+  | "disabled";
 
 export interface PostSuggestionEntry {
   post_id: number;

--- a/frontend/src/components/PostSuggestionsModal.tsx
+++ b/frontend/src/components/PostSuggestionsModal.tsx
@@ -8,6 +8,7 @@ import {
   Lock,
   Ban,
   Info,
+  SlidersHorizontal,
 } from "lucide-react";
 import { previewPostSuggestions, applyPostSuggestions } from "../api/sieges";
 import type {
@@ -70,6 +71,7 @@ const SKIP_REASON_LABEL: Record<
   NonNullable<PostSuggestionEntry["skip_reason"]>,
   string
 > = {
+  no_conditions: "No conditions configured for this post",
   no_match: "No member matches any of the post conditions",
   reserve: "Position is set to reserve",
   disabled: "Position is disabled",
@@ -248,6 +250,8 @@ function SkipIcon({ reason }: { reason: string | null }) {
     return <Lock className="h-3 w-3" aria-hidden="true" />;
   if (reason === "disabled")
     return <Ban className="h-3 w-3" aria-hidden="true" />;
+  if (reason === "no_conditions")
+    return <SlidersHorizontal className="h-3 w-3" aria-hidden="true" />;
   return <Info className="h-3 w-3" aria-hidden="true" />;
 }
 

--- a/frontend/src/test/components/PostSuggestionsModal.test.tsx
+++ b/frontend/src/test/components/PostSuggestionsModal.test.tsx
@@ -17,6 +17,7 @@
  * 12. "Apply remaining N" re-issues apply with only non-stale IDs.
  * 13. Expiry countdown renders given a fixed expires_at (~5 min in the future).
  * 14. Apply button disables when expiry hits zero; "Preview expired" chip appears.
+ * 15. no_conditions rows render distinct copy and a different icon than no_match rows.
  */
 
 import { screen, waitFor, within } from "@testing-library/react";
@@ -656,5 +657,73 @@ describe("PostSuggestionsModal", () => {
 
     // "Preview expired" chip should be visible in the header.
     expect(screen.getByText("Preview expired")).toBeInTheDocument();
+  });
+
+  it("no_conditions rows render distinct copy and a different icon than no_match rows", async () => {
+    // Preview with one no_conditions row and one no_match row so we can
+    // verify both the label text and that the SVG icons differ.
+    const preview = makePreview({
+      assignments: [
+        {
+          post_id: 1,
+          building_number: 1,
+          priority: 2,
+          position_id: 101,
+          suggested_member_id: null,
+          suggested_member_name: null,
+          suggested_condition_id: null,
+          suggested_condition_description: null,
+          current_member_id: null,
+          current_member_name: null,
+          current_condition_id: null,
+          current_condition_description: null,
+          matches_current: false,
+          skip_reason: "no_conditions",
+        },
+        {
+          post_id: 2,
+          building_number: 2,
+          priority: 1,
+          position_id: 102,
+          suggested_member_id: null,
+          suggested_member_name: null,
+          suggested_condition_id: null,
+          suggested_condition_description: null,
+          current_member_id: null,
+          current_member_name: null,
+          current_condition_id: null,
+          current_condition_description: null,
+          matches_current: false,
+          skip_reason: "no_match",
+        },
+      ],
+    });
+
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () =>
+        HttpResponse.json(preview)
+      )
+    );
+
+    renderModal();
+
+    // no_conditions label
+    await waitFor(() =>
+      expect(
+        screen.getByText("No conditions configured for this post")
+      ).toBeInTheDocument()
+    );
+
+    // no_match label still present (unchanged)
+    expect(
+      screen.getByText("No member matches any of the post conditions")
+    ).toBeInTheDocument();
+
+    // Icons must differ: no_conditions uses SlidersHorizontal, no_match uses Info.
+    // lucide-react adds a CSS class lucide-<kebab-name> to every icon SVG.
+    const slidersIcons = document.querySelectorAll(".lucide-sliders-horizontal");
+    const infoIcons = document.querySelectorAll(".lucide-info");
+    expect(slidersIcons.length).toBeGreaterThanOrEqual(1);
+    expect(infoIcons.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

Posts with zero active conditions now return `skip_reason: "no_conditions"` instead of incorrectly reusing `"no_match"`. The two cases require different user actions — configure the post vs. add eligible members — so conflating them was actively misleading.

The `no_match` path is unchanged; it still fires when conditions exist but no member's preferences intersect them.

## Acceptance Criteria

- [x] Backend service emits `skip_reason: "no_conditions"` when `post.active_conditions` is empty (early-exit before the candidate-filtering step)
- [x] Existing `no_match` path unchanged for posts that have conditions but no qualifying members
- [x] Pydantic schema `PostSuggestionEntry.skip_reason` extended with `"no_conditions"` literal
- [x] Frontend `PostSuggestionSkipReason` type includes `"no_conditions"`
- [x] Modal renders distinct copy: "No conditions configured for this post"
- [x] Modal renders `SlidersHorizontal` icon for `no_conditions` (vs `Info` for `no_match`)
- [x] Backend: 3 new tests — no_conditions skip, no_match regression guard, mixed coexistence
- [x] Frontend: 1 new modal test asserting copy and icon distinction
- [x] All CI checks passing: black, ruff, pytest (+3), eslint, prettier, vitest (+1), build

## Test counts

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| Backend (pytest) | 367 passed | 370 passed | +3 |
| Frontend (vitest) | 184 passed | 185 passed | +1 |

Closes #366

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_