### PR TITLE
docs(bot): add quick-start checklist to INTERFACE.md

### DIFF
--- a/bot/INTERFACE.md
+++ b/bot/INTERFACE.md
@@ -15,6 +15,49 @@ broader context live in
 
 ---
 
+## Quick start: implementing a sidecar bot
+
+A navigation checklist for anyone building an alternative sidecar (e.g. mom-bot or
+an integration-test stub). Each item links to the normative section that elaborates.
+
+- **Implement Bearer auth** — validate the shared `BOT_API_KEY` on every protected
+  endpoint. Two distinct failure modes are required: 401 when the `Authorization`
+  header is present with a wrong token, 403 when the header is absent entirely.
+  See [§ Authentication](#authentication).
+
+- **Implement the 7 sidecar endpoints** — `GET /api/version`, `GET /api/health`,
+  `POST /api/notify`, `POST /api/post-message`, `POST /api/post-image`,
+  `GET /api/members`, and `GET /api/members/{discord_user_id}` — with the exact
+  request and response shapes documented. See [§ Endpoint reference](#endpoint-reference).
+
+- **Match the `id` vs `discord_id` field naming** — `GET /api/members` returns `id`
+  for the Discord snowflake; `GET /api/members/{discord_user_id}` returns `discord_id`.
+  This distinction is load-bearing and not arbitrary; renaming either field breaks
+  existing consumers. See the [rationale note in § Endpoint reference](#get-apimembers).
+
+- **Honour the singleton Discord-token constraint** — the bundled bot and any
+  alternate sidecar sharing the same Discord token cannot coexist. Operators must
+  exclude the bundled bot when deploying an alternate sidecar.
+  See [§ Discord coupling](#discord-coupling).
+
+- **Translate Discord errors to HTTP status codes** — `discord.Forbidden` → 403,
+  Discord 4xx → 502, Discord 5xx or timeout → 503. Correct translation is required
+  for `BotClient` error-handling paths to behave as designed.
+  See [§ Error semantics](#error-semantics).
+
+- **Verify against the integration test suite** — `backend/tests/integration/sidecar/`
+  is the executable contract. When this document and the tests disagree, the tests win.
+
+- _(Optional)_ **Implement the 2 backend preference endpoint callers** —
+  `GET /api/members/me/preferences` and `PUT /api/members/me/preferences` live on the
+  backend, not the sidecar. If the sidecar exposes member-preference UI, implement the
+  callers; otherwise sidecar conformance does not require them.
+  See [§ Endpoint reference — preferences](#get-apimembersmepreferences-and-put-apimembersmepreferences).
+
+_For everything else (versioning, conformance table, glossary), see the full doc below._
+
+---
+
 ## Process model
 
 `SiegeBot` (discord.py client) and the FastAPI HTTP sidecar run concurrently in the


### PR DESCRIPTION
## Summary

- Adds a 1-page **Quick start: implementing a sidecar bot** section near the top of `bot/INTERFACE.md`. A 7-item checklist (Bearer auth + failure modes, seven endpoints, the `id` vs `discord_id` distinction, singleton Discord-token constraint, error semantics, integration test suite as executable contract, optional backend preference-endpoint callers) — every item links down to the normative section that elaborates.
- Lowers the entry bar for sidecar implementers (mom-bot consumer-guide agent, future operator-supplied sidecars) without weakening the 851-line normative spec.

## What was NOT changed

- **"seven endpoints" prose fix from the AC was a no-op.** That wording does not appear anywhere in `bot/INTERFACE.md` — verified via grep on this branch. The phrase exists only in `docs/superpowers/plans/2026-05-10-bot-seam-hardening.md` (3 occurrences), where it is tied to historical "Step 2 will deliver the seven endpoints" framing. Per the issue AC ("if the line will read awkwardly after the plan's work is fully merged, fine to leave the plan alone and only fix INTERFACE.md"), the plan file is intentionally untouched.
- Endpoint reference section itself — already correct, only added the nav-aid section above it.
- No code, no API surface, no contract change.

## Test plan

- [x] `bot/INTERFACE.md` renders cleanly on GitHub (this PR's "Files changed" tab is the easiest preview).
- [ ] Quick-start anchor links resolve to the right normative sections — verify by clicking each one in the rendered diff.
- [ ] No broken cross-references introduced.

Closes #444

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_