### PR TITLE
fix(bot): translate discord.py exceptions to HTTPException (closes #419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Bot HTTP sidecar (`bot/app/http_api.py`) now translates discord.py exceptions
+  to structured HTTP error responses via FastAPI global exception handlers:
+  `discord.Forbidden` → 403, `discord.NotFound` → 404,
+  `discord.HTTPException` (4xx) → 502, `discord.HTTPException` (5xx) /
+  `asyncio.TimeoutError` → 503.  Previously these surfaced as unhandled 500s.
+  (#419)
+
 ## [1.2.0] - 2026-05-11
 
 ### Added

--- a/bot/app/http_api.py
+++ b/bot/app/http_api.py
@@ -1,9 +1,37 @@
+"""HTTP API sidecar for the Siege Bot.
+
+Exposes internal endpoints consumed by the backend service to send Discord
+DMs, post channel messages, and post images.  Authentication is via a shared
+Bearer token (BOT_API_KEY).
+
+Discord exception translation
+------------------------------
+Any discord.py exception that escapes a route handler is caught by the
+global exception handlers registered below.  The mapping is:
+
+  discord.Forbidden (403 from Discord)          → HTTP 403
+  discord.NotFound  (404 from Discord)          → HTTP 404
+  discord.HTTPException with status < 500       → HTTP 502 (upstream error)
+  discord.HTTPException with status >= 500      → HTTP 503 (unavailable)
+  asyncio.TimeoutError                          → HTTP 503 (unavailable)
+
+``discord.Forbidden`` and ``discord.NotFound`` are subclasses of
+``discord.HTTPException``, so they are registered with separate, more-specific
+handlers and FastAPI resolves them in MRO order.
+
+Note: per-endpoint ``ValueError → 404`` handling is retained in each route
+handler rather than promoted to a global handler, because ``ValueError`` is a
+broad built-in that could mask programming errors if caught globally.
+"""
+
+import asyncio
 import os
 import secrets
 from pathlib import Path
 
 import discord
-from fastapi import Depends, FastAPI, Form, HTTPException, UploadFile, status
+from fastapi import Depends, FastAPI, Form, HTTPException, Request, UploadFile, status
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
@@ -13,6 +41,103 @@ from app.discord_client import SiegeBot
 _VERSION_FILE = Path(__file__).parent.parent / "VERSION"
 
 app = FastAPI(title="Siege Bot HTTP API", version="0.1.0")
+
+
+# ---------------------------------------------------------------------------
+# Discord exception → HTTP translation (global handlers)
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(discord.Forbidden)
+async def _handle_discord_forbidden(request: Request, exc: discord.Forbidden) -> JSONResponse:
+    """Translate discord.Forbidden to HTTP 403.
+
+    Raised when the bot lacks channel permissions or a user's DMs are
+    closed.
+
+    Args:
+        request: The incoming FastAPI request (unused, required by signature).
+        exc: The discord.Forbidden exception instance.
+
+    Returns:
+        JSONResponse with status 403 and a detail message.
+    """
+    return JSONResponse(
+        status_code=status.HTTP_403_FORBIDDEN,
+        content={"detail": f"Discord permission denied: {exc.text}"},
+    )
+
+
+@app.exception_handler(discord.NotFound)
+async def _handle_discord_not_found(request: Request, exc: discord.NotFound) -> JSONResponse:
+    """Translate discord.NotFound to HTTP 404.
+
+    Raised when the target channel, message, or user does not exist.
+    Shares the 404 response shape with the existing ValueError path.
+
+    Args:
+        request: The incoming FastAPI request (unused, required by signature).
+        exc: The discord.NotFound exception instance.
+
+    Returns:
+        JSONResponse with status 404 and a fixed detail message.
+    """
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND,
+        content={"detail": "Discord resource not found"},
+    )
+
+
+@app.exception_handler(discord.HTTPException)
+async def _handle_discord_http_exception(
+    request: Request, exc: discord.HTTPException
+) -> JSONResponse:
+    """Translate discord.HTTPException to 502 or 503.
+
+    discord.Forbidden and discord.NotFound are subclasses of this class;
+    they are handled by their own more-specific handlers above and will
+    NOT reach this handler.
+
+    Status mapping:
+      - exc.status < 500  → 502 Bad Gateway (upstream Discord 4xx)
+      - exc.status >= 500 → 503 Service Unavailable (upstream Discord 5xx)
+
+    Args:
+        request: The incoming FastAPI request (unused, required by signature).
+        exc: The discord.HTTPException instance.
+
+    Returns:
+        JSONResponse with status 502 or 503.
+    """
+    if exc.status < 500:
+        return JSONResponse(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            content={"detail": f"Upstream Discord error: {exc.status}"},
+        )
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"detail": "Discord temporarily unavailable"},
+    )
+
+
+@app.exception_handler(asyncio.TimeoutError)
+async def _handle_timeout(request: Request, exc: asyncio.TimeoutError) -> JSONResponse:
+    """Translate asyncio.TimeoutError to HTTP 503.
+
+    Raised when a Discord API call exceeds its configured timeout.
+
+    Args:
+        request: The incoming FastAPI request (unused, required by signature).
+        exc: The asyncio.TimeoutError instance.
+
+    Returns:
+        JSONResponse with status 503.
+    """
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"detail": "Discord temporarily unavailable"},
+    )
+
 
 _bearer_scheme = HTTPBearer()
 

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -26,21 +26,38 @@ if "discord" not in sys.modules:
     class _FakeTextChannel:
         pass
 
-    # discord.NotFound and discord.HTTPException must be real exception classes
-    # so that ``except discord.NotFound`` and ``except discord.HTTPException``
-    # clauses in http_api.py work correctly during tests.
+    # discord.NotFound, discord.Forbidden, and discord.HTTPException must be
+    # real exception classes so that ``except discord.NotFound`` /
+    # ``except discord.Forbidden`` / ``except discord.HTTPException`` clauses
+    # in http_api.py work correctly during tests, AND so that FastAPI's
+    # ``@app.exception_handler(discord.Forbidden)`` decorator passes
+    # Starlette's ``issubclass(exc_class, Exception)`` assertion at
+    # module-import time.
+    #
+    # The constructors accept ``(response, text)`` to mirror the real discord.py
+    # API; the exception handler reads ``exc.status`` (from response.status) and
+    # ``exc.text`` so both must be preserved on the instance.
     class _FakeHTTPException(Exception):
-        pass
+        def __init__(self, response=None, text=""):
+            self.response = response
+            self.status = getattr(response, "status", 0)
+            self.text = text
+            super().__init__(text)
 
     class _FakeNotFound(_FakeHTTPException):
+        pass
+
+    class _FakeForbidden(_FakeHTTPException):
         pass
 
     discord_mock.Client = _FakeClient
     discord_mock.TextChannel = _FakeTextChannel
     discord_mock.HTTPException = _FakeHTTPException
     discord_mock.NotFound = _FakeNotFound
+    discord_mock.Forbidden = _FakeForbidden
     discord_mock.Intents = MagicMock()
     discord_mock.File = MagicMock()
+
     # Provide a real find() so SiegeBot methods work with mock guilds
     def _find(predicate, iterable):
         for item in iterable:

--- a/bot/tests/test_http_api.py
+++ b/bot/tests/test_http_api.py
@@ -1,9 +1,11 @@
 """Tests for the bot HTTP API endpoints."""
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -329,3 +331,148 @@ async def test_get_members_bot_not_ready_returns_503(client):
     async with client as c:
         response = await c.get("/api/members", headers=AUTH_HEADER)
     assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Discord exception translation — global handler (#419)
+# ---------------------------------------------------------------------------
+#
+# Each block below covers one row of the translation table.  We vary the
+# endpoint under test so the suite demonstrates the handler fires globally
+# (not just for one call site).
+#
+# discord.Forbidden and discord.NotFound are subclasses of
+# discord.HTTPException, so they must be caught before the generic
+# HTTPException branch.
+#
+# Helper: build a minimal discord.HTTPException-like object.  The real
+# constructors require a aiohttp.ClientResponse, so we mock the .status
+# attribute directly.
+# ---------------------------------------------------------------------------
+
+
+def _discord_http_exc(status: int, text: str = "") -> discord.HTTPException:
+    """Return a discord.HTTPException instance with a given HTTP status.
+
+    Constructs via MagicMock to avoid requiring a live aiohttp response.
+    The .status attribute is the one inspected by the exception handler.
+
+    Args:
+        status: Integer HTTP status code to attach to the exception.
+        text: Optional response body text (maps to exc.text in discord.py).
+
+    Returns:
+        A discord.HTTPException (or subclass) instance with .status set.
+    """
+    response = MagicMock()
+    response.status = status
+    response.reason = "test"
+    exc = discord.HTTPException(response, text)
+    return exc
+
+
+# -- discord.Forbidden → 403 -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_discord_forbidden_returns_403(client):
+    """discord.Forbidden from send_dm must translate to HTTP 403."""
+    bot = _make_mock_bot()
+    response = MagicMock()
+    response.status = 403
+    response.reason = "Forbidden"
+    bot.send_dm.side_effect = discord.Forbidden(response, "Missing Permissions")
+    http_api_module._bot = bot
+    async with client as c:
+        resp = await c.post(
+            "/api/notify",
+            json={"username": "alice", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert resp.status_code == 403
+    assert "permission denied" in resp.json()["detail"].lower()
+
+
+# -- discord.NotFound → 404 --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_message_discord_not_found_returns_404(client):
+    """discord.NotFound from post_message must translate to HTTP 404."""
+    bot = _make_mock_bot()
+    response = MagicMock()
+    response.status = 404
+    response.reason = "Not Found"
+    bot.post_message.side_effect = discord.NotFound(response, "Unknown Channel")
+    http_api_module._bot = bot
+    async with client as c:
+        resp = await c.post(
+            "/api/post-message",
+            json={"channel_name": "no-such-channel", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+# -- discord.HTTPException (status < 500) → 502 ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_image_discord_http_4xx_returns_502(client):
+    """discord.HTTPException with status 429 (rate limit) must translate to 502."""
+    bot = _make_mock_bot()
+    bot.post_image.side_effect = _discord_http_exc(429, "You are being rate limited")
+    http_api_module._bot = bot
+    async with client as c:
+        resp = await c.post(
+            "/api/post-image",
+            data={"channel_name": "siege-images"},
+            files={"file": ("board.png", b"fake-png", "image/png")},
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert resp.status_code == 502
+    assert "429" in resp.json()["detail"]
+
+
+# -- discord.HTTPException (status >= 500) → 503 -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_discord_http_5xx_returns_503(client):
+    """discord.HTTPException with status 500 must translate to HTTP 503."""
+    bot = _make_mock_bot()
+    bot.send_dm.side_effect = _discord_http_exc(500, "Internal Server Error")
+    http_api_module._bot = bot
+    async with client as c:
+        resp = await c.post(
+            "/api/notify",
+            json={"username": "alice", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert resp.status_code == 503
+    assert "unavailable" in resp.json()["detail"].lower()
+
+
+# -- asyncio.TimeoutError → 503 ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_message_timeout_returns_503(client):
+    """asyncio.TimeoutError from post_message must translate to HTTP 503."""
+    bot = _make_mock_bot()
+    bot.post_message.side_effect = asyncio.TimeoutError()
+    http_api_module._bot = bot
+    async with client as c:
+        resp = await c.post(
+            "/api/post-message",
+            json={"channel_name": "general", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert resp.status_code == 503
+    assert "unavailable" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary

Fixes #419. The bot's HTTP sidecar (`bot/app/http_api.py`) was previously letting `discord.Forbidden`, `discord.NotFound`, `discord.HTTPException`, and `asyncio.TimeoutError` raised from the discord.py send/post path surface as uncaught FastAPI 500s. The backend (which swallows `httpx.HTTPError`) could not distinguish "Discord said no" from "the sidecar is on fire," and the bundled bot was therefore unable to honor an operationally meaningful contract.

This PR adds **four FastAPI global exception handlers** that translate those exceptions to the status codes specified in #419:

| Exception                                              | HTTP status | Body                                                      |
| ------------------------------------------------------ | ----------- | --------------------------------------------------------- |
| `discord.Forbidden`                                    | 403         | `{"detail": "Discord permission denied: <reason>"}`       |
| `discord.NotFound`                                     | 404         | `{"detail": "Discord resource not found"}`                |
| `discord.HTTPException` (status < 500)                 | 502         | `{"detail": "Upstream Discord error: <status>"}`          |
| `discord.HTTPException` (status >= 500) / `asyncio.TimeoutError` | 503 | `{"detail": "Discord temporarily unavailable"}`           |

The existing `ValueError → 404` per-endpoint paths (for "channel/username not in cache") are preserved.

Refs #347 (Step 2-prerequisite — should land before Step 3 integration tests so the tests can assert on the corrected status codes).

## Sequencing note

Acceptance criterion in #419 calls for an INTERFACE.md update in the same PR. That file currently lives only on the `347-step2-interface-md` branch (open as #420, not yet merged). Updating it on this branch would create a phantom file that disappears on rebase. Tightening INTERFACE.md to reflect the new 403/502/503 contract is tracked as a follow-up commit/PR after #420 merges.

## Test plan

- [x] `bot/tests/test_http_api.py` — 5 new tests cover each translation row (mock discord.py client to raise each exception type)
- [x] `pytest bot/` — 23 passed, 0 failed
- [x] `pytest backend/` (excluding test_schema.py) — 415 passed, 0 failed
- [x] `black --check backend/` clean
- [x] `ruff check backend/` clean
- [ ] CI green on this PR

## Out of scope (deferred)

- **`bot/INTERFACE.md` tightening** — follow-up after #420 merges.
- **`backend/app/services/bot_client.py` error discrimination** — the swallowing `httpx.HTTPError` catch in 5 methods could distinguish 4xx (configuration error → ERROR log) from 5xx (transient → already retried). Kept as a deliberate follow-up to avoid widening this PR.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_