### PR TITLE
fix(tests): rate_limit caplog tests must work in CI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,13 @@ select = ["E", "F", "I", "UP"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Set log_level so pytest's catching_logs fixture explicitly initialises the
+# caplog handler and root logger to WARNING for every test.  Without this,
+# catching_logs receives level=None and skips the setLevel/setLevel calls,
+# which leaves the handler uninitialised on Python 3.12 + Linux (CI) in a
+# way that prevents caplog from capturing WARNING records from child loggers
+# (e.g. app.rate_limit) even when caplog.at_level() is used inside the test.
+log_level = "WARNING"
 
 [tool.coverage.run]
 source = ["app"]

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -391,10 +391,19 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            # No X-Forwarded-For header — simulates direct backend access.
-            await _get(client, LOGIN_URL)
+    # caplog.set_level is used instead of the caplog.at_level context manager
+    # because it persists for the entire test and is managed by pytest's fixture
+    # teardown, which works correctly across Python versions and operating systems.
+    # caplog.at_level() as a context manager can miss records emitted from
+    # thread-pool threads (via asyncio run_in_executor) on Python 3.12 / Linux
+    # due to handler-level initialisation differences in catching_logs when
+    # log_level is not set in pyproject.toml.  The log_level = "WARNING" entry
+    # in pyproject.toml (added alongside this fix) addresses the root cause;
+    # caplog.set_level here is belt-and-suspenders so the intent is explicit.
+    caplog.set_level(logging.WARNING, logger="app.rate_limit")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # No X-Forwarded-For header — simulates direct backend access.
+        await _get(client, LOGIN_URL)
 
     warning_records = [
         r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message
@@ -468,11 +477,14 @@ async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatc
         req = StarletteRequest(scope)
         _get_client_ip(req)
 
-    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
-        with ThreadPoolExecutor(max_workers=N) as pool:
-            futures = [pool.submit(_call_get_client_ip) for _ in range(N)]
-            for f in futures:
-                f.result()  # surface any exceptions
+    # caplog.set_level persists for the full test so the handler is guaranteed
+    # at WARNING before the thread pool is submitted.  See comment in
+    # test_missing_xff_in_production_logs_warning for the full rationale.
+    caplog.set_level(logging.WARNING, logger="app.rate_limit")
+    with ThreadPoolExecutor(max_workers=N) as pool:
+        futures = [pool.submit(_call_get_client_ip) for _ in range(N)]
+        for f in futures:
+            f.result()  # surface any exceptions
 
     absent_warnings = [
         r
@@ -504,13 +516,15 @@ async def test_invalid_xff_in_production_logs_warning(monkeypatch, caplog):
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            await _get(
-                client,
-                LOGIN_URL,
-                headers={"X-Forwarded-For": "not-a-valid-ip"},
-            )
+    # caplog.set_level persists for the full test.  See comment in
+    # test_missing_xff_in_production_logs_warning for the full rationale.
+    caplog.set_level(logging.WARNING, logger="app.rate_limit")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await _get(
+            client,
+            LOGIN_URL,
+            headers={"X-Forwarded-For": "not-a-valid-ip"},
+        )
 
     invalid_warnings = [
         r
@@ -568,14 +582,16 @@ async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, 
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    with caplog.at_level(logging.WARNING, logger="app.rate_limit"):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            for _ in range(5):
-                await _get(
-                    client,
-                    LOGIN_URL,
-                    headers={"X-Forwarded-For": "bad-ip-value"},
-                )
+    # caplog.set_level persists for the full test.  See comment in
+    # test_missing_xff_in_production_logs_warning for the full rationale.
+    caplog.set_level(logging.WARNING, logger="app.rate_limit")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for _ in range(5):
+            await _get(
+                client,
+                LOGIN_URL,
+                headers={"X-Forwarded-For": "bad-ip-value"},
+            )
 
     invalid_warnings = [
         r


### PR DESCRIPTION
## Root cause

pytest's `catching_logs` fixture receives `level=None` when no `log_level` is configured in `pyproject.toml`. With `level=None`, `catching_logs.__enter__` skips the explicit `handler.setLevel()` and `root_logger.setLevel()` calls, leaving the caplog handler uninitialised. On Python 3.12 / Linux (CI), this causes `caplog.at_level(WARNING, logger="app.rate_limit")` used inside an async test to fail to capture WARNING records emitted from thread-pool executor threads (the path slowapi uses to call the sync `key_func`). The same tests pass on Python 3.14 / Windows because of runtime differences in how the logging and asyncio thread pool layers interact when the handler is not explicitly pre-initialised.

## Fix

Two targeted changes, neither of which lowers any assertion threshold:

1. **`backend/pyproject.toml`** — add `log_level = "WARNING"` to `[tool.pytest.ini_options]`. This makes `catching_logs` explicitly call `handler.setLevel(WARNING)` and `root_logger.setLevel(min(..., WARNING))` for every test, ensuring the caplog infrastructure is fully initialised regardless of Python version or OS.

2. **`backend/tests/test_auth_rate_limit.py`** — replace `with caplog.at_level(WARNING, logger="app.rate_limit"):` context managers in the four failing tests with `caplog.set_level(WARNING, logger="app.rate_limit")` calls at the top of each test. `set_level` is managed by pytest's own fixture teardown and persists for the entire test, removing any dependency on context-manager scoping interacting with asyncio event loops or thread-pool executors. The two "development" tests that already pass are left unchanged.

The assertions are identical — they still enforce that exactly N WARNING records are emitted under the specified conditions. No production code was changed.

Closes #372

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_