### PR TITLE
fix(posts): include condition_type in _serialize_post active_conditions (closes #450)

### DIFF
--- a/backend/app/api/posts.py
+++ b/backend/app/api/posts.py
@@ -19,7 +19,12 @@ def _serialize_post(post: Post) -> dict:
         "priority": post.priority,
         "description": post.description,
         "active_conditions": [
-            {"id": c.id, "description": c.description, "stronghold_level": c.stronghold_level}
+            {
+                "id": c.id,
+                "description": c.description,
+                "stronghold_level": c.stronghold_level,
+                "condition_type": c.condition_type,
+            }
             for c in post.active_conditions
         ],
     }

--- a/backend/tests/test_posts.py
+++ b/backend/tests/test_posts.py
@@ -22,6 +22,21 @@ def _make_building(id: int = 10, building_number: int = 1) -> SimpleNamespace:
     )
 
 
+def _make_condition(
+    id: int = 1,
+    description: str = "Role: Heavy Hitter",
+    stronghold_level: int = 1,
+    condition_type: str = "role",
+) -> SimpleNamespace:
+    """Build a minimal PostCondition-shaped object for test fixtures."""
+    return SimpleNamespace(
+        id=id,
+        description=description,
+        stronghold_level=stronghold_level,
+        condition_type=condition_type,
+    )
+
+
 def _make_post(
     id: int = 1,
     siege_id: int = 1,
@@ -29,6 +44,7 @@ def _make_post(
     building_number: int = 1,
     priority: int = 1,
     description: str | None = None,
+    active_conditions: list | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=id,
@@ -36,7 +52,7 @@ def _make_post(
         building_id=building_id,
         priority=priority,
         description=description,
-        active_conditions=[],
+        active_conditions=active_conditions if active_conditions is not None else [],
         building=_make_building(id=building_id, building_number=building_number),
     )
 
@@ -137,3 +153,48 @@ async def test_list_posts_sorted_by_building_number(client):
         2,
         3,
     ], f"Expected posts sorted by building_number [1,2,3], got {building_numbers}"
+
+
+# ---------------------------------------------------------------------------
+# 5. active_conditions in list_posts response includes condition_type field
+#    Regression for #450: _serialize_post omitted condition_type, causing a
+#    ResponseValidationError (HTTP 500) on every GET /api/sieges/{id}/posts
+#    when posts had active conditions.
+# ---------------------------------------------------------------------------
+
+VALID_CONDITION_TYPES = {"role", "affinity", "faction", "league", "rarity", "effect", "other"}
+
+
+@pytest.mark.asyncio
+async def test_list_posts_active_conditions_include_condition_type(client):
+    """Each active_condition in the posts list response must include condition_type.
+
+    Without the fix, FastAPI's response validation raises ResponseValidationError
+    (HTTP 500) because PostConditionResponse declares condition_type as a required
+    Literal field that the hand-rolled serializer dict did not populate.
+    """
+    condition = _make_condition(
+        id=7, description="Role: Heavy Hitter", stronghold_level=1, condition_type="role"
+    )
+    post = _make_post(id=1, active_conditions=[condition])
+
+    with patch("app.api.posts.posts_service.list_posts", new_callable=AsyncMock) as mock:
+        mock.return_value = [post]
+        async with client as c:
+            response = await c.get("/api/sieges/1/posts")
+
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert len(data) == 1
+    conditions = data[0]["active_conditions"]
+    assert len(conditions) == 1, "Post fixture has one active condition — response must include it"
+    cond = conditions[0]
+    assert "condition_type" in cond, (
+        "condition_type must be present in active_condition response; "
+        "its absence causes ResponseValidationError (HTTP 500)"
+    )
+    assert (
+        cond["condition_type"] in VALID_CONDITION_TYPES
+    ), f"condition_type '{cond['condition_type']}' is not one of {VALID_CONDITION_TYPES}"
+    assert cond["id"] == 7
+    assert cond["stronghold_level"] == 1


### PR DESCRIPTION
## Summary

Dev is hard down — every `GET /api/sieges/{siege_id}/posts` returns HTTP 500. Same shape for `PUT /api/sieges/{siege_id}/posts/{post_id}` and `PUT /api/sieges/{siege_id}/posts/{post_id}/conditions` when posts have active conditions. Filed as #450.

## Root cause

`backend/app/api/posts.py` `_serialize_post()` builds `active_conditions` as hand-rolled dicts with `id`, `description`, `stronghold_level`. PR #446 added `condition_type` as a **required** Literal field to `PostConditionResponse`, but missed this serializer. FastAPI's response-validation raises `ResponseValidationError` because the required field is absent from every response item.

The DB and migration are fine — column exists, all 36 rows populated. Bug is purely in the Python serialization layer.

## Fix

One-line change in `_serialize_post()`:

```python
"active_conditions": [
    {"id": c.id, "description": c.description, "stronghold_level": c.stronghold_level, "condition_type": c.condition_type}
    for c in post.active_conditions
],
```

## Audit (defense against the same class of bug)

Grepped `backend/app/**/*.py` for every site that touches the `PostConditionResponse` shape. Result: `_serialize_post()` in `posts.py` was the only hand-rolled dict-builder. All other consumers (`reference.py`, `members.py`, `board.py`, `post_suggestions.py`) use ORM passthrough via `from_attributes=True`, which picks up the new column automatically. No second land mine.

## Regression test

Added `test_list_posts_active_conditions_include_condition_type` in `backend/tests/test_posts.py`. Seeds a post with active conditions, calls `GET /api/sieges/{siege_id}/posts`, asserts response status 200 AND every active_condition has a valid `condition_type` value. Verified red-first: the test failed without the fix with the exact production error (`Field required` on `condition_type`), and passes with the fix.

## Verification

```
pytest --ignore=tests/test_schema.py -v   → 444 passed (+1 new)
black --check .                            → clean
ruff check .                               → clean
```

## Why CI didn't catch the original bug

PR #446's test additions (`test_seed_canonical.py`, `test_me_preferences.py`, `test_reference.py`) covered the `/preferences` and reference catalog response shapes but did NOT exercise `GET /api/sieges/{id}/posts`. The posts-endpoint test fixtures created posts without active_conditions, so response validation never tripped the `Literal` requirement on `condition_type`. The new test in this PR closes that gap by explicitly seeding active conditions.

This is a "Verify-all-CI-jobs / grep-for-pattern" miss in #446's brief — the code-writer was told "all endpoints returning PostConditionResponse must propagate the new field" and assumed `from_attributes=True` covered everything. Hand-rolled dicts elsewhere in the response tree weren't audited. The lesson: when a schema gains a required field, grep for every site that constructs that shape, not just every endpoint annotated with the schema.

## Test plan

- [ ] CI green.
- [ ] After merge auto-deploys to dev: `GET /api/sieges/<any-id>/posts` returns 200 with populated body.
- [ ] `condition_type` present on every entry in `active_conditions[]`.

Closes #450

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_