### PR TITLE
docs(infra): useExternalSidecar polish — bicepparam + README + safe-nav (closes #434)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ az deployment group create \
 
 Via the **Infra Deploy** workflow (`workflow_dispatch`): set the `useExternalSidecar` input to `true` and ensure `externalBotApiUrl` is set in the relevant `.bicepparam` file before triggering.
 
+**Dev exemption:** When `ENVIRONMENT=dev`, the HTTPS-enforcement Bicep assert is bypassed so `externalBotApiUrl` may use `http://localhost:<port>` for local-stack iteration. Production deployments enforce `https://` unconditionally.
+
 ## Run it yourself
 
 Full self-host guides live in the [project wiki](https://github.com/glitchwerks/rsl-siege-manager/wiki):

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -31,6 +31,7 @@ param postgresGeoRedundantBackup = false
 // Set true only when substituting an alternate Discord sidecar and also supply
 // externalBotApiUrl pointing at its HTTP API.
 param useExternalSidecar = false
+// param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
 
 // ── ACR image retention ───────────────────────────────────────────────────────
 // Release tags (v*) are never purged. SHA/commit tags beyond the keep count

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -125,6 +125,7 @@ param alertEmail = 'cmb_dev@outlook.com'
 // Set true only when substituting an alternate Discord sidecar and also supply
 // externalBotApiUrl pointing at its HTTP API.
 param useExternalSidecar = false
+// param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
 
 // ── ACR image retention ───────────────────────────────────────────────────────
 // Dev currently has ~364 manifests (127/126/111 across api/bot/frontend).

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -153,6 +153,7 @@ param alertEmail = 'cmb_dev@outlook.com'
 // Set true only when substituting an alternate Discord sidecar and also supply
 // externalBotApiUrl pointing at its HTTP API.
 param useExternalSidecar = false
+// param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
 
 // ── ACR image retention ───────────────────────────────────────────────────────
 // Prod currently has ~155 manifests (51/52/52 across api/bot/frontend).

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -512,9 +512,7 @@ output apiAppPrincipalId string = apiApp.identity.principalId
 output frontendAppName string = frontendApp.name
 output frontendAppFqdn string = frontendApp.properties.configuration.ingress.fqdn
 output frontendAppPrincipalId string = frontendApp.identity.principalId
-// When useExternalSidecar = true the bot resource is not provisioned; safe-
-// navigation (?.) returns null for the absent resource, and ?? '' coerces to
-// an empty string so callers can detect the conditional case gracefully.
+// Safe-nav (`?.`) returns null if botApp isn't created (useExternalSidecar=true); `?? ''` falls back to an empty string so downstream consumers don't get null.
 output botAppName string = botApp.?name ?? ''
 output botAppPrincipalId string = botApp.?identity.?principalId ?? ''
 output useExternalSidecar bool = useExternalSidecar


### PR DESCRIPTION
Closes #434. Part of #429 (umbrella).

Three small polish items from PR #427's review — pure config/doc additions, no behavior change.

## What's in this PR

1. **Commented `externalBotApiUrl` example in all three `.bicepparam` files** (`infra/main.bicepparam`, `infra/main.dev.bicepparam`, `infra/main.prod.bicepparam`). Operators flipping `useExternalSidecar=true` no longer have to invent the second parameter from scratch:

   ```bicep
   param useExternalSidecar = false
   // param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
   ```

2. **README dev-https-exemption note** in the Deployment Modes section. The dev-only `http://localhost` exemption was previously discoverable only by reading the Bicep assert in `infra/main.bicep`.

3. **Safe-nav comment in `infra/modules/container-apps.bicep`**, near the outputs block. Tightened the existing 3-line comment to a single line explaining the `.?identity.?principalId ?? ''` pattern (same semantic content; more compact).

## Test plan

- [x] `az bicep build --file infra/main.bicep` → exit 0 (one pre-existing warning on `vault.azure.net`, not introduced here)
- [x] README diff renders correctly (no broken lists / headings)
- [ ] CI green (Infra Validate + lint jobs)

## Out of scope (tracked separately)

#435 covers the heavier follow-ups from #429 — workflow validation-step dedupe into a composite action + the validation unit test.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*