### PR TITLE
fix(tests): bypass dotenv in env-required validation test

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -106,6 +106,7 @@ class TestEnvironmentRequired:
         monkeypatch.delenv("ENVIRONMENT", raising=False)
         with pytest.raises(ValidationError) as exc_info:
             Settings(
+                _env_file=None,  # bypass backend/.env on dev machines (issue #358)
                 database_url="postgresql+asyncpg://u:p@localhost/db",
                 discord_bot_api_url="http://bot:8001",
                 discord_bot_api_key="key",


### PR DESCRIPTION
## Problem

`test_missing_environment_raises_validation_error` passes in CI but fails on every developer machine that has a `backend/.env` file. The test calls `monkeypatch.delenv("ENVIRONMENT", raising=False)` to make the field appear unset, then expects a `ValidationError`. But `monkeypatch.delenv` only clears the **process environment** — pydantic-settings has a second env source, the `_env_file` dotfile loader, which is unaffected. When `backend/.env` is present (every dev has one), pydantic still reads `ENVIRONMENT=development` from the file, the validation path is never exercised, and the test silently passes CI while staying red on every local checkout.

## Fix

Pass `_env_file=None` to the `Settings(...)` constructor inside this one test. This disables dotenv loading for that single instance, making the test environment-agnostic — green in CI (no `.env`) and green on every developer machine (`.env` present but bypassed). The production `Settings()` call is unchanged.

The change is one line with an explanatory comment so a future maintainer knows why the parameter is there.

## Verification

- RED confirmed locally: `Failed: DID NOT RAISE <class 'pydantic_core._pydantic_core.ValidationError'>` with `backend/.env` present (pre-fix)
- GREEN confirmed locally: test passes after fix
- Full suite: **387 passed, 0 failed** (previously 386 passed + 1 failed — no regressions)
- `black --check app/ tests/`: clean
- `ruff check app/ tests/`: clean

Closes #358

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_