### PR TITLE
feat(backend): expose post-condition category taxonomy via API (closes #442)

### DIFF
--- a/backend/alembic/versions/0012_add_condition_type_to_post_condition.py
+++ b/backend/alembic/versions/0012_add_condition_type_to_post_condition.py
@@ -1,0 +1,120 @@
+"""Add condition_type column to post_condition table.
+
+Adds a NOT NULL VARCHAR column with a CHECK constraint restricting values
+to the seven canonical condition categories:
+  role | affinity | faction | league | rarity | effect | other
+
+Backfills existing rows from the id→type map that is the canonical source
+of truth in frontend/src/lib/postConditionTypes.ts.
+
+Revision ID: 0012
+Revises: 0011_add_post_suggest_preview
+Create Date: 2026-05-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+# Canonical id→condition_type map lifted verbatim from
+# frontend/src/lib/postConditionTypes.ts (POST_CONDITION_TYPE_BY_ID).
+# Any change to the map requires a coordinated frontend + migration update.
+_CONDITION_TYPE_MAP: dict[int, str] = {
+    # League (4)
+    1: "league",
+    2: "league",
+    3: "league",
+    4: "league",
+    # Role (4)
+    5: "role",
+    6: "role",
+    7: "role",
+    8: "role",
+    # Faction L1 (8)
+    9: "faction",
+    10: "faction",
+    11: "faction",
+    12: "faction",
+    13: "faction",
+    14: "faction",
+    15: "faction",
+    16: "faction",
+    # Effect L1 (2)
+    17: "effect",
+    18: "effect",
+    # Affinity (4)
+    19: "affinity",
+    20: "affinity",
+    21: "affinity",
+    22: "affinity",
+    # Faction L2 (4)
+    23: "faction",
+    24: "faction",
+    25: "faction",
+    26: "faction",
+    # Effect L2 (2)
+    27: "effect",
+    28: "effect",
+    # Rarity (3)
+    29: "rarity",
+    30: "rarity",
+    31: "rarity",
+    # Faction L3 (3)
+    32: "faction",
+    33: "faction",
+    34: "faction",
+    # Effect L3 (1)
+    35: "effect",
+    # Other (1)
+    36: "other",
+}
+
+
+def upgrade() -> None:
+    """Add condition_type column, backfill from canonical map, enforce NOT NULL."""
+    # Step 1: Add column as nullable so existing rows don't immediately violate
+    # NOT NULL. The CHECK constraint is added after the backfill.
+    op.add_column(
+        "post_condition",
+        sa.Column("condition_type", sa.String(), nullable=True),
+    )
+
+    # Step 2: Backfill each row from the canonical id→type map.
+    connection = op.get_bind()
+    for id_, condition_type in _CONDITION_TYPE_MAP.items():
+        connection.execute(
+            sa.text(
+                "UPDATE post_condition SET condition_type = :ct WHERE id = :id"
+            ),
+            {"ct": condition_type, "id": id_},
+        )
+
+    # Step 3: Enforce NOT NULL now that all rows are populated.
+    op.alter_column(
+        "post_condition",
+        "condition_type",
+        nullable=False,
+    )
+
+    # Step 4: Add the CHECK constraint.
+    op.create_check_constraint(
+        "condition_type_valid",
+        "post_condition",
+        "condition_type IN ('role','affinity','faction','league','rarity','effect','other')",
+    )
+
+
+def downgrade() -> None:
+    """Drop condition_type column and its CHECK constraint."""
+    op.drop_constraint(
+        "condition_type_valid",
+        "post_condition",
+        type_="check",
+    )
+    op.drop_column("post_condition", "condition_type")

--- a/backend/app/db/seeds.py
+++ b/backend/app/db/seeds.py
@@ -5,57 +5,68 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def seed_post_conditions(session: AsyncSession) -> None:
-    """Insert all 36 PostCondition rows. Safe to re-run (ON CONFLICT DO NOTHING)."""
+    """Insert all 36 PostCondition rows. Safe to re-run (ON CONFLICT DO NOTHING).
+
+    Each tuple is (id, description, stronghold_level, condition_type).
+    The condition_type values mirror the canonical frontend map in
+    ``frontend/src/lib/postConditionTypes.ts``.
+    """
     rows = [
         # Level 1 (18 conditions)
-        (1, "Only Champions from the Telerian League can be used.", 1),
-        (2, "Only Champions from the Gaellen Pact can be used.", 1),
-        (3, "Only Champions from The Corrupted can be used.", 1),
-        (4, "Only Champions from the Nyresan Union can be used.", 1),
-        (5, "Only HP Champions can be used.", 1),
-        (6, "Only DEF Champions can be used.", 1),
-        (7, "Only Support Champions can be used.", 1),
-        (8, "Only ATK Champions can be used.", 1),
-        (9, "Only Banner Lord Champions can be used.", 1),
-        (10, "Only High Elves Champions can be used.", 1),
-        (11, "Only Sacred Order Champions can be used.", 1),
-        (12, "Only Barbarian Champions can be used.", 1),
-        (13, "Only Ogryn Tribe Champions can be used.", 1),
-        (14, "Only Lizardmen Champions can be used.", 1),
-        (15, "Only Skinwalker Champions can be used.", 1),
-        (16, "Only Orc Champions can be used.", 1),
-        (17, "All Champions are immune to Turn Meter reduction effects.", 1),
-        (18, "All Champions are immune to Turn Meter fill effects.", 1),
+        (1, "Only Champions from the Telerian League can be used.", 1, "league"),
+        (2, "Only Champions from the Gaellen Pact can be used.", 1, "league"),
+        (3, "Only Champions from The Corrupted can be used.", 1, "league"),
+        (4, "Only Champions from the Nyresan Union can be used.", 1, "league"),
+        (5, "Only HP Champions can be used.", 1, "role"),
+        (6, "Only DEF Champions can be used.", 1, "role"),
+        (7, "Only Support Champions can be used.", 1, "role"),
+        (8, "Only ATK Champions can be used.", 1, "role"),
+        (9, "Only Banner Lord Champions can be used.", 1, "faction"),
+        (10, "Only High Elves Champions can be used.", 1, "faction"),
+        (11, "Only Sacred Order Champions can be used.", 1, "faction"),
+        (12, "Only Barbarian Champions can be used.", 1, "faction"),
+        (13, "Only Ogryn Tribe Champions can be used.", 1, "faction"),
+        (14, "Only Lizardmen Champions can be used.", 1, "faction"),
+        (15, "Only Skinwalker Champions can be used.", 1, "faction"),
+        (16, "Only Orc Champions can be used.", 1, "faction"),
+        (17, "All Champions are immune to Turn Meter reduction effects.", 1, "effect"),
+        (18, "All Champions are immune to Turn Meter fill effects.", 1, "effect"),
         # Level 2 (10 conditions)
-        (19, "Only Void Champions can be used.", 2),
-        (20, "Only Force Champions can be used.", 2),
-        (21, "Only Magic Champions can be used.", 2),
-        (22, "Only Spirit Champions can be used.", 2),
-        (23, "Only Demonspawn Champions can be used.", 2),
-        (24, "Only Undead Horde Champions can be used.", 2),
-        (25, "Only Dark Elves Champions can be used.", 2),
-        (26, "Only Knights Revenant Champions can be used.", 2),
-        (27, "All Champions are immune to cooldown increasing effects.", 2),
-        (28, "All Champions are immune to cooldown decreasing effects.", 2),
+        (19, "Only Void Champions can be used.", 2, "affinity"),
+        (20, "Only Force Champions can be used.", 2, "affinity"),
+        (21, "Only Magic Champions can be used.", 2, "affinity"),
+        (22, "Only Spirit Champions can be used.", 2, "affinity"),
+        (23, "Only Demonspawn Champions can be used.", 2, "faction"),
+        (24, "Only Undead Horde Champions can be used.", 2, "faction"),
+        (25, "Only Dark Elves Champions can be used.", 2, "faction"),
+        (26, "Only Knights Revenant Champions can be used.", 2, "faction"),
+        (27, "All Champions are immune to cooldown increasing effects.", 2, "effect"),
+        (28, "All Champions are immune to cooldown decreasing effects.", 2, "effect"),
         # Level 3 (8 conditions)
-        (29, "Only Legendary Champions can be used.", 3),
-        (30, "Only Epic Champions can be used.", 3),
-        (31, "Only Rare Champions can be used.", 3),
-        (32, "Only Dwarves Champions can be used.", 3),
-        (33, "Only Shadowkin Champions can be used.", 3),
-        (34, "Only Sylvan Watcher Champions can be used.", 3),
-        (35, "All Champions are immune to [Sheep] debuffs.", 3),
-        (36, "Champions cannot be revived.", 3),
+        (29, "Only Legendary Champions can be used.", 3, "rarity"),
+        (30, "Only Epic Champions can be used.", 3, "rarity"),
+        (31, "Only Rare Champions can be used.", 3, "rarity"),
+        (32, "Only Dwarves Champions can be used.", 3, "faction"),
+        (33, "Only Shadowkin Champions can be used.", 3, "faction"),
+        (34, "Only Sylvan Watcher Champions can be used.", 3, "faction"),
+        (35, "All Champions are immune to [Sheep] debuffs.", 3, "effect"),
+        (36, "Champions cannot be revived.", 3, "other"),
     ]
     await session.execute(
         text(
-            "INSERT INTO post_condition (id, description, stronghold_level) "
-            "VALUES (:id, :description, :stronghold_level) "
+            "INSERT INTO post_condition "
+            "(id, description, stronghold_level, condition_type) "
+            "VALUES (:id, :description, :stronghold_level, :condition_type) "
             "ON CONFLICT DO NOTHING"
         ),
         [
-            {"id": id_, "description": description, "stronghold_level": level}
-            for id_, description, level in rows
+            {
+                "id": id_,
+                "description": description,
+                "stronghold_level": level,
+                "condition_type": condition_type,
+            }
+            for id_, description, level, condition_type in rows
         ],
     )
 

--- a/backend/app/models/post_condition.py
+++ b/backend/app/models/post_condition.py
@@ -17,11 +17,16 @@ class PostCondition(Base):
             "stronghold_level IN (1, 2, 3)",
             name="stronghold_level_valid",
         ),
+        CheckConstraint(
+            "condition_type IN ('role','affinity','faction','league','rarity','effect','other')",
+            name="condition_type_valid",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     description: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     stronghold_level: Mapped[int] = mapped_column(Integer, nullable=False)
+    condition_type: Mapped[str] = mapped_column(String, nullable=False)
 
     posts: Mapped[list["Post"]] = relationship(
         secondary="post_active_condition", back_populates="active_conditions"

--- a/backend/app/schemas/post_condition.py
+++ b/backend/app/schemas/post_condition.py
@@ -1,8 +1,13 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 
 class PostConditionResponse(BaseModel):
+    """Pydantic response schema for a PostCondition catalog entry."""
+
     model_config = {"from_attributes": True}
     id: int
     description: str
     stronghold_level: int
+    condition_type: Literal["role", "affinity", "faction", "league", "rarity", "effect", "other"]

--- a/backend/scripts/seed_demo.py
+++ b/backend/scripts/seed_demo.py
@@ -39,37 +39,37 @@ from app.models.siege_member import SiegeMember
 
 DEMO_MEMBERS: list[tuple[str, MemberRole, str]] = [
     # Heavy Hitters (5) — gt_25m
-    ("Grimmaw",   MemberRole.heavy_hitter, "gt_25m"),
-    ("Valdris",   MemberRole.heavy_hitter, "gt_25m"),
-    ("Korath",    MemberRole.heavy_hitter, "gt_25m"),
+    ("Grimmaw", MemberRole.heavy_hitter, "gt_25m"),
+    ("Valdris", MemberRole.heavy_hitter, "gt_25m"),
+    ("Korath", MemberRole.heavy_hitter, "gt_25m"),
     ("Thornclaw", MemberRole.heavy_hitter, "gt_25m"),
-    ("Malakar",   MemberRole.heavy_hitter, "gt_25m"),
+    ("Malakar", MemberRole.heavy_hitter, "gt_25m"),
     # Advanced (7) — 3 at 21_25m, 4 at 16_20m
     ("Drakemoor", MemberRole.advanced, "21_25m"),
-    ("Sylvaris",  MemberRole.advanced, "21_25m"),
-    ("Varek",     MemberRole.advanced, "21_25m"),
-    ("Kaelith",   MemberRole.advanced, "16_20m"),
-    ("Morvain",   MemberRole.advanced, "16_20m"),
-    ("Rhogar",    MemberRole.advanced, "16_20m"),
-    ("Ashborne",  MemberRole.advanced, "16_20m"),
+    ("Sylvaris", MemberRole.advanced, "21_25m"),
+    ("Varek", MemberRole.advanced, "21_25m"),
+    ("Kaelith", MemberRole.advanced, "16_20m"),
+    ("Morvain", MemberRole.advanced, "16_20m"),
+    ("Rhogar", MemberRole.advanced, "16_20m"),
+    ("Ashborne", MemberRole.advanced, "16_20m"),
     # Medium (7) — 2 at 16_20m, 5 at 10_15m
-    ("Brennan",   MemberRole.medium, "16_20m"),
-    ("Tovik",     MemberRole.medium, "16_20m"),
-    ("Sellira",   MemberRole.medium, "10_15m"),
-    ("Jorund",    MemberRole.medium, "10_15m"),
-    ("Marek",     MemberRole.medium, "10_15m"),
-    ("Dravak",    MemberRole.medium, "10_15m"),
-    ("Linneth",   MemberRole.medium, "10_15m"),
+    ("Brennan", MemberRole.medium, "16_20m"),
+    ("Tovik", MemberRole.medium, "16_20m"),
+    ("Sellira", MemberRole.medium, "10_15m"),
+    ("Jorund", MemberRole.medium, "10_15m"),
+    ("Marek", MemberRole.medium, "10_15m"),
+    ("Dravak", MemberRole.medium, "10_15m"),
+    ("Linneth", MemberRole.medium, "10_15m"),
     # Novice (9) — lt_10m
-    ("Tamsin",    MemberRole.novice, "lt_10m"),
-    ("Wren",      MemberRole.novice, "lt_10m"),
-    ("Orrin",     MemberRole.novice, "lt_10m"),
-    ("Finnick",   MemberRole.novice, "lt_10m"),
-    ("Perrin",    MemberRole.novice, "lt_10m"),
-    ("Lira",      MemberRole.novice, "lt_10m"),
-    ("Kessen",    MemberRole.novice, "lt_10m"),
-    ("Brandis",   MemberRole.novice, "lt_10m"),
-    ("Noll",      MemberRole.novice, "lt_10m"),
+    ("Tamsin", MemberRole.novice, "lt_10m"),
+    ("Wren", MemberRole.novice, "lt_10m"),
+    ("Orrin", MemberRole.novice, "lt_10m"),
+    ("Finnick", MemberRole.novice, "lt_10m"),
+    ("Perrin", MemberRole.novice, "lt_10m"),
+    ("Lira", MemberRole.novice, "lt_10m"),
+    ("Kessen", MemberRole.novice, "lt_10m"),
+    ("Brandis", MemberRole.novice, "lt_10m"),
+    ("Noll", MemberRole.novice, "lt_10m"),
 ]
 
 # Building layout: (type, building_number, level, group_count, slots_per_group)
@@ -183,9 +183,7 @@ async def seed_buildings_and_positions(
         # Post-type buildings require a matching Post record.
         if building_type == BuildingType.post:
             ppc_result = await session.execute(
-                select(PostPriorityConfig).where(
-                    PostPriorityConfig.post_number == building_number
-                )
+                select(PostPriorityConfig).where(PostPriorityConfig.post_number == building_number)
             )
             ppc = ppc_result.scalar_one_or_none()
             session.add(
@@ -203,7 +201,10 @@ async def seed_buildings_and_positions(
 async def get_or_create_second_siege(session: AsyncSession, first_siege: Siege) -> Siege:
     """Return the existing planning siege or create one one week after the first."""
     result = await session.execute(
-        select(Siege).where(Siege.status == SiegeStatus.planning).order_by(Siege.date.desc()).limit(1)
+        select(Siege)
+        .where(Siege.status == SiegeStatus.planning)
+        .order_by(Siege.date.desc())
+        .limit(1)
     )
     siege = result.scalar_one_or_none()
     if siege is None:

--- a/backend/tests/test_me_preferences.py
+++ b/backend/tests/test_me_preferences.py
@@ -58,13 +58,19 @@ def _make_post_condition(
     id: int = 1,
     description: str = "Condition A",
     stronghold_level: int = 1,
+    condition_type: str = "role",
 ) -> SimpleNamespace:
     """Build a minimal PostCondition-like namespace for mocking.
 
     Fields match the ``PostConditionResponse`` schema: ``id``,
-    ``description``, and ``stronghold_level``.
+    ``description``, ``stronghold_level``, and ``condition_type``.
     """
-    return SimpleNamespace(id=id, description=description, stronghold_level=stronghold_level)
+    return SimpleNamespace(
+        id=id,
+        description=description,
+        stronghold_level=stronghold_level,
+        condition_type=condition_type,
+    )
 
 
 def _make_mock_db(member: object = None) -> AsyncMock:
@@ -723,3 +729,134 @@ async def test_put_mixed_valid_and_invalid_post_condition_ids_is_atomic(
                 assert returned_ids == [1], f"Expected prefs unchanged ([1]), got {returned_ids}"
     finally:
         app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# condition_type field serialization tests (#442)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_response_includes_condition_type(
+    monkeypatch,
+    service_token_headers,
+):
+    """GET /me/preferences response items must include condition_type field."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    member = _make_member()
+    prefs = [
+        _make_post_condition(
+            id=5,
+            description="Only HP Champions can be used.",
+            stronghold_level=1,
+            condition_type="role",
+        ),
+        _make_post_condition(
+            id=12,
+            description="Only Barbarian Champions can be used.",
+            stronghold_level=1,
+            condition_type="faction",
+        ),
+        _make_post_condition(
+            id=19,
+            description="Only Void Champions can be used.",
+            stronghold_level=2,
+            condition_type="affinity",
+        ),
+    ]
+
+    mock_db = _make_mock_db(member=member)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": MEMBER_DISCORD_ID,
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+    for item in data:
+        assert "condition_type" in item, f"condition_type missing from response item: {item}"
+    assert data[0]["condition_type"] == "role"
+    assert data[1]["condition_type"] == "faction"
+    assert data[2]["condition_type"] == "affinity"
+
+
+@pytest.mark.asyncio
+async def test_put_preferences_response_includes_condition_type(
+    monkeypatch,
+    service_token_headers,
+):
+    """PUT /me/preferences response items must include condition_type field."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    member = _make_member()
+    prefs = [
+        _make_post_condition(
+            id=1,
+            description="Only Telerian League can be used.",
+            stronghold_level=1,
+            condition_type="league",
+        ),
+        _make_post_condition(
+            id=29,
+            description="Only Legendary Champions can be used.",
+            stronghold_level=3,
+            condition_type="rarity",
+        ),
+    ]
+
+    mock_db = _make_mock_db(member=member)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.set_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.put(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": MEMBER_DISCORD_ID,
+                    },
+                    json={"post_condition_ids": [1, 29]},
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    for item in data:
+        assert "condition_type" in item, f"condition_type missing from PUT response item: {item}"
+    assert data[0]["condition_type"] == "league"
+    assert data[1]["condition_type"] == "rarity"

--- a/backend/tests/test_post_suggestions_integration.py
+++ b/backend/tests/test_post_suggestions_integration.py
@@ -93,8 +93,8 @@ async def _seed_siege(session: AsyncSession) -> tuple:
              pos1, pos2)
     """
     # Conditions
-    cond_a = PostCondition(description="Attack Lv1", stronghold_level=1)
-    cond_b = PostCondition(description="Defense Lv2", stronghold_level=2)
+    cond_a = PostCondition(description="Attack Lv1", stronghold_level=1, condition_type="role")
+    cond_b = PostCondition(description="Defense Lv2", stronghold_level=2, condition_type="faction")
     session.add_all([cond_a, cond_b])
     await session.flush()
 

--- a/backend/tests/test_reference.py
+++ b/backend/tests/test_reference.py
@@ -10,8 +10,19 @@ from app.main import app
 from app.models.enums import BuildingType
 
 
-def _make_post_condition(id: int, description: str, stronghold_level: int) -> SimpleNamespace:
-    return SimpleNamespace(id=id, description=description, stronghold_level=stronghold_level)
+def _make_post_condition(
+    id: int,
+    description: str,
+    stronghold_level: int,
+    condition_type: str = "other",
+) -> SimpleNamespace:
+    """Build a minimal PostCondition-like namespace for mocking."""
+    return SimpleNamespace(
+        id=id,
+        description=description,
+        stronghold_level=stronghold_level,
+        condition_type=condition_type,
+    )
 
 
 @pytest.fixture
@@ -27,8 +38,8 @@ def client():
 @pytest.mark.asyncio
 async def test_get_post_conditions_returns_list(client):
     conditions = [
-        _make_post_condition(1, "Condition A", 1),
-        _make_post_condition(2, "Condition B", 2),
+        _make_post_condition(1, "Condition A", 1, condition_type="league"),
+        _make_post_condition(2, "Condition B", 2, condition_type="role"),
     ]
     with patch(
         "app.api.reference.reference_service.get_post_conditions", new_callable=AsyncMock
@@ -43,6 +54,56 @@ async def test_get_post_conditions_returns_list(client):
     assert data[0]["id"] == 1
     assert data[0]["description"] == "Condition A"
     assert data[0]["stronghold_level"] == 1
+    assert data[0]["condition_type"] == "league"
+    assert data[1]["condition_type"] == "role"
+
+
+# ---------------------------------------------------------------------------
+# condition_type field in catalog endpoint (#442)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_post_conditions_includes_condition_type_field(client):
+    """GET /api/post-conditions must include condition_type in each item."""
+    conditions = [
+        _make_post_condition(5, "Only HP Champions can be used.", 1, condition_type="role"),
+        _make_post_condition(
+            12, "Only Barbarian Champions can be used.", 1, condition_type="faction"
+        ),
+        _make_post_condition(19, "Only Void Champions can be used.", 2, condition_type="affinity"),
+        _make_post_condition(
+            29, "Only Legendary Champions can be used.", 3, condition_type="rarity"
+        ),
+        _make_post_condition(
+            17,
+            "All Champions are immune to Turn Meter reduction effects.",
+            1,
+            condition_type="effect",
+        ),
+        _make_post_condition(
+            1, "Only Champions from the Telerian League can be used.", 1, condition_type="league"
+        ),
+        _make_post_condition(36, "Champions cannot be revived.", 3, condition_type="other"),
+    ]
+    with patch(
+        "app.api.reference.reference_service.get_post_conditions", new_callable=AsyncMock
+    ) as mock:
+        mock.return_value = conditions
+        async with client as c:
+            response = await c.get("/api/post-conditions")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 7
+    for item in data:
+        assert (
+            "condition_type" in item
+        ), f"condition_type missing from catalog response item: {item}"
+    # Verify each of the 7 categories is represented
+    types_present = {item["condition_type"] for item in data}
+    expected_types = {"role", "faction", "affinity", "rarity", "effect", "league", "other"}
+    assert types_present == expected_types
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_seed_canonical.py
+++ b/backend/tests/test_seed_canonical.py
@@ -158,3 +158,122 @@ class TestCanonicalSeedPostPriorityConfig:
             await session.execute(select(func.count()).select_from(PostPriorityConfig))
         ).scalar_one()
         assert count == 18
+
+
+class TestConditionTypeSeeded:
+    """Assert that condition_type is populated for at least one row per category.
+
+    The seven categories are: league, role, faction, effect, affinity, rarity,
+    other. Each must have at least one seeded row with the correct value to prove
+    the seed backfill works end-to-end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_league_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='league' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "league")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'league' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_role_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='role' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "role")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'role' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_faction_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='faction' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "faction")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'faction' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_effect_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='effect' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "effect")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'effect' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_affinity_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='affinity' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "affinity")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'affinity' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_rarity_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='rarity' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "rarity")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'rarity' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_other_condition_type_seeded(self, session: AsyncSession) -> None:
+        """At least one PostCondition with condition_type='other' exists after seed."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type == "other")
+        )
+        rows = result.scalars().all()
+        assert len(rows) >= 1, "Expected at least one 'other' condition_type row"
+
+    @pytest.mark.asyncio
+    async def test_all_36_rows_have_condition_type(self, session: AsyncSession) -> None:
+        """All 36 seeded PostCondition rows must have a non-null condition_type."""
+        await _run_canonical_seed(session)
+        result = await session.execute(
+            select(PostCondition).where(PostCondition.condition_type.is_(None))
+        )
+        null_rows = result.scalars().all()
+        assert len(null_rows) == 0, f"Expected zero NULL condition_type rows, got {len(null_rows)}"
+
+    @pytest.mark.asyncio
+    async def test_league_ids_have_correct_condition_type(self, session: AsyncSession) -> None:
+        """IDs 1-4 (league) must all have condition_type='league'."""
+        await _run_canonical_seed(session)
+        for id_ in [1, 2, 3, 4]:
+            row = await session.get(PostCondition, id_)
+            assert row is not None, f"PostCondition id={id_} missing"
+            assert (
+                row.condition_type == "league"
+            ), f"id={id_} expected 'league', got {row.condition_type!r}"
+
+    @pytest.mark.asyncio
+    async def test_role_ids_have_correct_condition_type(self, session: AsyncSession) -> None:
+        """IDs 5-8 (role) must all have condition_type='role'."""
+        await _run_canonical_seed(session)
+        for id_ in [5, 6, 7, 8]:
+            row = await session.get(PostCondition, id_)
+            assert row is not None, f"PostCondition id={id_} missing"
+            assert (
+                row.condition_type == "role"
+            ), f"id={id_} expected 'role', got {row.condition_type!r}"
+
+    @pytest.mark.asyncio
+    async def test_other_id_36_has_correct_condition_type(self, session: AsyncSession) -> None:
+        """ID 36 (other) must have condition_type='other'."""
+        await _run_canonical_seed(session)
+        row = await session.get(PostCondition, 36)
+        assert row is not None, "PostCondition id=36 missing"
+        assert row.condition_type == "other", f"id=36 expected 'other', got {row.condition_type!r}"

--- a/bot/INTERFACE.md
+++ b/bot/INTERFACE.md
@@ -662,10 +662,19 @@ An empty list clears all preferences:
 **Response — 200 OK.** `list[PostConditionResponse]` — the member's updated
 preference set (may be `[]`).
 
+`PostConditionResponse` fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `int` | Stable identifier, never reused |
+| `description` | `string` | Human-readable condition text |
+| `stronghold_level` | `int` | One of: `1`, `2`, `3` |
+| `condition_type` | `string` | One of: `role`, `affinity`, `faction`, `league`, `rarity`, `effect`, `other` — enforced by a CHECK constraint; the set is closed |
+
 ```json
 [
-  {"id": 1, "description": "Day 1 attacker", "stronghold_level": 8},
-  {"id": 3, "description": "Reserve only", "stronghold_level": 8}
+  {"id": 5,  "description": "Only HP Champions can be used.",        "stronghold_level": 1, "condition_type": "role"},
+  {"id": 12, "description": "Only Barbarian Champions can be used.", "stronghold_level": 1, "condition_type": "faction"}
 ]
 ```
 

--- a/docs/mom-bot-postcondition-integration.md
+++ b/docs/mom-bot-postcondition-integration.md
@@ -1,0 +1,222 @@
+# mom-bot: Post-Condition Preference Integration Guide
+
+This document is a handoff brief for the agent implementing mom-bot's integration
+with siege-web's member post-condition preference endpoints. It covers only the
+per-member get/set surface. Post-condition catalog enumeration and all other
+siege-web endpoints are out of scope.
+
+---
+
+## What this is
+
+siege-web maintains a per-member list of preferred post-conditions — the
+stronghold building states a member is willing to attack. mom-bot reads and writes
+this list on behalf of individual Discord users by calling two `/api/members/me/`
+endpoints. The `/me/` path variant resolves the target member from headers rather
+than from a URL path parameter, which is the contract designed for bot consumers.
+
+---
+
+## Endpoints
+
+| Method | Path                           | Request body                          | Response                        |
+|--------|--------------------------------|---------------------------------------|---------------------------------|
+| GET    | `/api/members/me/preferences`  | none                                  | `list[PostConditionResponse]`   |
+| PUT    | `/api/members/me/preferences`  | `{"post_condition_ids": [int, ...]}`  | `list[PostConditionResponse]`   |
+
+**PostConditionResponse shape:**
+
+```json
+{
+  "id": 12,
+  "description": "Only Barbarian Champions can be used.",
+  "stronghold_level": 1,
+  "condition_type": "faction"
+}
+```
+
+Fields: `id` (stable backend integer), `description` (human-readable label),
+`stronghold_level` (the stronghold level this condition applies to),
+`condition_type` (category string — see Schema Contract below).
+
+---
+
+## Authentication
+
+Both endpoints require two headers on every request. Neither is optional when
+calling as a bot service.
+
+| Header                  | Value                              | Purpose                                          |
+|-------------------------|------------------------------------|--------------------------------------------------|
+| `Authorization`         | `Bearer <BOT_SERVICE_TOKEN>`       | Authenticates mom-bot as a trusted service caller |
+| `X-Acting-Discord-Id`   | Discord snowflake (numeric string) | Tells siege-web which member's data to operate on |
+
+**What each header does:**
+
+- `Authorization: Bearer <BOT_SERVICE_TOKEN>` — siege-web performs a
+  timing-safe comparison against the `BOT_SERVICE_TOKEN` secret it was started
+  with. A missing or wrong token returns **401**.
+- `X-Acting-Discord-Id` — siege-web looks up the supplied Discord snowflake
+  in its Member table to find the target member. A missing header on a
+  service-token request returns **401** (no unambiguous subject). An ID that
+  does not match any known member returns **404**.
+
+**Security:** `BOT_SERVICE_TOKEN` is a shared secret. Store it in mom-bot's
+secret store (environment variable, secrets manager, etc.) and never log it,
+echo it to Discord, or include it in error messages.
+
+---
+
+## PUT semantics: replacement, not append
+
+`PUT /api/members/me/preferences` is a **replacement set** operation. The IDs
+you send become the member's complete preference list — any IDs previously saved
+but absent from the new body are removed. There is no partial-update or additive
+endpoint.
+
+When building the Discord interaction that lets a user set preferences (e.g. a
+select-menu), present all available choices and submit the full desired set in
+one PUT. Do not read-modify-write; the API does not support incremental updates
+and a read-modify-write pattern is subject to race conditions.
+
+---
+
+## Schema Contract
+
+### PostConditionResponse — formal schema
+
+```json
+{
+  "id": 5,                                   // int, ≥1, stable (never reused)
+  "description": "Only HP Champions can be used.",  // string, human-readable
+  "stronghold_level": 1,                     // int, one of: 1 | 2 | 3
+  "condition_type": "role"                   // string, one of 7 closed values
+}
+```
+
+`condition_type` is guaranteed present in all responses. The backend enforces
+the closed set via a CHECK constraint — a value outside the seven listed below
+cannot appear.
+
+### `condition_type` value enumeration
+
+Values are drawn from the seeded catalog (`backend/app/db/seeds.py`). The set is
+closed — the backend enforces it with a CheckConstraint. A new value requires a
+coordinated schema change; it will never appear silently.
+
+| Value      | Meaning                                      | Example conditions (seeded)                                                    |
+|------------|----------------------------------------------|--------------------------------------------------------------------------------|
+| `league`   | Faction alliance (Telerian, Gaellen, etc.)   | Telerian League · Gaellen Pact · The Corrupted · Nyresan Union                |
+| `role`     | Champion combat role                         | HP · DEF · Support · ATK                                                       |
+| `faction`  | Specific in-game faction                     | Banner Lords · High Elves · Sacred Order · Barbarian · Ogryn Tribe · Lizardmen · Skinwalker · Orc · Demonspawn · Undead Horde · Dark Elves · Knights Revenant · Dwarves · Shadowkin · Sylvan Watcher |
+| `affinity` | Elemental affinity                           | Void · Force · Magic · Spirit                                                  |
+| `rarity`   | Champion rarity tier                         | Legendary · Epic · Rare                                                        |
+| `effect`   | Immunity to a game mechanic                  | Turn Meter reduction immunity · Turn Meter fill immunity · Cooldown increasing immunity · Cooldown decreasing immunity · [Sheep] immunity |
+| `other`    | Conditions that don't fit a specific category | Champions cannot be revived.                                                  |
+
+Suggested display order (matches frontend): `role`, `affinity`, `faction`, `league`, `rarity`, `effect`, `other`. Frontend display labels mirror the value names (title-cased); mom-bot may use the same or its own.
+
+### PUT request schema
+
+```json
+{
+  "post_condition_ids": [5, 12, 17]   // list[int]; each ID must exist in siege-web's DB
+}
+```
+
+IDs that do not exist in siege-web's database return **422**. See the Error modes
+table for the recommended recovery action.
+
+### Worked example: grouping preferences by category
+
+Given this GET response:
+
+```json
+[
+  {"id": 5,  "description": "Only HP Champions can be used.",          "stronghold_level": 1, "condition_type": "role"},
+  {"id": 12, "description": "Only Barbarian Champions can be used.",   "stronghold_level": 1, "condition_type": "faction"},
+  {"id": 17, "description": "All Champions are immune to Turn Meter reduction effects.", "stronghold_level": 1, "condition_type": "effect"},
+  {"id": 19, "description": "Only Void Champions can be used.",        "stronghold_level": 2, "condition_type": "affinity"}
+]
+```
+
+Group by `condition_type` in display order, then render each group:
+
+```python
+DISPLAY_ORDER = ["role", "affinity", "faction", "league", "rarity", "effect", "other"]
+
+def group_preferences(prefs):
+    groups = {ct: [] for ct in DISPLAY_ORDER}
+    for p in prefs:
+        groups.setdefault(p["condition_type"], []).append(p["description"])
+    return [(ct, groups[ct]) for ct in DISPLAY_ORDER if groups[ct]]
+
+for label, descriptions in group_preferences(preferences):
+    print(f"**{label.capitalize()}**")
+    for desc in descriptions:
+        print(f"  - {desc}")
+```
+
+---
+
+## Example requests
+
+Replace `<BOT_SERVICE_TOKEN>`, `<DISCORD_ID>`, and `<SIEGE_WEB_HOST>` with
+values from your environment.
+
+**GET — read a member's current preferences:**
+
+```bash
+curl -s \
+  -H "Authorization: Bearer <BOT_SERVICE_TOKEN>" \
+  -H "X-Acting-Discord-Id: <DISCORD_ID>" \
+  https://<SIEGE_WEB_HOST>/api/members/me/preferences
+```
+
+Example response:
+
+```json
+[
+  {"id": 5,  "description": "Only HP Champions can be used.",        "stronghold_level": 1, "condition_type": "role"},
+  {"id": 12, "description": "Only Barbarian Champions can be used.", "stronghold_level": 1, "condition_type": "faction"}
+]
+```
+
+**PUT — replace a member's preferences:**
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: Bearer <BOT_SERVICE_TOKEN>" \
+  -H "X-Acting-Discord-Id: <DISCORD_ID>" \
+  -H "Content-Type: application/json" \
+  -d '{"post_condition_ids": [5, 12, 17]}' \
+  https://<SIEGE_WEB_HOST>/api/members/me/preferences
+```
+
+Response is the same shape as GET — the full updated preference list.
+
+---
+
+## Error modes
+
+| Status | Trigger                                                                 | Action                                                          |
+|--------|-------------------------------------------------------------------------|-----------------------------------------------------------------|
+| 400    | `X-Acting-Discord-Id` is present but not a valid numeric snowflake      | Validate the Discord ID before sending                          |
+| 401    | Wrong or missing `Authorization` header                                 | Check `BOT_SERVICE_TOKEN` in mom-bot's config                   |
+| 401    | Valid service token but `X-Acting-Discord-Id` header is absent          | Always include the header; there is no default subject          |
+| 404    | `X-Acting-Discord-Id` value does not match any Member in siege-web's DB | The user may not be registered; surface a user-facing message   |
+| 422    | `post_condition_ids` contains IDs that don't exist in siege-web's DB    | Fetch current valid IDs before submitting; do not cache IDs indefinitely |
+
+---
+
+## Out of scope
+
+This document does not cover:
+
+- How to enumerate the full catalog of available post-conditions (the set of
+  valid IDs to present to users in a select-menu).
+- The `/api/members/{member_id}/preferences` sibling routes — those require a
+  user session cookie and are not for bot use.
+- Any other siege-web API surface (boards, assignments, notifications, auth
+  flow, etc.).
+- mom-bot's internal command or interaction structure.


### PR DESCRIPTION
## Summary

Backend half of the post-condition category-taxonomy migration. The frontend has owned a hardcoded id→type map at `frontend/src/lib/postConditionTypes.ts` since the MVP; mom-bot (the first non-bundled sidecar) needs the same taxonomy and replicating it would create a two-source-of-truth drift risk. This PR moves the source of truth to the backend and exposes it on `PostConditionResponse` so every consumer reads the same data.

- New `condition_type` column on `post_condition` (`VARCHAR NOT NULL`, `CheckConstraint("condition_type IN ('role','affinity','faction','league','rarity','effect','other')")`) — Alembic migration `0012`, backfilled verbatim from `frontend/src/lib/postConditionTypes.ts:61-109` so all 36 existing rows populate at upgrade time.
- `PostCondition` SQLAlchemy model and `seed_post_conditions()` updated so fresh DB bootstrap also populates the column (not just upgraded DBs).
- `PostConditionResponse` Pydantic schema gains `condition_type: Literal[...]` over the closed 7-value set. All four `/preferences` endpoints + the reference catalog endpoint inherit propagation automatically via `from_attributes=True`.
- Tests: +14 new tests across `test_seed_canonical.py`, `test_me_preferences.py`, `test_reference.py`. At least one assertion per category. Baseline 429 → 443 passed.
- Docs: `bot/INTERFACE.md` (the canonical sidecar contract) updated to describe `condition_type` and refresh example response bodies. `docs/mom-bot-postcondition-integration.md` — the post-#442 caveats and defensive-fallback note are removed; the field is now guaranteed present. **This doc was written earlier in the conversation but never committed; this PR is the first time it lands in git history.**

## What's NOT in this PR (separate follow-up issue, intentional)

- Frontend cutover from `POST_CONDITION_TYPE_BY_ID` to API-sourced `condition_type`. `frontend/src/lib/postConditionTypes.ts` is unchanged.
- Deletion of the frontend id→type map. The union type + label/order constants stay there as presentation concerns.

## Verification

Local from the worktree (using project venv):

```
pytest --ignore=tests/test_schema.py -v   → 443 passed (+14 new)
black --check .                            → 139 files unchanged
ruff check .                               → All checks passed
```

**Alembic round-trip caveat.** The agent could not exercise `alembic upgrade head → downgrade -1 → upgrade head` locally — local PG password rejected the `.env.example` default and Docker wasn't running. The migration uses standard Alembic API calls (`op.add_column`, `op.alter_column`, `op.create_check_constraint`, `op.drop_constraint`, `op.drop_column`) matching migrations `0001`–`0011`, and pytest (443 passed) exercises the ORM model built from the same metadata. CI's `Backend Lint & Test` job runs against real Postgres so the upgrade path is exercised there. **The downgrade path is the unverified piece** — recommend a manual `alembic downgrade -1 && alembic upgrade head` against a dev DB before merge if rollback safety matters here.

## Test plan

- [ ] CI green (Backend Lint & Test, Frontend, Bot, Sidecar Integration Tests, PR review bot).
- [ ] Manual smoke against dev: `alembic upgrade head` succeeds, `SELECT id, condition_type FROM post_condition LIMIT 5` returns populated values.
- [ ] Manual rollback smoke: `alembic downgrade -1` succeeds (constraint + column drop), then `alembic upgrade head` re-applies cleanly.
- [ ] `curl -H "Authorization: Bearer $BOT_SERVICE_TOKEN" -H "X-Acting-Discord-Id: $DISCORD_ID" .../api/members/me/preferences` returns rows with `condition_type` populated.

Closes #442

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_