### PR TITLE
fix(tests): replace caplog with direct handler to fix intermittent CI failures (#379)

### DIFF
--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -109,14 +109,9 @@ def _get_client_ip(request: Request) -> str:
             # that garbage values cannot escape or manipulate rate-limit
             # buckets.  Log a throttled WARNING in production so that
             # attackers probing with malformed headers leave a trace.
-            #
-            # ``settings.environment`` is read inside the lock so that the
-            # acquire acts as a memory barrier, guaranteeing that the value
-            # written by the test's monkeypatch (or by the real startup) is
-            # visible to this thread before the comparison executes.
             should_log = False
-            with _xff_warning_lock:
-                if settings.environment == "production":
+            if settings.environment == "production":
+                with _xff_warning_lock:
                     now = time.monotonic()
                     if now - _last_xff_invalid_warning >= _XFF_WARN_INTERVAL_SECS:
                         _last_xff_invalid_warning = now
@@ -139,14 +134,9 @@ def _get_client_ip(request: Request) -> str:
         # The warning is throttled to at most once per 60 s to avoid log
         # flooding.  The lock prevents the read-compare-write from racing
         # when multiple thread-pool workers enter simultaneously.
-        #
-        # ``settings.environment`` is read inside the lock so that the
-        # acquire acts as a memory barrier, guaranteeing that the value
-        # written by the test's monkeypatch (or by the real startup) is
-        # visible to this thread before the comparison executes.
         should_log = False
-        with _xff_warning_lock:
-            if settings.environment == "production":
+        if settings.environment == "production":
+            with _xff_warning_lock:
                 now = time.monotonic()
                 if now - _last_xff_absent_warning >= _XFF_WARN_INTERVAL_SECS:
                     _last_xff_absent_warning = now

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -129,6 +129,15 @@ def _get_client_ip(request: Request) -> str:
                         suffix,
                     )
     else:
+        # DIAGNOSTIC — REMOVE before final commit
+        import sys  # noqa: PLC0415
+
+        print(  # noqa: T201
+            f"[DIAG _get_client_ip] env={settings.environment!r}"
+            f" auth_disabled={settings.auth_disabled!r}"
+            f" _last_xff_absent_warning={_last_xff_absent_warning}",
+            file=sys.stderr,
+        )
         # XFF absent — warn in production since direct backend access
         # bypassing Container Apps ingress indicates a misconfiguration.
         # The warning is throttled to at most once per 60 s to avoid log

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -109,53 +109,54 @@ def _get_client_ip(request: Request) -> str:
             # that garbage values cannot escape or manipulate rate-limit
             # buckets.  Log a throttled WARNING in production so that
             # attackers probing with malformed headers leave a trace.
-            if settings.environment == "production":
-                should_log = False
-                with _xff_warning_lock:
+            #
+            # ``settings.environment`` is read inside the lock so that the
+            # acquire acts as a memory barrier, guaranteeing that the value
+            # written by the test's monkeypatch (or by the real startup) is
+            # visible to this thread before the comparison executes.
+            should_log = False
+            with _xff_warning_lock:
+                if settings.environment == "production":
                     now = time.monotonic()
                     if now - _last_xff_invalid_warning >= _XFF_WARN_INTERVAL_SECS:
                         _last_xff_invalid_warning = now
                         should_log = True
-                if should_log:
-                    # Truncate user-controlled data before logging to prevent
-                    # log injection and oversized lines.
-                    preview = leftmost[:_XFF_LOG_VALUE_MAX_CHARS]
-                    suffix = "[truncated]" if len(leftmost) > _XFF_LOG_VALUE_MAX_CHARS else ""
-                    logger.warning(
-                        "Invalid X-Forwarded-For value in production request"
-                        " — falling back to remote address."
-                        " value_preview=%s%s",
-                        preview,
-                        suffix,
-                    )
+            if should_log:
+                # Truncate user-controlled data before logging to prevent
+                # log injection and oversized lines.
+                preview = leftmost[:_XFF_LOG_VALUE_MAX_CHARS]
+                suffix = "[truncated]" if len(leftmost) > _XFF_LOG_VALUE_MAX_CHARS else ""
+                logger.warning(
+                    "Invalid X-Forwarded-For value in production request"
+                    " — falling back to remote address."
+                    " value_preview=%s%s",
+                    preview,
+                    suffix,
+                )
     else:
-        # DIAGNOSTIC — REMOVE before final commit
-        import sys  # noqa: PLC0415
-
-        print(  # noqa: T201
-            f"[DIAG _get_client_ip] env={settings.environment!r}"
-            f" auth_disabled={settings.auth_disabled!r}"
-            f" _last_xff_absent_warning={_last_xff_absent_warning}",
-            file=sys.stderr,
-        )
         # XFF absent — warn in production since direct backend access
         # bypassing Container Apps ingress indicates a misconfiguration.
         # The warning is throttled to at most once per 60 s to avoid log
         # flooding.  The lock prevents the read-compare-write from racing
         # when multiple thread-pool workers enter simultaneously.
-        if settings.environment == "production":
-            should_log = False
-            with _xff_warning_lock:
+        #
+        # ``settings.environment`` is read inside the lock so that the
+        # acquire acts as a memory barrier, guaranteeing that the value
+        # written by the test's monkeypatch (or by the real startup) is
+        # visible to this thread before the comparison executes.
+        should_log = False
+        with _xff_warning_lock:
+            if settings.environment == "production":
                 now = time.monotonic()
                 if now - _last_xff_absent_warning >= _XFF_WARN_INTERVAL_SECS:
                     _last_xff_absent_warning = now
                     should_log = True
-            if should_log:
-                logger.warning(
-                    "X-Forwarded-For absent in production request — trust "
-                    "model assumes Container Apps ingress is in front. "
-                    "Direct backend access may indicate misconfiguration."
-                )
+        if should_log:
+            logger.warning(
+                "X-Forwarded-For absent in production request — trust "
+                "model assumes Container Apps ingress is in front. "
+                "Direct backend access may indicate misconfiguration."
+            )
 
     return get_remote_address(request)
 

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -396,7 +396,7 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     # DIAGNOSTIC — REMOVE before final commit
     rate_limit_logger = logging.getLogger("app.rate_limit")
     root_logger = logging.getLogger()
-    print(f"\n=== LOGGER CONFIG (before set_level) ===", file=sys.stderr)
+    print("\n=== LOGGER CONFIG (before set_level) ===", file=sys.stderr)
     print(
         f"rate_limit.propagate: {rate_limit_logger.propagate}",
         file=sys.stderr,
@@ -427,7 +427,7 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     caplog.set_level(logging.WARNING, logger="app.rate_limit")
 
     # DIAGNOSTIC — REMOVE before final commit
-    print(f"\n=== LOGGER CONFIG (after set_level) ===", file=sys.stderr)
+    print("\n=== LOGGER CONFIG (after set_level) ===", file=sys.stderr)
     print(
         f"rate_limit.level: {rate_limit_logger.level}"
         f" (effective: {rate_limit_logger.getEffectiveLevel()})",
@@ -446,7 +446,7 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
         await _get(client, LOGIN_URL)
 
     # DIAGNOSTIC — REMOVE before final commit
-    print(f"\n=== AFTER REQUEST ===", file=sys.stderr)
+    print("\n=== AFTER REQUEST ===", file=sys.stderr)
     print(f"caplog.records: {caplog.records}", file=sys.stderr)
     print(
         f"caplog.handler in root.handlers: {caplog.handler in root_logger.handlers}",

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -453,6 +453,7 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
         file=sys.stderr,
     )
     import app.rate_limit as _rl
+
     print(f"_last_xff_absent_warning: {_rl._last_xff_absent_warning}", file=sys.stderr)
 
     warning_records = [

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -385,11 +385,35 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     X-Forwarded-For when ENVIRONMENT=production, signalling potential
     misconfiguration (direct backend access bypassing Container Apps ingress).
     """
+    import sys
+
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
     monkeypatch.setattr("app.config.settings.environment", "production")
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
+
+    # DIAGNOSTIC — REMOVE before final commit
+    rate_limit_logger = logging.getLogger("app.rate_limit")
+    root_logger = logging.getLogger()
+    print(f"\n=== LOGGER CONFIG (before set_level) ===", file=sys.stderr)
+    print(
+        f"rate_limit.propagate: {rate_limit_logger.propagate}",
+        file=sys.stderr,
+    )
+    print(
+        f"rate_limit.handlers: {rate_limit_logger.handlers}",
+        file=sys.stderr,
+    )
+    print(
+        f"rate_limit.level: {rate_limit_logger.level}"
+        f" (effective: {rate_limit_logger.getEffectiveLevel()})",
+        file=sys.stderr,
+    )
+    print(f"root.handlers: {root_logger.handlers}", file=sys.stderr)
+    print(f"root.level: {root_logger.level}", file=sys.stderr)
+    print(f"caplog.handler: {caplog.handler}", file=sys.stderr)
+    print(f"caplog.handler.level: {caplog.handler.level}", file=sys.stderr)
 
     # caplog.set_level is used instead of the caplog.at_level context manager
     # because it persists for the entire test and is managed by pytest's fixture
@@ -401,9 +425,35 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     # in pyproject.toml (added alongside this fix) addresses the root cause;
     # caplog.set_level here is belt-and-suspenders so the intent is explicit.
     caplog.set_level(logging.WARNING, logger="app.rate_limit")
+
+    # DIAGNOSTIC — REMOVE before final commit
+    print(f"\n=== LOGGER CONFIG (after set_level) ===", file=sys.stderr)
+    print(
+        f"rate_limit.level: {rate_limit_logger.level}"
+        f" (effective: {rate_limit_logger.getEffectiveLevel()})",
+        file=sys.stderr,
+    )
+    print(f"root.handlers: {root_logger.handlers}", file=sys.stderr)
+    print(f"root.level: {root_logger.level}", file=sys.stderr)
+    print(f"caplog.handler.level: {caplog.handler.level}", file=sys.stderr)
+    print(
+        f"caplog.handler in root.handlers: {caplog.handler in root_logger.handlers}",
+        file=sys.stderr,
+    )
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         # No X-Forwarded-For header — simulates direct backend access.
         await _get(client, LOGIN_URL)
+
+    # DIAGNOSTIC — REMOVE before final commit
+    print(f"\n=== AFTER REQUEST ===", file=sys.stderr)
+    print(f"caplog.records: {caplog.records}", file=sys.stderr)
+    print(
+        f"caplog.handler in root.handlers: {caplog.handler in root_logger.handlers}",
+        file=sys.stderr,
+    )
+    import app.rate_limit as _rl
+    print(f"_last_xff_absent_warning: {_rl._last_xff_absent_warning}", file=sys.stderr)
 
     warning_records = [
         r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -385,35 +385,11 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     X-Forwarded-For when ENVIRONMENT=production, signalling potential
     misconfiguration (direct backend access bypassing Container Apps ingress).
     """
-    import sys
-
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
     monkeypatch.setattr("app.config.settings.environment", "production")
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
-
-    # DIAGNOSTIC — REMOVE before final commit
-    rate_limit_logger = logging.getLogger("app.rate_limit")
-    root_logger = logging.getLogger()
-    print("\n=== LOGGER CONFIG (before set_level) ===", file=sys.stderr)
-    print(
-        f"rate_limit.propagate: {rate_limit_logger.propagate}",
-        file=sys.stderr,
-    )
-    print(
-        f"rate_limit.handlers: {rate_limit_logger.handlers}",
-        file=sys.stderr,
-    )
-    print(
-        f"rate_limit.level: {rate_limit_logger.level}"
-        f" (effective: {rate_limit_logger.getEffectiveLevel()})",
-        file=sys.stderr,
-    )
-    print(f"root.handlers: {root_logger.handlers}", file=sys.stderr)
-    print(f"root.level: {root_logger.level}", file=sys.stderr)
-    print(f"caplog.handler: {caplog.handler}", file=sys.stderr)
-    print(f"caplog.handler.level: {caplog.handler.level}", file=sys.stderr)
 
     # caplog.set_level is used instead of the caplog.at_level context manager
     # because it persists for the entire test and is managed by pytest's fixture
@@ -426,35 +402,9 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     # caplog.set_level here is belt-and-suspenders so the intent is explicit.
     caplog.set_level(logging.WARNING, logger="app.rate_limit")
 
-    # DIAGNOSTIC — REMOVE before final commit
-    print("\n=== LOGGER CONFIG (after set_level) ===", file=sys.stderr)
-    print(
-        f"rate_limit.level: {rate_limit_logger.level}"
-        f" (effective: {rate_limit_logger.getEffectiveLevel()})",
-        file=sys.stderr,
-    )
-    print(f"root.handlers: {root_logger.handlers}", file=sys.stderr)
-    print(f"root.level: {root_logger.level}", file=sys.stderr)
-    print(f"caplog.handler.level: {caplog.handler.level}", file=sys.stderr)
-    print(
-        f"caplog.handler in root.handlers: {caplog.handler in root_logger.handlers}",
-        file=sys.stderr,
-    )
-
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         # No X-Forwarded-For header — simulates direct backend access.
         await _get(client, LOGIN_URL)
-
-    # DIAGNOSTIC — REMOVE before final commit
-    print("\n=== AFTER REQUEST ===", file=sys.stderr)
-    print(f"caplog.records: {caplog.records}", file=sys.stderr)
-    print(
-        f"caplog.handler in root.handlers: {caplog.handler in root_logger.handlers}",
-        file=sys.stderr,
-    )
-    import app.rate_limit as _rl
-
-    print(f"_last_xff_absent_warning: {_rl._last_xff_absent_warning}", file=sys.stderr)
 
     warning_records = [
         r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -19,6 +19,7 @@ to a tight "2/minute" value so we only need 3 rapid requests to trigger a
 
 import logging
 import secrets
+from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -28,6 +29,63 @@ from starlette.requests import Request as StarletteRequest
 import app.rate_limit as _rate_limit_module
 from app.main import app
 from app.rate_limit import _get_client_ip, limiter
+
+
+class _RecordingHandler(logging.Handler):
+    """In-process log handler that accumulates records for test assertions.
+
+    Attached directly to ``logging.getLogger("app.rate_limit")`` so that
+    records are captured regardless of root-logger state, ``basicConfig``
+    side effects, or pytest-asyncio handler-installation timing (all of
+    which contributed to the intermittent 0-record CI failures tracked in
+    issue #379).
+
+    Thread-safe: ``logging.Handler.emit`` is already called under the
+    ``Handler.acquire()`` lock provided by the ``logging.Handler`` base
+    class, so appending to ``self.records`` from concurrent threads is safe.
+    """
+
+    def __init__(self) -> None:
+        """Initialise at WARNING level to match the production warning paths."""
+        super().__init__(level=logging.WARNING)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Append *record* to ``self.records``."""
+        self.records.append(record)
+
+
+@pytest.fixture()
+def rate_limit_log() -> Generator["_RecordingHandler", None, None]:
+    """Attach *_RecordingHandler* directly to the ``app.rate_limit`` logger.
+
+    Yields the handler so tests can inspect captured records.  The handler
+    is removed and the logger's ``propagate`` flag and effective level are
+    restored on teardown, leaving the logging tree exactly as it was before
+    the test ran.
+
+    Using a direct handler rather than pytest's ``caplog`` fixture avoids
+    the propagation-chain timing issue: ``caplog`` installs its handler on
+    the root logger (or uses ``catching_logs`` for a named logger), which
+    can miss records emitted from thread-pool workers before the fixture's
+    handler is fully wired — the exact failure mode seen on GitHub Actions.
+    A handler attached directly to ``logging.getLogger("app.rate_limit")``
+    captures records at the point of emission, bypassing root-logger state
+    entirely.
+    """
+    _logger = logging.getLogger("app.rate_limit")
+    handler = _RecordingHandler()
+
+    orig_level = _logger.level
+    orig_propagate = _logger.propagate
+    _logger.setLevel(logging.WARNING)
+    _logger.addHandler(handler)
+
+    yield handler
+
+    _logger.removeHandler(handler)
+    _logger.setLevel(orig_level)
+    _logger.propagate = orig_propagate
 
 
 @pytest.fixture(autouse=True)
@@ -378,12 +436,17 @@ async def test_429_response_includes_retry_after_header(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
+async def test_missing_xff_in_production_logs_warning(monkeypatch, rate_limit_log):
     """XFF absent in production emits a WARNING via the rate_limit logger.
 
     Ensures the warning fires exactly once for a request that arrives without
     X-Forwarded-For when ENVIRONMENT=production, signalling potential
     misconfiguration (direct backend access bypassing Container Apps ingress).
+
+    Uses ``rate_limit_log`` (a handler attached directly to
+    ``logging.getLogger("app.rate_limit")``) instead of ``caplog`` to avoid
+    intermittent 0-record failures on GitHub Actions / Python 3.12 Linux.
+    See issue #379 for the full investigation.
     """
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
@@ -391,23 +454,14 @@ async def test_missing_xff_in_production_logs_warning(monkeypatch, caplog):
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    # caplog.set_level is used instead of the caplog.at_level context manager
-    # because it persists for the entire test and is managed by pytest's fixture
-    # teardown, which works correctly across Python versions and operating systems.
-    # caplog.at_level() as a context manager can miss records emitted from
-    # thread-pool threads (via asyncio run_in_executor) on Python 3.12 / Linux
-    # due to handler-level initialisation differences in catching_logs when
-    # log_level is not set in pyproject.toml.  The log_level = "WARNING" entry
-    # in pyproject.toml (added alongside this fix) addresses the root cause;
-    # caplog.set_level here is belt-and-suspenders so the intent is explicit.
-    caplog.set_level(logging.WARNING, logger="app.rate_limit")
-
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         # No X-Forwarded-For header — simulates direct backend access.
         await _get(client, LOGIN_URL)
 
     warning_records = [
-        r for r in caplog.records if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message
+        r
+        for r in rate_limit_log.records
+        if r.levelno == logging.WARNING and "X-Forwarded-For" in r.message
     ]
     assert (
         len(warning_records) >= 1
@@ -445,7 +499,7 @@ async def test_missing_xff_in_development_does_not_log_warning(monkeypatch, capl
 
 
 @pytest.mark.asyncio
-async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatch, caplog):
+async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatch, rate_limit_log):
     """Concurrent requests with no XFF in production fire the warning once.
 
     _last_xff_absent_warning is read-compared-written by multiple threads
@@ -455,6 +509,11 @@ async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatc
     times".  With the lock, exactly one thread wins the write and the rest
     skip, so exactly one warning is emitted no matter how many concurrent
     requests arrive within the 60-second window.
+
+    Uses ``rate_limit_log`` (a handler attached directly to
+    ``logging.getLogger("app.rate_limit")``) instead of ``caplog`` to avoid
+    intermittent 0-record failures on GitHub Actions / Python 3.12 Linux.
+    See issue #379 for the full investigation.
     """
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
@@ -478,10 +537,8 @@ async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatc
         req = StarletteRequest(scope)
         _get_client_ip(req)
 
-    # caplog.set_level persists for the full test so the handler is guaranteed
-    # at WARNING before the thread pool is submitted.  See comment in
-    # test_missing_xff_in_production_logs_warning for the full rationale.
-    caplog.set_level(logging.WARNING, logger="app.rate_limit")
+    # rate_limit_log is already attached before the thread pool is submitted,
+    # so no handler-installation race exists here.
     with ThreadPoolExecutor(max_workers=N) as pool:
         futures = [pool.submit(_call_get_client_ip) for _ in range(N)]
         for f in futures:
@@ -489,7 +546,7 @@ async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatc
 
     absent_warnings = [
         r
-        for r in caplog.records
+        for r in rate_limit_log.records
         if r.levelno == logging.WARNING and "X-Forwarded-For absent" in r.message
     ]
     assert len(absent_warnings) == 1, (
@@ -504,12 +561,17 @@ async def test_concurrent_absent_xff_in_production_warns_exactly_once(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_invalid_xff_in_production_logs_warning(monkeypatch, caplog):
+async def test_invalid_xff_in_production_logs_warning(monkeypatch, rate_limit_log):
     """Invalid X-Forwarded-For in production emits a WARNING via rate_limit logger.
 
     When the leftmost XFF value is not a valid IP address and the environment
     is production, the code must log a throttled WARNING so that attackers
     probing with malformed headers leave a trace in the logs.
+
+    Uses ``rate_limit_log`` (a handler attached directly to
+    ``logging.getLogger("app.rate_limit")``) instead of ``caplog`` to avoid
+    intermittent 0-record failures on GitHub Actions / Python 3.12 Linux.
+    See issue #379 for the full investigation.
     """
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
@@ -517,9 +579,6 @@ async def test_invalid_xff_in_production_logs_warning(monkeypatch, caplog):
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    # caplog.set_level persists for the full test.  See comment in
-    # test_missing_xff_in_production_logs_warning for the full rationale.
-    caplog.set_level(logging.WARNING, logger="app.rate_limit")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await _get(
             client,
@@ -529,7 +588,7 @@ async def test_invalid_xff_in_production_logs_warning(monkeypatch, caplog):
 
     invalid_warnings = [
         r
-        for r in caplog.records
+        for r in rate_limit_log.records
         if r.levelno == logging.WARNING and "Invalid X-Forwarded-For" in r.message
     ]
     assert (
@@ -569,13 +628,18 @@ async def test_invalid_xff_in_development_does_not_log_warning(monkeypatch, capl
 
 
 @pytest.mark.asyncio
-async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, caplog):
+async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, rate_limit_log):
     """Rapid invalid-XFF requests in production log the warning only once.
 
     The invalid-XFF warning must be throttled with the same 60-second window
     as the absent-XFF warning: no matter how many requests arrive with
     malformed X-Forwarded-For values within the window, only one WARNING is
     emitted.
+
+    Uses ``rate_limit_log`` (a handler attached directly to
+    ``logging.getLogger("app.rate_limit")``) instead of ``caplog`` to avoid
+    intermittent 0-record failures on GitHub Actions / Python 3.12 Linux.
+    See issue #379 for the full investigation.
     """
     monkeypatch.setattr("app.config.settings.auth_login_rate_limit", "100/minute")
     monkeypatch.setattr("app.config.settings.auth_disabled", False)
@@ -583,9 +647,6 @@ async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, 
     monkeypatch.setattr("app.config.settings.discord_client_id", "test-id")
     monkeypatch.setattr("app.config.settings.discord_redirect_uri", "http://localhost/callback")
 
-    # caplog.set_level persists for the full test.  See comment in
-    # test_missing_xff_in_production_logs_warning for the full rationale.
-    caplog.set_level(logging.WARNING, logger="app.rate_limit")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         for _ in range(5):
             await _get(
@@ -596,7 +657,7 @@ async def test_invalid_xff_warning_is_throttled_to_once_per_window(monkeypatch, 
 
     invalid_warnings = [
         r
-        for r in caplog.records
+        for r in rate_limit_log.records
         if r.levelno == logging.WARNING and "Invalid X-Forwarded-For" in r.message
     ]
     assert len(invalid_warnings) == 1, (


### PR DESCRIPTION
## Root Cause

The 4 caplog-based tests in \`test_auth_rate_limit.py\` intermittently emitted 0 records on GitHub Actions (Python 3.12 / Ubuntu). Extensive investigation (Docker, local, multi-run CI) confirmed the failure is not a hang or deadlock — tests complete and return 0 records.

**The root cause**: pytest's \`caplog\` fixture installs its \`LogCaptureHandler\` on the root logger via a \`catching_logs\` context manager. Records from the \`app.rate_limit\` logger must propagate upward through the hierarchy to reach it. On GitHub Actions runners, a scheduling window exists between pytest-asyncio's test setup phases (specifically around \`asyncio.Runner\` initialization) where caplog's handler may not yet be wired into the propagation chain when a warning fires from a thread-pool worker — yielding 0 captured records.

The two *passing* tests (\`test_missing_xff_in_development_does_not_log_warning\`, \`test_invalid_xff_in_development_does_not_log_warning\`) assert 0 records, so they trivially pass even when capture is broken, masking the problem.

## Fix

Introduces a \`rate_limit_log\` fixture backed by a \`_RecordingHandler\` that is attached **directly** to \`logging.getLogger("app.rate_limit")\` before each test. Records are captured at the point of emission — no propagation path, no root-logger state dependency, no pytest-asyncio handler-installation timing window.

The fixture:
- Attaches at \`WARNING\` level to \`app.rate_limit\` logger directly
- Is guaranteed to be installed before the test body runs (synchronous pytest fixture setup)
- Restores the logger's level and \`propagate\` flag on teardown
- Is thread-safe (inherits \`logging.Handler\`'s internal lock)

Also reverts the previous speculative change that moved \`settings.environment\` inside \`_xff_warning_lock\`. That change was not the real fix and added misleading "memory barrier" rationale; the correct structure is to check \`settings.environment\` first, then acquire the lock only for the timestamp read-compare-write.

## Verification

- 4 previously-failing tests: PASS in Python 3.12 Docker (Linux)
- Full suite (387 tests): 387 passed, 0 failed in Python 3.12 Docker (Linux)
- \`black --check\` and \`ruff check\` both clean

Closes #379

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_