### PR TITLE
chore(role-sync): document DAY_ROLE_SYNC_ENABLED + DAY_ROLE_SYNC_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,8 @@ IMPORT_EXCEL_PATH=C:/path/to/siege/excel/files
 
 # Azure Application Insights (optional; telemetry SDK is a no-op when unset)
 # APPLICATIONINSIGHTS_CONNECTION_STRING=
+
+# Day-role sync webhook (see docs/webhooks/day-role-sync.md §9 for the full contract).
+# Kill switch — keep false until a conforming receiver is deployed and smoke-tested.
+DAY_ROLE_SYNC_ENABLED=false
+DAY_ROLE_SYNC_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ Copy `.env.example` to `.env`. Required:
 | `ALLOWED_ORIGINS` | backend (comma-separated CORS allowlist; required for non-localhost deployments) |
 | `VITE_PUBLIC_URL` | frontend (canonical URL used in `<link rel="canonical">` and `og:url` meta tags) |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | backend, bot (optional; telemetry no-op when unset) |
+| `DAY_ROLE_SYNC_ENABLED` | backend (kill switch for day-role sync webhook; default `false` — set `true` only after a conforming receiver is deployed) |
+| `DAY_ROLE_SYNC_URL` | backend (receiver endpoint URL for day-role sync webhook; required when feature is enabled) |
 
 ## Domain Reference
 


### PR DESCRIPTION
## Summary

Closes #402

Adds the two env vars introduced in PR #409 to `.env.example` and the project `CLAUDE.md` Environment Variables table so operators can see the feature flag and receiver URL alongside other configuration. Closes out the docs gap left by #402's trimmed scope.

## Changes

- **`.env.example`** — new section near the existing backend/bot integration vars:

  ```
  # Day-role sync webhook (see docs/webhooks/day-role-sync.md §9 for the full contract).
  # Kill switch — keep false until a conforming receiver is deployed and smoke-tested.
  DAY_ROLE_SYNC_ENABLED=false
  DAY_ROLE_SYNC_URL=
  ```

- **`CLAUDE.md`** — two new rows appended to the Environment Variables table:

  | `DAY_ROLE_SYNC_ENABLED` | backend (kill switch for day-role sync webhook; default `false` — set `true` only after a conforming receiver is deployed) |
  | `DAY_ROLE_SYNC_URL` | backend (receiver endpoint URL for day-role sync webhook; required when feature is enabled) |

## Why

PR #409 added the underlying settings in `backend/app/config.py` but didn't surface them to operators. Without the `.env.example` entry, an operator setting up a fresh deployment has no signal that the kill switch exists; without the `CLAUDE.md` row, the canonical env-var reference is incomplete.

## Test plan

- [x] Diff is config + markdown only — zero Python, zero JS. No CI tests cover these files.
- [x] `.env.example` reflects current `backend/app/config.py` settings.
- [x] `CLAUDE.md` row voice matches surrounding rows (terse, parenthetical, behavior-anchored).

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_