### PR TITLE
infra: split BOT_SERVICE_TOKEN onto its own KV secret (closes #443)

### DIFF
--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -180,6 +180,15 @@ resource apiApp 'Microsoft.App/containerApps@2025-07-01' = {
           keyVaultUrl: '${keyVaultUri}secrets/discord-client-secret'
           identity: 'system'
         }
+        {
+          // Separate KV secret for the inbound bot→backend trust boundary.
+          // bot-service-token backs BOT_SERVICE_TOKEN (verifies requests FROM the
+          // bot TO the backend). Splitting it off discord-bot-api-key gives each
+          // direction its own rotation surface — see issue #443.
+          name: 'bot-service-token'
+          keyVaultUrl: '${keyVaultUri}secrets/bot-service-token'
+          identity: 'system'
+        }
       ]
     }
     template: {
@@ -204,7 +213,7 @@ resource apiApp 'Microsoft.App/containerApps@2025-07-01' = {
               { name: 'DISCORD_CLIENT_ID', secretRef: 'discord-client-id' }
               { name: 'DISCORD_CLIENT_SECRET', secretRef: 'discord-client-secret' }
               { name: 'DISCORD_REDIRECT_URI', value: discordRedirectUri }
-              { name: 'BOT_SERVICE_TOKEN', secretRef: 'discord-bot-api-key' }
+              { name: 'BOT_SERVICE_TOKEN', secretRef: 'bot-service-token' }
               // When a custom domain is configured, allow CORS from that origin so
               // the browser can reach /api/* from the custom domain frontend.
               // Falls back to localhost:5173 for dev deployments without a custom domain.


### PR DESCRIPTION
## Summary

Splits `BOT_SERVICE_TOKEN` (the secret the API verifies on inbound bot→backend Bearer-authed calls) off the shared Key Vault secret `discord-bot-api-key` and onto a dedicated new KV secret `bot-service-token`. The split cleanly separates the two trust boundaries that were previously conflated on a single rotation surface:

| Env var (API container) | Direction | KV secret (after this PR) |
|---|---|---|
| `DISCORD_BOT_API_KEY` | outbound: backend → siege-bot | `discord-bot-api-key` (unchanged) |
| `BOT_SERVICE_TOKEN` | inbound: bot → backend | `bot-service-token` (new) |

The bot container (`BOT_API_KEY` ← KV `bot-api-key`) is unchanged.

## Why now

mom-bot will be the first non-bundled sidecar to exercise the inbound direction. Splitting the secrets now means independent rotation (compromising the backend→bot path doesn't force every bot→backend caller to rotate, and vice versa) and a smaller blast radius if either env var ever leaks. Doing this before consumer count grows is strictly easier than after.

## Files changed

- `infra/modules/container-apps.bicep` — two hunks:
  - New `bot-service-token` entry in the API container's `secrets:` array (mirrors the existing `identity: 'system'` pattern).
  - `BOT_SERVICE_TOKEN` env var `secretRef` switched from `'discord-bot-api-key'` to `'bot-service-token'`.
- Single commit, single file.

## Key Vault access

RBAC is **vault-scoped** (verified at `infra/modules/kv-role-assignments.bicep:26-34` — the API Container App identity has "Key Vault Secrets User" at vault scope). The new secret inherits access automatically; no additional role assignment needed.

## Operator prerequisite — create KV secrets BEFORE deploying

The Container App will fail to start if `bot-service-token` doesn't exist when the new Bicep is applied. Run these one-time steps in each environment before triggering the Infra Deploy workflow.

### Dev

```bash
# Resolve the dev vault name
DEV_VAULT=$(az keyvault list -g siege-rg-dev --query "[].name" -o tsv)
echo "$DEV_VAULT"

# Initial value: safest is to reuse the existing discord-bot-api-key value so
# zero-downtime, then rotate after confirming the app starts cleanly.
# For fresh value: openssl rand -hex 32
EXISTING=$(az keyvault secret show --vault-name "$DEV_VAULT" --name discord-bot-api-key --query value -o tsv)

az keyvault secret set \
  --vault-name "$DEV_VAULT" \
  --name bot-service-token \
  --value "$EXISTING"
```

### Prod

```bash
PROD_VAULT=siege-web-kv-prod-yf3fl2   # verify before running

EXISTING=$(az keyvault secret show --vault-name "$PROD_VAULT" --name discord-bot-api-key --query value -o tsv)

az keyvault secret set \
  --vault-name "$PROD_VAULT" \
  --name bot-service-token \
  --value "$EXISTING"
```

After both secrets exist and this PR merges to `main`, run `infra-deploy.yml` for dev first, verify the API container's new revision picks up the env mapping cleanly, then dev → prod.

**Post-deploy rotation step** (recommended, after parity is confirmed): rotate `bot-service-token` to an independent value (`openssl rand -hex 32`), then update any bot consumer that uses it (currently no production caller — mom-bot will be the first).

## Verification

- `az bicep build --file infra/modules/container-apps.bicep --stdout` → exit 0, no errors.
- `az bicep lint --file infra/modules/container-apps.bicep` → exit 0, no new warnings.
- Backend / bot / frontend code unchanged → no application-test surface affected.

## Test plan

- [ ] CI green (no Python/JS changes, but the workflows still run).
- [ ] Operator: KV secrets created in both dev and prod vaults (commands above).
- [ ] Infra Deploy workflow runs cleanly against dev.
- [ ] Post-deploy: `az containerapp revision show -g siege-rg-dev -n siege-web-api-dev --query "properties.template.containers[0].env"` confirms `BOT_SERVICE_TOKEN` is sourced from `bot-service-token` (not `discord-bot-api-key`).
- [ ] API `/api/health` returns 200 on the new revision (BOT_SERVICE_TOKEN startup guard satisfied).
- [ ] Same for prod.
- [ ] (Future, post-mom-bot ship) Rotate `bot-service-token` to a value independent of `discord-bot-api-key`.

## Out of scope

- Per-consumer token differentiation. Still a single shared `bot-service-token` value across all bot→backend callers. Worth a separate issue if/when a third consumer appears.
- Renaming `discord-bot-api-key` (stays — now exclusively backs backend→siege-bot).
- `BOT_API_KEY` on the bot side, or `DISCORD_BOT_API_KEY` on the API side.
- Application-code changes — none required.

Closes #443

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_