### PR TITLE
auth: match acting member by discord_username with opportunistic snowflake backfill

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -112,8 +112,16 @@ async def _resolve_acting_member(
     if not acting_username:
         raise HTTPException(status_code=404, detail=_NOT_REGISTERED_MSG)
 
+    if len(acting_username) > 32:
+        raise HTTPException(
+            status_code=400,
+            detail="X-Acting-Discord-Username exceeds maximum length",
+        )
+
     result = await db.execute(
-        select(Member).where(func.lower(Member.discord_username) == acting_username.lower())
+        select(Member)
+        .where(func.lower(Member.discord_username) == acting_username.lower())
+        .limit(2)
     )
     rows = result.scalars().all()
 
@@ -121,7 +129,7 @@ async def _resolve_acting_member(
     if len(rows) > 1:
         raise HTTPException(
             status_code=409,
-            detail=("multiple members claim this Discord username;" " admin must resolve"),
+            detail="multiple members claim this Discord username; admin must resolve",
         )
 
     if not rows:
@@ -144,6 +152,11 @@ async def _resolve_acting_member(
             raise HTTPException(status_code=404, detail=_NOT_REGISTERED_MSG)
 
         # --- Step 5: opportunistic backfill ---------------------------------
+        # The commit here is intentional and independent of outer request
+        # success.  get_db() yields a fresh session per request, so nothing
+        # else is dirty.  Persisting the backfill unconditionally means a
+        # user hitting transient downstream errors will not permanently pay
+        # the slow username-fallback path on every retry.
         matched.discord_id = acting_discord_id
         await db.commit()
 
@@ -191,7 +204,7 @@ async def get_current_user(
                 if not acting_discord_id.isdigit() or len(acting_discord_id) > 20:
                     raise HTTPException(
                         status_code=400,
-                        detail=("X-Acting-Discord-Id must be a numeric" " Discord snowflake"),
+                        detail="X-Acting-Discord-Id must be a numeric Discord snowflake",
                     )
                 acting_member = await _resolve_acting_member(
                     db,

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -9,19 +9,35 @@ Checks three paths in order:
 The ``get_acting_member_id`` dependency extends service-token auth with an
 optional ``X-Acting-Discord-Id`` header that allows the bot to act on behalf
 of a specific member for ``/me/*`` endpoints.
+
+When ``X-Acting-Discord-Id`` is present, the member lookup follows this order:
+
+1. Snowflake match — ``Member.discord_id == acting_discord_id``.  Hit → done.
+2. Username fallback (requires ``X-Acting-Discord-Username``) — case-insensitive
+   match on ``Member.discord_username``.  Multi-row → 409.  No rows → 404.
+3. Backfill conflict guard — if the matched member has no ``discord_id``,
+   verify no other row already owns ``acting_discord_id``.  Conflict → 404.
+4. Opportunistic backfill — write ``discord_id = acting_discord_id`` and commit
+   so future calls hit path 1 directly.
 """
 
+import logging
 import secrets
 from dataclasses import dataclass
 
 import jwt
 from fastapi import Depends, HTTPException, Request
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import JWT_ALGORITHM, settings
 from app.db.session import get_db
 from app.models.member import Member
+
+logger = logging.getLogger(__name__)
+
+# Reused across every 404 branch so the bot sees a consistent message.
+_NOT_REGISTERED_MSG = "Acting Discord user not found"
 
 
 @dataclass
@@ -48,6 +64,90 @@ class AuthenticatedUser:
     role: str | None = None
     discord_id: str | None = None
     acting_member_id: int | None = None
+
+
+async def _resolve_acting_member(
+    db: AsyncSession,
+    acting_discord_id: str,
+    acting_username: str | None,
+) -> Member:
+    """Resolve the acting member from a Discord snowflake (and optional username).
+
+    Lookup order:
+
+    1. Snowflake match — ``Member.discord_id == acting_discord_id``.
+       Returns immediately on hit.
+    2. Username fallback — case-insensitive match on
+       ``Member.discord_username``.  Skipped when ``acting_username`` is
+       ``None``.
+    3. Multi-row guard — raises 409 when two or more rows share the same
+       lowercased ``discord_username``.
+    4. Backfill conflict guard — if the matched member has
+       ``discord_id IS NULL``, checks that no other row already owns
+       ``acting_discord_id``.  Raises 404 on conflict.
+    5. Opportunistic backfill — writes ``discord_id = acting_discord_id``
+       and commits so future calls hit path 1 directly.
+
+    Args:
+        db: Async SQLAlchemy session.
+        acting_discord_id: Validated numeric Discord snowflake string.
+        acting_username: Value of the ``X-Acting-Discord-Username`` header,
+            or ``None`` when the header was absent.
+
+    Returns:
+        The resolved ``Member`` record.
+
+    Raises:
+        HTTPException: 404 when no member can be matched, or when the
+            backfill conflict guard fires.  409 when two members share the
+            same lowercased ``discord_username``.
+    """
+    # --- Step 1: snowflake lookup -------------------------------------------
+    result = await db.execute(select(Member).where(Member.discord_id == acting_discord_id))
+    member = result.scalar_one_or_none()
+    if member is not None:
+        return member
+
+    # --- Step 2: username fallback ------------------------------------------
+    if not acting_username:
+        raise HTTPException(status_code=404, detail=_NOT_REGISTERED_MSG)
+
+    result = await db.execute(
+        select(Member).where(func.lower(Member.discord_username) == acting_username.lower())
+    )
+    rows = result.scalars().all()
+
+    # --- Step 3: multi-row guard --------------------------------------------
+    if len(rows) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail=("multiple members claim this Discord username;" " admin must resolve"),
+        )
+
+    if not rows:
+        raise HTTPException(status_code=404, detail=_NOT_REGISTERED_MSG)
+
+    matched = rows[0]
+
+    # --- Step 4: backfill conflict guard ------------------------------------
+    if matched.discord_id is None:
+        conflict_result = await db.execute(
+            select(Member.id).where(Member.discord_id == acting_discord_id)
+        )
+        if conflict_result.scalar_one_or_none() is not None:
+            logger.warning(
+                "Backfill conflict: acting_discord_id=%s already owned "
+                "by another member; matched member id=%s left unchanged",
+                acting_discord_id,
+                matched.id,
+            )
+            raise HTTPException(status_code=404, detail=_NOT_REGISTERED_MSG)
+
+        # --- Step 5: opportunistic backfill ---------------------------------
+        matched.discord_id = acting_discord_id
+        await db.commit()
+
+    return matched
 
 
 async def get_current_user(
@@ -91,17 +191,13 @@ async def get_current_user(
                 if not acting_discord_id.isdigit() or len(acting_discord_id) > 20:
                     raise HTTPException(
                         status_code=400,
-                        detail="X-Acting-Discord-Id must be a numeric Discord snowflake",
+                        detail=("X-Acting-Discord-Id must be a numeric" " Discord snowflake"),
                     )
-                result = await db.execute(
-                    select(Member).where(Member.discord_id == acting_discord_id)
+                acting_member = await _resolve_acting_member(
+                    db,
+                    acting_discord_id,
+                    request.headers.get("X-Acting-Discord-Username"),
                 )
-                acting_member = result.scalar_one_or_none()
-                if acting_member is None:
-                    raise HTTPException(
-                        status_code=404,
-                        detail="Acting Discord user not found",
-                    )
                 acting_member_id = acting_member.id
             return AuthenticatedUser(
                 member_id=None,

--- a/backend/tests/test_me_preferences.py
+++ b/backend/tests/test_me_preferences.py
@@ -37,15 +37,28 @@ def _make_member(
     id: int = 42,
     name: str = "Alice",
     discord_id: str = MEMBER_DISCORD_ID,
+    discord_username: str | None = None,
     role: MemberRole = MemberRole.advanced,
     is_active: bool = True,
 ) -> SimpleNamespace:
-    """Build a minimal Member-like namespace for mocking."""
+    """Build a minimal Member-like namespace for mocking.
+
+    Args:
+        id: Database primary key.
+        name: Display name.
+        discord_id: Discord snowflake string.
+        discord_username: Discord username, or None when not yet stored.
+        role: Member role enum value.
+        is_active: Whether the member is active.
+
+    Returns:
+        A SimpleNamespace whose attributes mirror the Member ORM model.
+    """
     return SimpleNamespace(
         id=id,
         name=name,
         discord_id=discord_id,
-        discord_username=None,
+        discord_username=discord_username,
         role=role,
         power=None,
         sort_value=None,
@@ -1360,3 +1373,45 @@ async def test_username_fallback_h_multi_row_collision_returns_409(
 
     assert response.status_code == 409
     mock_db.commit.assert_not_called()
+
+
+# (i) X-Acting-Discord-Username too long (>32 chars) → 400
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_i_username_too_long_returns_400(
+    monkeypatch,
+    service_token_headers,
+):
+    """X-Acting-Discord-Username longer than 32 chars → 400 Bad Request.
+
+    Discord caps usernames at 32 characters.  A 33-char value must be
+    rejected before any DB query is attempted.  The snowflake header is
+    present and valid so the only reason for 400 is the length guard.
+    """
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    mock_db = _make_mock_db()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    # 33 characters — one over the 32-char Discord cap.
+    too_long_username = "a" * 33
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/members/me/preferences",
+                headers={
+                    **service_token_headers,
+                    "X-Acting-Discord-Id": MEMBER_DISCORD_ID,
+                    "X-Acting-Discord-Username": too_long_username,
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 400
+    assert "exceeds maximum length" in response.json()["detail"]

--- a/backend/tests/test_me_preferences.py
+++ b/backend/tests/test_me_preferences.py
@@ -860,3 +860,503 @@ async def test_put_preferences_response_includes_condition_type(
         assert "condition_type" in item, f"condition_type missing from PUT response item: {item}"
     assert data[0]["condition_type"] == "league"
     assert data[1]["condition_type"] == "rarity"
+
+
+# ---------------------------------------------------------------------------
+# Tests (a)–(h): #452 username fallback + opportunistic discord_id backfill
+# ---------------------------------------------------------------------------
+
+
+def _make_execute_result(rows: list) -> MagicMock:
+    """Build a mock execute() result supporting both scalar styles.
+
+    Args:
+        rows: List of Member-like objects to return from .scalars().all().
+            A single-element list is also available via
+            .scalar_one_or_none() for the snowflake lookup path.
+
+    Returns:
+        A MagicMock whose .scalar_one_or_none() returns the first row
+        (or None) and whose .scalars().all() returns the full list.
+    """
+    result = MagicMock()
+    # scalar_one_or_none used by the snowflake lookup path
+    result.scalar_one_or_none = MagicMock(return_value=rows[0] if rows else None)
+    # scalars().all() used by the username fallback path
+    scalars_mock = MagicMock()
+    scalars_mock.all = MagicMock(return_value=rows)
+    result.scalars = MagicMock(return_value=scalars_mock)
+    return result
+
+
+# (a) snowflake match — regression: existing path still works with username
+# header present but unused
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_a_snowflake_match_returns_member(
+    monkeypatch,
+    service_token_headers,
+):
+    """Snowflake lookup hits; username header present but unused."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    member = _make_member(discord_id=MEMBER_DISCORD_ID)
+    prefs = [_make_post_condition(id=1)]
+
+    # First execute (snowflake lookup) hits; second should never be called.
+    snowflake_result = _make_execute_result([member])
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=snowflake_result)
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": MEMBER_DISCORD_ID,
+                        "X-Acting-Discord-Username": "alice_discord",
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+
+
+# (b) username fallback match + backfill: discord_id IS NULL, username match
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_b_username_match_backfills_discord_id(
+    monkeypatch,
+    service_token_headers,
+):
+    """Username fallback hits a member with discord_id IS NULL; backfills it."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    # Member has no discord_id yet but has a matching discord_username.
+    member = SimpleNamespace(
+        id=55,
+        name="Bob",
+        discord_id=None,
+        discord_username="bob_discord",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+    prefs = [_make_post_condition(id=3)]
+
+    # Call sequence:
+    # 1. snowflake lookup  → miss (empty)
+    # 2. username lookup   → hit (member)
+    # 3. conflict guard    → miss (no other member owns acting_discord_id)
+    snowflake_miss = _make_execute_result([])
+    username_hit = _make_execute_result([member])
+    conflict_miss = _make_execute_result([])
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[snowflake_miss, username_hit, conflict_miss])
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": "555555555555555555",
+                        "X-Acting-Discord-Username": "bob_discord",
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    # Backfill: discord_id was written onto the member object.
+    assert member.discord_id == "555555555555555555"
+    # commit() must have been called to persist the backfill.
+    mock_db.commit.assert_called_once()
+
+
+# (c) both miss → 404
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_c_both_miss_returns_404(
+    monkeypatch,
+    service_token_headers,
+):
+    """Neither snowflake nor username matches → 404."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    snowflake_miss = _make_execute_result([])
+    username_miss = _make_execute_result([])
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[snowflake_miss, username_miss])
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/members/me/preferences",
+                headers={
+                    **service_token_headers,
+                    "X-Acting-Discord-Id": "999999999999999999",
+                    "X-Acting-Discord-Username": "nobody_discord",
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 404
+
+
+# (d) case-insensitive username match
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_d_case_insensitive_match(
+    monkeypatch,
+    service_token_headers,
+):
+    """Username lookup is case-insensitive; 'Alice_Discord' matches 'alice_discord'."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    member = SimpleNamespace(
+        id=60,
+        name="Alice",
+        discord_id=None,
+        discord_username="alice_discord",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+    prefs = []
+
+    snowflake_miss = _make_execute_result([])
+    username_hit = _make_execute_result([member])
+    conflict_miss = _make_execute_result([])
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[snowflake_miss, username_hit, conflict_miss])
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": "600600600600600600",
+                        # Header username has different case than stored value.
+                        "X-Acting-Discord-Username": "ALICE_DISCORD",
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    assert member.discord_id == "600600600600600600"
+
+
+# (e) backfill idempotency: second call hits snowflake path; no second write
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_e_backfill_idempotency(
+    monkeypatch,
+    service_token_headers,
+):
+    """After backfill, the member now has a discord_id; second call skips fallback."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    # Simulate post-backfill state: member already has discord_id set.
+    member = _make_member(id=70, discord_id="700700700700700700")
+    prefs = []
+
+    # Only one execute call — snowflake hits immediately.
+    snowflake_hit = _make_execute_result([member])
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=snowflake_hit)
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": "700700700700700700",
+                        "X-Acting-Discord-Username": "eve_discord",
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    # commit() should NOT be called (no backfill needed).
+    mock_db.commit.assert_not_called()
+    # execute() called exactly once (snowflake path short-circuits).
+    assert mock_db.execute.call_count == 1
+
+
+# (f) snowflake match + stale username header: snowflake wins; no error/rewrite
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_f_snowflake_wins_over_stale_username(
+    monkeypatch,
+    service_token_headers,
+):
+    """Snowflake matches even when username header differs from stored value."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    # Member whose stored discord_username differs from the header value.
+    member = SimpleNamespace(
+        id=80,
+        name="Frank",
+        discord_id=MEMBER_DISCORD_ID,
+        discord_username="frank_old_handle",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+    prefs = []
+
+    # Snowflake hits on first execute; no further executes needed.
+    snowflake_hit = _make_execute_result([member])
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=snowflake_hit)
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with patch(
+            "app.api.members.members_service.get_member_preferences",
+            new_callable=AsyncMock,
+        ) as mock_svc:
+            mock_svc.return_value = prefs
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get(
+                    "/api/members/me/preferences",
+                    headers={
+                        **service_token_headers,
+                        "X-Acting-Discord-Id": MEMBER_DISCORD_ID,
+                        # Header username drifted from stored value.
+                        "X-Acting-Discord-Username": "frank_new_handle",
+                    },
+                )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    # discord_username must NOT be rewritten.
+    assert member.discord_username == "frank_old_handle"
+    # No commit (no backfill performed).
+    mock_db.commit.assert_not_called()
+
+
+# (g) backfill conflict guard: another member already owns the discord_id → 404
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_g_backfill_conflict_returns_404(
+    monkeypatch,
+    service_token_headers,
+):
+    """Member A has discord_id IS NULL; Member B owns the snowflake → 404, no write."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    ACTING_SNOWFLAKE = "888888888888888888"
+
+    # Member A: username match candidate, discord_id IS NULL.
+    member_a = SimpleNamespace(
+        id=91,
+        name="Grace",
+        discord_id=None,
+        discord_username="grace_discord",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+    # Member B: already owns the acting snowflake (different member).
+    member_b = SimpleNamespace(
+        id=92,
+        name="Henry",
+        discord_id=ACTING_SNOWFLAKE,
+        discord_username="henry_discord",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+
+    # Call sequence:
+    # 1. snowflake lookup  → miss (member A has no discord_id)
+    # 2. username lookup   → hit (member A via username)
+    # 3. conflict guard    → hit (member B owns the snowflake)
+    snowflake_miss = _make_execute_result([])
+    username_hit = _make_execute_result([member_a])
+    conflict_hit = _make_execute_result([member_b])
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[snowflake_miss, username_hit, conflict_hit])
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/members/me/preferences",
+                headers={
+                    **service_token_headers,
+                    "X-Acting-Discord-Id": ACTING_SNOWFLAKE,
+                    "X-Acting-Discord-Username": "grace_discord",
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 404
+    # Member A must NOT have been mutated.
+    assert member_a.discord_id is None
+    mock_db.commit.assert_not_called()
+
+
+# (h) multi-row username collision → 409
+
+
+@pytest.mark.asyncio
+async def test_username_fallback_h_multi_row_collision_returns_409(
+    monkeypatch,
+    service_token_headers,
+):
+    """Two members share a lowercased discord_username → 409 Conflict."""
+    monkeypatch.setattr("app.config.settings.auth_disabled", False)
+    monkeypatch.setattr("app.config.settings.bot_service_token", SERVICE_TOKEN)
+
+    # Two members with the same lowercased discord_username, both no discord_id.
+    member_x = SimpleNamespace(
+        id=101,
+        name="Xena",
+        discord_id=None,
+        discord_username="duplicate_handle",
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+    member_y = SimpleNamespace(
+        id=102,
+        name="Yara",
+        discord_id=None,
+        discord_username="Duplicate_Handle",  # same lowercased value
+        role=MemberRole.advanced,
+        power=None,
+        sort_value=None,
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+    )
+
+    snowflake_miss = _make_execute_result([])
+    # Username lookup returns both rows.
+    username_multi = _make_execute_result([member_x, member_y])
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[snowflake_miss, username_multi])
+    mock_db.commit = AsyncMock()
+
+    async def override_get_db():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/members/me/preferences",
+                headers={
+                    **service_token_headers,
+                    "X-Acting-Discord-Id": "101010101010101010",
+                    "X-Acting-Discord-Username": "duplicate_handle",
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 409
+    mock_db.commit.assert_not_called()


### PR DESCRIPTION
Fixes #452.

## Summary

Adds a `discord_username` fallback path to `get_current_user` so mom-bot members who haven't logged into siege-web can be matched. On a unique fallback hit with `discord_id IS NULL`, opportunistically backfills the snowflake so subsequent calls take the fast snowflake path.

## Lookup order (in new `_resolve_acting_member()` helper)

1. **Snowflake match** — `Member.discord_id == acting_discord_id` (existing behavior; regression-protected).
2. **Username fallback** — case-insensitive match on `Member.discord_username` (requires the new `X-Acting-Discord-Username` header; skipped if absent). Header value capped at 32 chars (Discord's handle-length limit) — longer values rejected with 400.
3. **Multi-row guard** — `409` if `>1` row shares the lowercased username (defensive; `discord_username` has no DB `UNIQUE` constraint). Query is `.limit(2)` so we never fetch more than needed.
4. **Backfill conflict guard** — if the matched row has `discord_id IS NULL`, verify no other row already owns `acting_discord_id`; log + `404` on conflict to prevent corrupting either row.
5. **Opportunistic backfill** — write `discord_id = acting_discord_id` and commit. The commit is intentional and independent of outer request success — `get_db()` yields a fresh session per request, so nothing else is dirty here; backfill persists even if the outer request later fails, so users with transient downstream errors don't permanently pay the slow username-fallback path.

Both miss → existing `404` with the unchanged `"Acting Discord user not found"` detail (refactored to a `_NOT_REGISTERED_MSG` constant).

## Coordination

mom-bot caller change is tracked in glitchwerks/mom-bot#155 (adds `X-Acting-Discord-Username` to outgoing `/post-conditions-*` requests). This PR is backward-compatible — if the header is absent, only the snowflake path runs.

## Tests

`backend/tests/test_me_preferences.py` — 9 cases (a)–(i):

- (a) snowflake match (regression).
- (b) username fallback match + backfill assertion.
- (c) both miss → `404`.
- (d) case-insensitive username match.
- (e) backfill idempotency (second call takes snowflake path).
- (f) snowflake match + stale username (snowflake wins, no rewrite).
- (g) backfill conflict guard (`404`, no mutation).
- (h) multi-row username collision (`409`, defensive).
- (i) `X-Acting-Discord-Username` > 32 chars → `400`.

## PR-review triage (Claude PR Review bot)

Triage applied in commit `7bf6587`:

**Applied:** username length validation (#2 from review), `.limit(2)` on fallback query (#4), single-string detail literals (#5), `_make_member` helper takes `discord_username` (#6), test (i) for length guard (#7).

**Rejected with rationale:**
- **#1 "premature commit"** — backfill is intentionally independent of outer request success (see step 5 above + inline comment in `_resolve_acting_member`). Removing the commit means users with transient downstream errors never backfill and permanently take the slow path.
- **#3 "unnecessary conflict-guard query"** — the conflict guard is the explicit mitigation for the snowflake-squat concern from the prior architectural review (see #452 comments). Removing it reopens that hole.

## Out of scope

- mom-bot caller change (#155).
- Adding DB `UNIQUE` constraint on `discord_username` — runtime guard sufficient given Discord's post-2023 global handle uniqueness; separate housekeeping if we want belt-and-suspenders.
- Schema migrations.

## Test plan

- [x] `black --check .` (CI step 1)
- [x] `ruff check .` (CI step 2)
- [x] `pytest --ignore=tests/test_schema.py -v` — 453 passed, 0 failed
- [ ] CI green on this PR
- [ ] Manual smoke after merge: send `/post-conditions-get` from a clan member whose `discord_id` is null but `discord_username` is set; verify the response succeeds and that `Member.discord_id` is populated afterward.

---

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*
