### PR TITLE
fix(posts): optimal chip is a label + right-side + auto-refreshes (closes #368)

### DIFF
--- a/frontend/src/components/PostsTab.tsx
+++ b/frontend/src/components/PostsTab.tsx
@@ -137,6 +137,7 @@ function MemberAssignRow({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
       setConfirmPending(false);
       onAssigned();
     },
@@ -354,6 +355,7 @@ function PostRow({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
     },
   });
 
@@ -739,43 +741,8 @@ export function PostsTab({
 
   return (
     <>
-      {/* Toolbar — optimal-status chip + Suggest Assignments button */}
+      {/* Toolbar — Suggest Assignments button + optimal-status chip */}
       <div className="mb-3 flex items-center gap-2">
-        {/* Optimal-status chip (issue #364) */}
-        {chipStatus === "optimal" && (
-          <button
-            type="button"
-            onClick={() => setSuggestModalOpen(true)}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-emerald-50 text-emerald-800 ring-emerald-200 hover:bg-emerald-100 transition-colors"
-          >
-            <Check className="h-3 w-3" aria-hidden="true" />
-            Optimal
-          </button>
-        )}
-        {chipStatus === "suggestions" && (
-          <button
-            type="button"
-            onClick={() => setSuggestModalOpen(true)}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-amber-50 text-amber-800 ring-amber-200 hover:bg-amber-100 transition-colors"
-          >
-            {suggestionCount} suggestion{suggestionCount === 1 ? "" : "s"}
-          </button>
-        )}
-        {chipStatus === "loading" && (
-          <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200">
-            Checking…
-          </span>
-        )}
-        {chipStatus === "errored" && (
-          <button
-            type="button"
-            onClick={() => setSuggestModalOpen(true)}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200 hover:bg-slate-100 transition-colors"
-            title="Couldn't compute (click Suggest to check)"
-          >
-            ?
-          </button>
-        )}
         <Button
           variant="outline"
           size="sm"
@@ -784,6 +751,31 @@ export function PostsTab({
         >
           Suggest Assignments
         </Button>
+        {/* Optimal-status chip (issue #364) — label only, not interactive */}
+        {chipStatus === "optimal" && (
+          <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-emerald-50 text-emerald-800 ring-emerald-200">
+            <Check className="h-3 w-3" aria-hidden="true" />
+            Optimal
+          </span>
+        )}
+        {chipStatus === "suggestions" && (
+          <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-amber-50 text-amber-800 ring-amber-200">
+            {suggestionCount} suggestion{suggestionCount === 1 ? "" : "s"}
+          </span>
+        )}
+        {chipStatus === "loading" && (
+          <span className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200">
+            Checking…
+          </span>
+        )}
+        {chipStatus === "errored" && (
+          <span
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset bg-slate-50 text-slate-500 ring-slate-200"
+            title="Couldn't compute (click Suggest to check)"
+          >
+            ?
+          </span>
+        )}
       </div>
 
       <div className="space-y-2">

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -138,6 +138,7 @@ function PositionCell({
     }) => updatePosition(siegeId, position.id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
       onUpdate();
       setMenuOpen(false);
     },
@@ -757,6 +758,7 @@ export default function BoardPage() {
     mutationFn: () => applyAutofill(siegeId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
       setAutofillOpen(false);
       setAutofillPreview(null);
     },
@@ -906,6 +908,7 @@ export default function BoardPage() {
       is_reserve: false,
     }).then(() => {
       queryClient.invalidateQueries({ queryKey: ["board", siegeId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
     });
   }
 

--- a/frontend/src/pages/MemberDetailPage.tsx
+++ b/frontend/src/pages/MemberDetailPage.tsx
@@ -147,6 +147,7 @@ export default function MemberDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["members"] });
       queryClient.invalidateQueries({ queryKey: ["member", memberId] });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
       setDeactivateOpen(false);
     },
   });
@@ -157,6 +158,7 @@ export default function MemberDetailPage() {
       queryClient.invalidateQueries({
         queryKey: ["memberPreferences", memberId],
       });
+      queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] });
     },
   });
 

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -680,9 +680,10 @@ describe("PostsTab — optimal-status chip (#364)", () => {
       expect(screen.getByText(/optimal/i)).toBeInTheDocument();
     });
 
-    // Should use an emerald styling cue — chip is a button
-    const chip = screen.getByRole("button", { name: /optimal/i });
-    expect(chip.className).toMatch(/emerald/);
+    // Chip is now a non-interactive <span>, not a button
+    const chip = screen.getByText(/optimal/i).closest("span");
+    expect(chip).not.toBeNull();
+    expect(chip!.className).toMatch(/emerald/);
   });
 
   it("chip renders suggestion count when suggestions are available", async () => {
@@ -710,9 +711,10 @@ describe("PostsTab — optimal-status chip (#364)", () => {
       expect(screen.getByText(/2 suggestion/i)).toBeInTheDocument();
     });
 
-    // Should use an amber styling cue
-    const chip = screen.getByRole("button", { name: /suggestion/i });
-    expect(chip.className).toMatch(/amber/);
+    // Chip is now a non-interactive <span>, not a button
+    const chip = screen.getByText(/2 suggestion/i).closest("span");
+    expect(chip).not.toBeNull();
+    expect(chip!.className).toMatch(/amber/);
   });
 
   it("chip flips to Optimal after a successful apply", async () => {
@@ -772,6 +774,78 @@ describe("PostsTab — optimal-status chip (#364)", () => {
     await user.click(applyBtn);
 
     // After apply, modal closes and chip should flip to Optimal
+    await waitFor(() => {
+      expect(screen.getByText(/optimal/i)).toBeInTheDocument();
+    });
+  });
+
+  it("chip auto-refreshes after reserveMutation fires (invalidates post-suggestions-status)", async () => {
+    const user = userEvent.setup();
+
+    // Board: post building with an assigned member (non-reserve) so the
+    // "Mark RESERVE" button is enabled.
+    const position = makePosition({
+      id: 10,
+      member_id: 1,
+      member_name: "Aethon",
+      is_reserve: false,
+    });
+    const post = makePost();
+
+    // Track preview endpoint calls so we can assert the chip re-fetches.
+    let previewCallCount = 0;
+    setupHandlers(makePostBoard([position]), makeSiege(), [], [post]);
+    server.use(
+      http.post("/api/sieges/42/post-suggestions", () => {
+        previewCallCount++;
+        // First call: suggestions available (chip shows count).
+        // Subsequent calls (after invalidation): optimal.
+        if (previewCallCount === 1) {
+          return HttpResponse.json(
+            makePostPreviewResult({
+              assignments: [makeSuggestionAssignment(101)],
+            })
+          );
+        }
+        return HttpResponse.json(
+          makePostPreviewResult({
+            assignments: [makeOptimalAssignment(101)],
+          })
+        );
+      }),
+      // reserveMutation calls PUT /api/sieges/42/positions/10
+      http.put("/api/sieges/42/positions/10", () =>
+        HttpResponse.json({ ok: true })
+      ),
+      // Board re-fetch after invalidation returns unchanged board
+      http.get("/api/sieges/42/board", () =>
+        HttpResponse.json(makePostBoard([position]))
+      )
+    );
+
+    renderBoard();
+    await navigateToPostsTab(user);
+
+    // Chip initially shows suggestion count
+    await waitFor(() => {
+      expect(screen.getByText(/suggestion/i)).toBeInTheDocument();
+    });
+
+    // Expand Post 1 to reveal the "Mark RESERVE" button
+    await user.click(screen.getByRole("button", { name: /post 1/i }));
+
+    // Wait for the "Mark RESERVE" button to appear
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /mark reserve/i })
+      ).toBeInTheDocument();
+    });
+
+    // Fire reserveMutation
+    await user.click(screen.getByRole("button", { name: /mark reserve/i }));
+
+    // After the mutation succeeds the chip should re-fetch and flip to Optimal,
+    // proving ["post-suggestions-status"] was invalidated.
     await waitFor(() => {
       expect(screen.getByText(/optimal/i)).toBeInTheDocument();
     });


### PR DESCRIPTION
The optimal-status chip had three UX problems: it was a button competing with Suggest Assignments, it sat to the left of the Suggest button instead of beside it as a status indicator, and it didn't update when board mutations changed the underlying data. This PR fixes all three.

## Acceptance criteria (from #368)

- [x] Chip variants (`optimal`, `suggestions`, `errored`) converted from `<button>` to `<span>` — no `onClick`, no hover classes
- [x] `loading` variant was already a `<span>` — unchanged
- [x] `title` tooltip preserved on `errored` variant
- [x] Chip moves to the **right** of the Suggest Assignments button (JSX reordered inside `mb-3 flex items-center gap-2`)
- [x] `queryClient.invalidateQueries({ queryKey: ["post-suggestions-status"] })` added to all listed mutations:
  - `PostsTab.tsx` — `MemberAssignRow.mutation` (position assign)
  - `PostsTab.tsx` — `PostRow.reserveMutation` (mark reserve)
  - `BoardPage.tsx:134` — `PositionCell.mutation` (board cell assign/clear/reserve)
  - `BoardPage.tsx:756` — `applyMutation` (autofill apply)
  - `BoardPage.tsx:908` — drag-and-drop `onDragEnd` `.then()` (see note below)
  - `MemberDetailPage.tsx:145` — `deactivateMutation`
  - `MemberDetailPage.tsx:154` — `prefMutation`

## BoardPage.tsx:908 — what it was

Line 908 is inside the `onDragEnd` handler — a direct `updatePosition(...).then(...)` call (not a `useMutation` `onSuccess`). It's a drag-and-drop position assignment that already invalidated `["board", siegeId]`. Since it changes post assignments it was included in the invalidation list per the issue spec. The `invalidateQueries({ queryKey: ["post-suggestions-status"] })` call was added to the same `.then()` block.

## Tests

- Updated two chip tests that asserted `getByRole("button", { name: /optimal|suggestion/i })` — chip is now a non-interactive `<span>`, so those assertions were changed to use `.closest("span")` and check `className` for the color token.
- Added one new test: "chip auto-refreshes after reserveMutation fires" — expands Post 1, clicks "Mark RESERVE", and asserts the chip flips from `suggestions` to `Optimal` by verifying the preview endpoint is called a second time and the chip text updates. This is the minimal scenario that exercises the `["post-suggestions-status"]` invalidation path inside `PostsTab` without crossing into integration territory.

**Test count:** 185 before → 186 after (1 added, 0 removed).

Closes #368

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_