### PR TITLE
infra: extract external-sidecar validation into composite action + add unit test (closes #435)

### DIFF
--- a/.github/actions/validate-external-sidecar/action.yml
+++ b/.github/actions/validate-external-sidecar/action.yml
@@ -1,0 +1,28 @@
+name: Validate External Sidecar Configuration
+description: >
+  Validates that externalBotApiUrl is set and starts with https:// in the
+  given Bicep parameter file. No-ops when use-external-sidecar is 'false'.
+  Emits ::error:: messages on failure so GitHub Actions surfaces them in the
+  run UI. Wraps scripts/validate-external-sidecar.sh — see that file for the
+  validation logic. Refs: issue #435, parent #429.
+
+inputs:
+  param-file:
+    description: 'Path to the Bicep parameter file to validate (e.g. infra/main.dev.bicepparam)'
+    required: true
+  use-external-sidecar:
+    description: 'Set to "true" to run validation; any other value short-circuits with a log line.'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Validate external sidecar configuration
+      shell: bash
+      run: |
+        if [[ "${{ inputs.use-external-sidecar }}" != "true" ]]; then
+          echo "useExternalSidecar=false; skipping external sidecar validation"
+          exit 0
+        fi
+        "${{ github.workspace }}/scripts/validate-external-sidecar.sh" "${{ inputs.param-file }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,26 @@ jobs:
         run: pytest tests/integration/sidecar/ -v
 
 
+  validation-script-tests:
+    name: Validation Script Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: pip install pytest>=8.3
+
+      - name: Run validation script tests
+        run: pytest scripts/tests/ -v
+
+
   claude-lint-fix:
     name: Claude Lint Fix
     needs: [backend-ci, frontend-ci, bot-ci]

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -92,26 +92,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate external sidecar configuration
-        if: inputs.useExternalSidecar == true
-        run: |
-          PARAM_FILE="infra/main.dev.bicepparam"
-          # Extract the externalBotApiUrl value, stripping leading/trailing
-          # whitespace and surrounding quotes (single or double — Bicep only
-          # accepts single, but the validator is lenient by design so a typo
-          # produces a clear error rather than a regex miss).
-          PARAM_VALUE=$(grep -E "^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=" "$PARAM_FILE" \
-            | sed -E "s/^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=[[:space:]]*['\"]?([^'\"[:space:]]*)['\"]?[[:space:]]*$/\1/" \
-            || true)
-          if [ -z "$PARAM_VALUE" ]; then
-            echo "::error::useExternalSidecar=true but externalBotApiUrl is not set in $PARAM_FILE"
-            echo "::error::Add: param externalBotApiUrl = 'https://your-sidecar.example.com'"
-            exit 1
-          fi
-          if ! [[ "$PARAM_VALUE" =~ ^https:// ]]; then
-            echo "::error::externalBotApiUrl in $PARAM_FILE must start with https:// (got: $PARAM_VALUE)"
-            echo "::error::Bearer-token traffic must not flow over plaintext http"
-            exit 1
-          fi
+        uses: ./.github/actions/validate-external-sidecar
+        with:
+          param-file: infra/main.dev.bicepparam
+          use-external-sidecar: ${{ inputs.useExternalSidecar }}
 
       - name: Log in to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
@@ -170,23 +154,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate external sidecar configuration
-        if: inputs.useExternalSidecar == true
-        run: |
-          PARAM_FILE="infra/main.prod.bicepparam"
-          # Same extract-and-validate as deploy-dev (see comment there).
-          PARAM_VALUE=$(grep -E "^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=" "$PARAM_FILE" \
-            | sed -E "s/^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=[[:space:]]*['\"]?([^'\"[:space:]]*)['\"]?[[:space:]]*$/\1/" \
-            || true)
-          if [ -z "$PARAM_VALUE" ]; then
-            echo "::error::useExternalSidecar=true but externalBotApiUrl is not set in $PARAM_FILE"
-            echo "::error::Add: param externalBotApiUrl = 'https://your-sidecar.example.com'"
-            exit 1
-          fi
-          if ! [[ "$PARAM_VALUE" =~ ^https:// ]]; then
-            echo "::error::externalBotApiUrl in $PARAM_FILE must start with https:// (got: $PARAM_VALUE)"
-            echo "::error::Bearer-token traffic must not flow over plaintext http"
-            exit 1
-          fi
+        uses: ./.github/actions/validate-external-sidecar
+        with:
+          param-file: infra/main.prod.bicepparam
+          use-external-sidecar: ${{ inputs.useExternalSidecar }}
 
       - name: Log in to Azure
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3

--- a/scripts/tests/test_validate_external_sidecar.py
+++ b/scripts/tests/test_validate_external_sidecar.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/validate-external-sidecar.sh.
+
+Covers the four validation cases the script is responsible for (the
+use-external-sidecar=false short-circuit lives in the composite action wrapper,
+not the script, so it is not tested here):
+
+  1. Valid https:// URL → exit 0
+  2. Plain http:// URL → exit 1, error mentions "must start with https://"
+  3. externalBotApiUrl line missing entirely → exit 1, error mentions "not set"
+  4. Malformed scheme (https:/typo) → exit 1, error mentions "must start with https://"
+  5. Empty quoted string → exit 1, error mentions "not set"
+
+These tests are a regression catch for #435 / #427: two review iterations
+almost let inadvertent regex tweaks through silently because the duplicated
+inline steps had no automated coverage.
+
+Usage:
+    pytest scripts/tests/ -v
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Resolve the script path relative to the repo root (two levels up from this file:
+# scripts/tests/ → scripts/ → repo root).
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "validate-external-sidecar.sh"
+
+# Locate bash. On Linux/macOS CI it's always on PATH. On Windows it lives in
+# Git Bash; fall back to the canonical Git for Windows path if shutil.which
+# returns the WSL relay (which cannot run scripts without a WSL distro).
+_BASH_CANDIDATES = [
+    shutil.which("bash"),
+    r"C:\Program Files\Git\usr\bin\bash.exe",
+    r"C:\Git\usr\bin\bash.exe",
+]
+_BASH = next(
+    (
+        b
+        for b in _BASH_CANDIDATES
+        if b and Path(b).exists() and "WindowsApps" not in b and "System32" not in b
+    ),
+    None,
+)
+
+if _BASH is None:
+    pytest.skip("bash not available — skipping script tests", allow_module_level=True)
+
+
+def run_script(param_file: Path) -> subprocess.CompletedProcess:
+    """Invoke the validation script against *param_file* and return the result."""
+    return subprocess.run(
+        [_BASH, str(SCRIPT), str(param_file)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_param_file(tmp_path: Path, content: str) -> Path:
+    """Write a minimal .bicepparam file with *content* and return its path."""
+    p = tmp_path / "main.test.bicepparam"
+    p.write_text(content)
+    return p
+
+
+# ── Case 1: valid https:// URL ────────────────────────────────────────────────
+
+
+def test_valid_https_url_passes(tmp_path):
+    """A correctly set https:// externalBotApiUrl exits 0 (validation passes)."""
+    param_file = write_param_file(
+        tmp_path,
+        "param externalBotApiUrl = 'https://x.example.com'\n",
+    )
+    result = run_script(param_file)
+    assert result.returncode == 0, (
+        f"Expected exit 0 for valid https URL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ── Case 2: plain http:// URL ─────────────────────────────────────────────────
+
+
+def test_http_url_fails_with_https_message(tmp_path):
+    """A plain http:// URL exits 1 and the error mentions 'must start with https://'."""
+    param_file = write_param_file(
+        tmp_path,
+        "param externalBotApiUrl = 'http://insecure.example.com'\n",
+    )
+    result = run_script(param_file)
+    assert result.returncode == 1, (
+        f"Expected exit 1 for http:// URL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "must start with https://" in combined, (
+        f"Expected 'must start with https://' in output.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ── Case 3: externalBotApiUrl line missing ────────────────────────────────────
+
+
+def test_missing_param_line_fails_with_not_set_message(tmp_path):
+    """A param file without externalBotApiUrl exits 1 and mentions 'not set'."""
+    param_file = write_param_file(
+        tmp_path,
+        "param environment = 'dev'\nparam appPrefix = 'siege-web'\n",
+    )
+    result = run_script(param_file)
+    assert result.returncode == 1, (
+        f"Expected exit 1 for missing externalBotApiUrl.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "not set" in combined, (
+        f"Expected 'not set' in output.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ── Case 4: malformed scheme (https:/typo) ────────────────────────────────────
+
+
+def test_malformed_scheme_fails_with_https_message(tmp_path):
+    """A URL with a single-slash typo (https:/typo) exits 1 and mentions 'must start with https://'."""
+    param_file = write_param_file(
+        tmp_path,
+        "param externalBotApiUrl = 'https:/typo'\n",
+    )
+    result = run_script(param_file)
+    assert result.returncode == 1, (
+        f"Expected exit 1 for malformed https:/typo URL.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "must start with https://" in combined, (
+        f"Expected 'must start with https://' in output.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ── Case 5: empty quoted string ───────────────────────────────────────────────
+
+
+def test_empty_quoted_string_fails_with_not_set_message(tmp_path):
+    """An empty quoted externalBotApiUrl exits 1 and mentions 'not set'."""
+    param_file = write_param_file(
+        tmp_path,
+        "param externalBotApiUrl = ''\n",
+    )
+    result = run_script(param_file)
+    assert result.returncode == 1, (
+        f"Expected exit 1 for empty quoted string.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "not set" in combined, (
+        f"Expected 'not set' in output.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/scripts/validate-external-sidecar.sh
+++ b/scripts/validate-external-sidecar.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# validate-external-sidecar.sh — validate externalBotApiUrl in a Bicep param file
+#
+# Usage:
+#   validate-external-sidecar.sh <param-file>
+#
+# Exits 0 when externalBotApiUrl is present and starts with https://.
+# Exits 1 when absent, empty, or not https://.
+# Emits ::error:: prefixed messages on failure so GitHub Actions surfaces them
+# in the run UI.
+#
+# This script is the single source of truth for the validation logic that was
+# previously duplicated across deploy-dev and deploy-prod in infra-deploy.yml.
+# It is invoked by .github/actions/validate-external-sidecar/action.yml.
+# See: issue #435, parent #429.
+
+set -euo pipefail
+
+PARAM_FILE="${1:?Usage: validate-external-sidecar.sh <param-file>}"
+
+# Extract the externalBotApiUrl value, stripping leading/trailing
+# whitespace and surrounding quotes (single or double — Bicep only
+# accepts single, but the validator is lenient by design so a typo
+# produces a clear error rather than a regex miss).
+PARAM_VALUE=$(grep -E "^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=" "$PARAM_FILE" \
+  | sed -E "s/^[[:space:]]*param[[:space:]]+externalBotApiUrl[[:space:]]*=[[:space:]]*['\"]?([^'\"[:space:]]*)['\"]?[[:space:]]*$/\1/" \
+  || true)
+
+if [ -z "$PARAM_VALUE" ]; then
+  echo "::error::useExternalSidecar=true but externalBotApiUrl is not set in $PARAM_FILE"
+  echo "::error::Add: param externalBotApiUrl = 'https://your-sidecar.example.com'"
+  exit 1
+fi
+
+if ! [[ "$PARAM_VALUE" =~ ^https:// ]]; then
+  echo "::error::externalBotApiUrl in $PARAM_FILE must start with https:// (got: $PARAM_VALUE)"
+  echo "::error::Bearer-token traffic must not flow over plaintext http"
+  exit 1
+fi


### PR DESCRIPTION
Closes #435. Part of #429 (umbrella). Pairs with already-merged #436 (#434 polish).

## Why

The "Validate external sidecar configuration" step was byte-identical in `deploy-dev` and `deploy-prod` (~15 lines each). PR #427's review iterated on this regex twice (`071993b` introduced strict grep, `0f2e7f4` replaced with extract-then-validate); the next tweak would be one PR away from silent divergence between the two copies. No automated test enforced behavior.

## What

Three new artifacts + two workflow updates:

### Script: `scripts/validate-external-sidecar.sh` (39 lines)

The validation logic, extracted verbatim. Same regex, same `::error::` strings, same exit semantics (0 pass / 1 fail). Single argv: the param-file path. `set -euo pipefail` + `#!/usr/bin/env bash`. Single source of truth for both CI and tests.

### Composite action: `.github/actions/validate-external-sidecar/action.yml` (28 lines)

Thin wrapper around the script. Two inputs:

| Input | Required | Behavior |
|---|---|---|
| `param-file` | yes | Path passed to the script |
| `use-external-sidecar` | no, default `'false'` | If `'true'`, runs validation; otherwise logs "skipping" and exits 0 |

This absorbs the `if: inputs.useExternalSidecar == true` gating from the workflow so both jobs are now one `uses:` block.

### Test: `scripts/tests/test_validate_external_sidecar.py` (158 lines)

Five subprocess-based pytest cases (5/5 passing locally):

1. Valid `https://...` → exit 0
2. `http://...` → exit 1, stderr contains "must start with https://"
3. `externalBotApiUrl` line missing → exit 1, stderr contains "not set"
4. `https:/typo` (malformed scheme) → exit 1, stderr contains "must start with https://"
5. Empty quoted string (`= ''`) → exit 1, stderr contains "not set"

Includes a Git Bash path-resolution preamble so the suite runs locally on Windows + in Linux CI unchanged.

### Workflow updates

| File | Change |
|---|---|
| `.github/workflows/infra-deploy.yml` | Both validate steps replaced with `uses: ./.github/actions/validate-external-sidecar`. `actions/checkout` ordering preserved (the composite action depends on the checked-out script). |
| `.github/workflows/ci.yml` | New `Validation Script Tests` job — separate from `Backend Lint & Test` (no project deps); installs pytest, runs `pytest scripts/tests/ -v`. |

## Why a separate CI job

Folding into `Backend Lint & Test` would couple unrelated test surfaces — exactly the kind of cross-contamination #387's flaky-test cleanup explicitly avoided. Separate job = clear failure boundary, no shared venv state.

## Verification

| Check | Result |
|---|---|
| `pytest scripts/tests/ -v` | 5/5 passed |
| Script direct invocation on `infra/main.dev.bicepparam` | Exit 1, `::error::useExternalSidecar=true but externalBotApiUrl is not set` (correct — `externalBotApiUrl` is commented out in that file, which is the expected state) |
| Diff inspection | Both validate-step replacements are isolated edits; env gates, secrets plumbing, `actions/checkout` ordering all preserved byte-for-byte |
| CI | _pending_ |

## Deviation from brief

Used `pip install pytest>=8.3` (matching the existing floor in `backend/requirements-dev.txt`) rather than the brief's suggested hard-pin `pytest==8.3.4`. Consistent with the repo's other unpinned tool jobs. If a tighter pin is preferred, single-line change.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*