### PR TITLE
fix(posts): add group-by-Type toggle to siege Post Condition Assignments

### DIFF
--- a/frontend/src/pages/PostsPage.tsx
+++ b/frontend/src/pages/PostsPage.tsx
@@ -5,13 +5,19 @@ import { getPosts, setPostConditions } from "../api/posts";
 import { getPostConditions } from "../api/members";
 import { getSiege } from "../api/sieges";
 import { getBoard } from "../api/board";
-import type { Post, PostConditionRef, BuildingResponse } from "../api/types";
+import type { Post, BuildingResponse } from "../api/types";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { Checkbox } from "../components/ui/checkbox";
 import { Badge } from "../components/ui/badge";
 import { ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
+import { GroupByToggle } from "../components/GroupByToggle";
+import { groupPostConditions } from "../lib/groupPostConditions";
+import {
+  useGroupByPreference,
+  GROUP_BY_STORAGE_KEY,
+} from "../lib/useGroupByPreference";
 
 const PRIORITY_LABELS: Record<number, string> = {
   0: "Unset",
@@ -19,15 +25,6 @@ const PRIORITY_LABELS: Record<number, string> = {
   2: "Medium",
   3: "High",
 };
-
-function groupConditionsByLevel(conditions: PostConditionRef[]) {
-  const groups: Record<number, PostConditionRef[]> = {};
-  for (const c of conditions) {
-    if (!groups[c.stronghold_level]) groups[c.stronghold_level] = [];
-    groups[c.stronghold_level].push(c);
-  }
-  return groups;
-}
 
 function PostRow({
   post,
@@ -45,6 +42,7 @@ function PostRow({
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(initialExpanded);
   const [condFilter, setCondFilter] = useState("");
+  const [groupByMode, setGroupByMode] = useGroupByPreference(GROUP_BY_STORAGE_KEY);
   const [selectedConditions, setSelectedConditions] = useState<Set<number>>(
     new Set(post.active_conditions.map((c) => c.id))
   );
@@ -75,7 +73,7 @@ function PostRow({
     });
   }
 
-  const condGroups = allConditions ? groupConditionsByLevel(allConditions) : {};
+  const condGroups = groupPostConditions(allConditions ?? [], groupByMode);
 
   // Derive the assignment match state from the board data for this building.
   // Flatten all non-reserve, non-disabled positions and find the first assigned one.
@@ -169,27 +167,28 @@ function PostRow({
             <h4 className="mb-2 text-sm font-medium text-slate-700">
               Conditions (max 3)
             </h4>
-            <Input
-              placeholder="Filter conditions..."
-              value={condFilter}
-              onChange={(e) => setCondFilter(e.target.value)}
-              className="mb-3 h-8 text-sm"
-            />
-            {Object.entries(condGroups)
-              .sort(([a], [b]) => Number(a) - Number(b))
-              .map(([level, conds]) => {
+            <div className="mb-3 flex items-center gap-2">
+              <Input
+                placeholder="Filter conditions..."
+                value={condFilter}
+                onChange={(e) => setCondFilter(e.target.value)}
+                className="h-8 flex-1 text-sm"
+              />
+              <GroupByToggle value={groupByMode} onChange={setGroupByMode} />
+            </div>
+            {condGroups.map((group) => {
                 const filtered = condFilter
-                  ? conds.filter((c) =>
+                  ? group.items.filter((c) =>
                       c.description
                         .toLowerCase()
                         .includes(condFilter.toLowerCase())
                     )
-                  : conds;
+                  : group.items;
                 if (filtered.length === 0) return null;
                 return (
-                  <div key={level} className="mb-3">
+                  <div key={group.heading} className="mb-3">
                     <p className="mb-1 text-xs font-medium text-slate-500">
-                      Stronghold Level {level}
+                      {group.heading}
                     </p>
                     <div className="grid grid-cols-2 gap-1.5">
                       {filtered.map((c) => {

--- a/frontend/src/test/pages/PostsPage.groupBy.test.tsx
+++ b/frontend/src/test/pages/PostsPage.groupBy.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * PostsPage — Group-by toggle on the condition picker inside each PostRow.
+ *
+ * Acceptance criteria from issue #375:
+ *  1. Default mode shows Stronghold Level headings inside the expanded picker.
+ *  2. Clicking "Type" in the toggle shows type-bucket headings in spec order.
+ *  3. Clicking "Type" writes 'type' to localStorage under the shared key.
+ *  4. Mounting with stored value 'type' initialises the picker in type mode.
+ *
+ * Pattern mirrors GroupByConditions.test.tsx (Surfaces A & B) for consistency.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import PostsPage from "../../pages/PostsPage";
+import type { Post, PostCondition } from "../../api/types";
+
+// ─── Server lifecycle ──────────────────────────────────────────────────────────
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => {
+  server.resetHandlers();
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** Representative conditions spanning multiple levels and types. */
+const SAMPLE_CONDITIONS: PostCondition[] = [
+  // League L1
+  {
+    id: 1,
+    description: "Only Champions from the Telerian League can be used.",
+    stronghold_level: 1,
+  },
+  // Role L1
+  { id: 5, description: "Only HP Champions can be used.", stronghold_level: 1 },
+  // Faction L1
+  {
+    id: 9,
+    description: "Only Banner Lord Champions can be used.",
+    stronghold_level: 1,
+  },
+  // Affinity L2
+  {
+    id: 19,
+    description: "Only Void Champions can be used.",
+    stronghold_level: 2,
+  },
+  // Faction L2
+  {
+    id: 23,
+    description: "Only Demonspawn Champions can be used.",
+    stronghold_level: 2,
+  },
+  // Rarity L3
+  {
+    id: 29,
+    description: "Only Legendary Champions can be used.",
+    stronghold_level: 3,
+  },
+  // Effect L3
+  {
+    id: 35,
+    description: "All Champions are immune to [Sheep] debuffs.",
+    stronghold_level: 3,
+  },
+  // Other L3
+  { id: 36, description: "Champions cannot be revived.", stronghold_level: 3 },
+];
+
+const SIEGE_ID = 42;
+
+function makePost(overrides: Partial<Post> = {}): Post {
+  return {
+    id: 1,
+    siege_id: SIEGE_ID,
+    building_id: 10,
+    building_number: 1,
+    priority: 1,
+    description: null,
+    active_conditions: [],
+    ...overrides,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function setupHandlers(posts: Post[] = [makePost()]) {
+  server.use(
+    http.get(`/api/sieges/${SIEGE_ID}`, () =>
+      HttpResponse.json({
+        id: SIEGE_ID,
+        name: "Test Siege",
+        status: "draft",
+        attack_day: null,
+        created_at: "2024-01-01T00:00:00Z",
+        member_count: 0,
+      })
+    ),
+    http.get(`/api/sieges/${SIEGE_ID}/posts`, () => HttpResponse.json(posts)),
+    http.get(`/api/sieges/${SIEGE_ID}/board`, () =>
+      HttpResponse.json({ siege_id: SIEGE_ID, buildings: [] })
+    ),
+    http.get("/api/post-conditions", () =>
+      HttpResponse.json(SAMPLE_CONDITIONS)
+    )
+  );
+}
+
+function renderPostsPage() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/sieges/:id/posts" element={<PostsPage />} />
+    </Routes>,
+    { initialEntries: [`/sieges/${SIEGE_ID}/posts`] }
+  );
+}
+
+/** Expand the first PostRow so the condition picker becomes visible. */
+async function expandFirstPost(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() =>
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument()
+  );
+  // The chevron button is the expand toggle — click it
+  const expandBtn = screen.getByRole("button", { name: "" });
+  await user.click(expandBtn);
+  // Wait for conditions to load (the picker renders once allConditions arrives)
+  await waitFor(() =>
+    expect(screen.getByPlaceholderText(/filter conditions/i)).toBeInTheDocument()
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PostsPage — Group-by toggle in PostRow condition picker", () => {
+  beforeEach(() => setupHandlers());
+
+  it("default mode shows Stronghold Level headings inside the expanded picker", async () => {
+    const user = userEvent.setup();
+    renderPostsPage();
+    await expandFirstPost(user);
+
+    expect(screen.getByText(/stronghold level 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/stronghold level 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/stronghold level 3/i)).toBeInTheDocument();
+  });
+
+  it("clicking Type shows type-bucket headings in spec order", async () => {
+    const user = userEvent.setup();
+    renderPostsPage();
+    await expandFirstPost(user);
+
+    await user.click(screen.getByRole("radio", { name: "Type" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Role")).toBeInTheDocument();
+      expect(screen.getByText("Affinity")).toBeInTheDocument();
+      expect(screen.getByText("Faction")).toBeInTheDocument();
+      expect(screen.getByText("League")).toBeInTheDocument();
+      expect(screen.getByText("Rarity")).toBeInTheDocument();
+      expect(screen.getByText("Effect")).toBeInTheDocument();
+      expect(screen.getByText("Other")).toBeInTheDocument();
+    });
+    // Level headings must disappear
+    expect(screen.queryByText(/stronghold level/i)).not.toBeInTheDocument();
+  });
+
+  it("clicking Type writes 'type' to the shared localStorage key", async () => {
+    const user = userEvent.setup();
+    renderPostsPage();
+    await expandFirstPost(user);
+
+    await user.click(screen.getByRole("radio", { name: "Type" }));
+
+    expect(
+      localStorage.getItem("siege-web:postConditions:groupBy")
+    ).toBe("type");
+  });
+
+  it("initialises in type mode when localStorage already has 'type'", async () => {
+    localStorage.setItem("siege-web:postConditions:groupBy", "type");
+    const user = userEvent.setup();
+    renderPostsPage();
+    await expandFirstPost(user);
+
+    // Should show type headings immediately, no click required
+    await waitFor(() => {
+      expect(screen.getByText("Role")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/stronghold level/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Completes the #371 surface coverage: `PostsPage.tsx` was the one surface missed in that PR, still using a private `groupConditionsByLevel` helper instead of the shared `groupPostConditions` + `GroupByToggle` introduced in #371
- Removes the local `groupConditionsByLevel` function (line 23 pre-change) and migrates `PostRow` to `groupPostConditions` + `useGroupByPreference(GROUP_BY_STORAGE_KEY)` — each PostRow reads and writes the same `siege-web:postConditions:groupBy` localStorage key, so the preference stays in sync across all three surfaces (PostPrioritiesPage, MemberDetailPage, PostsPage) without prop drilling
- Adds 4 new tests in `frontend/src/test/pages/PostsPage.groupBy.test.tsx` covering: default level headings, toggling to Type shows type-bucket headings in spec order, localStorage write on toggle, and localStorage-initialised type mode on mount

## Test results

235/235 pass (231 baseline + 4 new). ESLint: 0 errors. Build: success.

Closes #375

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_