### PR TITLE
feat(bot): POST /api/role-sync receiver (closes #458 item D)

### DIFF
--- a/bot/app/discord_client.py
+++ b/bot/app/discord_client.py
@@ -1,4 +1,7 @@
+"""Discord client for the Siege Assignment System."""
+
 import io
+from typing import Literal
 
 import discord
 
@@ -67,3 +70,45 @@ class SiegeBot(discord.Client):
             }
             for m in guild.members
         ]
+
+    async def apply_day_role(
+        self,
+        discord_id: str,
+        role_id: str,
+        action: Literal["assign", "unassign"],
+    ) -> str:
+        """Toggle a day role for a guild member.
+
+        Fetches the member by snowflake ID and applies or removes the
+        specified role.  Both ``add_roles`` and ``remove_roles`` are
+        idempotent at the Discord API level, so no prior-state check is
+        needed.
+
+        Args:
+            discord_id: Discord snowflake string of the target member.
+            role_id: Discord snowflake string of the role to toggle.
+            action: ``"assign"`` adds the role; ``"unassign"`` removes it.
+
+        Returns:
+            ``"applied"`` on success.
+
+        Raises:
+            discord.NotFound: When the member is not in the guild.
+            discord.Forbidden: When the bot lacks permission to manage
+                the role (e.g. role is above the bot in the hierarchy).
+            discord.HTTPException: On other Discord API errors.
+            ValueError: When ``role_id`` resolves to ``None`` in the
+                guild (role does not exist or was deleted).
+        """
+        guild = self._require_guild()
+        member = await guild.fetch_member(int(discord_id))
+        role = guild.get_role(int(role_id))
+        if role is None:
+            raise ValueError(
+                f"Role '{role_id}' not found in guild"
+            )
+        if action == "assign":
+            await member.add_roles(role)
+        else:
+            await member.remove_roles(role)
+        return "applied"

--- a/bot/app/discord_client.py
+++ b/bot/app/discord_client.py
@@ -76,7 +76,7 @@ class SiegeBot(discord.Client):
         discord_id: str,
         role_id: str,
         action: Literal["assign", "unassign"],
-    ) -> str:
+    ) -> tuple[str, str]:
         """Toggle a day role for a guild member.
 
         Fetches the member by snowflake ID and applies or removes the
@@ -90,7 +90,10 @@ class SiegeBot(discord.Client):
             action: ``"assign"`` adds the role; ``"unassign"`` removes it.
 
         Returns:
-            ``"applied"`` on success.
+            A 2-tuple ``(status, role_name)`` where ``status`` is always
+            ``"applied"`` and ``role_name`` is the Discord role's display
+            name (used by the HTTP route to populate the ``added`` /
+            ``removed`` fields in the response body).
 
         Raises:
             discord.NotFound: When the member is not in the guild.
@@ -104,11 +107,9 @@ class SiegeBot(discord.Client):
         member = await guild.fetch_member(int(discord_id))
         role = guild.get_role(int(role_id))
         if role is None:
-            raise ValueError(
-                f"Role '{role_id}' not found in guild"
-            )
+            raise ValueError(f"Role '{role_id}' not found in guild")
         if action == "assign":
             await member.add_roles(role)
         else:
             await member.remove_roles(role)
-        return "applied"
+        return "applied", role.name

--- a/bot/app/fake_discord.py
+++ b/bot/app/fake_discord.py
@@ -1,5 +1,19 @@
 """In-memory fake Discord client for integration testing.
 
+Role-sync magic trigger values (``apply_day_role``)
+-----------------------------------------------------
+The following role snowflake IDs produce exception paths in the fake client:
+
+  ``apply_day_role``:
+    - role_id ``"role-forbidden-id"``   → raises ``discord.Forbidden``
+    - role_id ``"role-http4xx-id"``     → raises ``discord.HTTPException`` 429
+    - role_id ``"role-http5xx-id"``     → raises ``discord.HTTPException`` 500
+
+Known good role snowflake: ``KNOWN_ROLE_ID = "888000888000888001"``
+Unknown role snowflake  : any value not in the known set → ``get_role`` returns ``None``
+
+# noqa: E501 — the original docstring continuation below
+
 Used when ``BOT_TEST_MODE=fake`` is set.  Replaces the real ``SiegeBot``
 (discord.py) with a deterministic, zero-network implementation that the
 HTTP sidecar can call through its normal seams.
@@ -90,6 +104,10 @@ KNOWN_MEMBER_DISPLAY_NAME = "Known User"
 KNOWN_CHANNEL_NAME = "known-channel"
 KNOWN_IMAGE_URL = "https://cdn.discordapp.com/attachments/fake/board.png"
 
+# Role fixture for apply_day_role tests
+KNOWN_ROLE_ID = "888000888000888001"
+KNOWN_ROLE_NAME = "Day 1"
+
 # Snowflake used for the guild itself (any non-zero value works)
 FAKE_GUILD_ID = 123456789
 
@@ -118,6 +136,20 @@ def _make_discord_http_exc(http_status: int, text: str = "") -> discord.HTTPExce
 # ---------------------------------------------------------------------------
 
 
+class _FakeRole:
+    """Minimal stand-in for ``discord.Role``."""
+
+    def __init__(self, role_id: str, name: str) -> None:
+        """Initialise the fake role.
+
+        Args:
+            role_id: Discord snowflake string for this role.
+            name: Human-readable role name (e.g. ``"Day 1"``).
+        """
+        self.id = int(role_id)
+        self.name = name
+
+
 class _FakeMember:
     """Minimal stand-in for ``discord.Member``."""
 
@@ -133,13 +165,33 @@ class _FakeMember:
         # Provide an empty roles list (no @everyone mock needed for fake).
         self.roles: list[Any] = []
 
+    async def add_roles(self, role: _FakeRole) -> None:
+        """Append ``role`` to this member's role list.
+
+        Args:
+            role: The ``_FakeRole`` instance to add.
+        """
+        if role not in self.roles:
+            self.roles.append(role)
+
+    async def remove_roles(self, role: _FakeRole) -> None:
+        """Remove ``role`` from this member's role list if present.
+
+        Args:
+            role: The ``_FakeRole`` instance to remove.
+        """
+        self.roles = [r for r in self.roles if r is not role]
+
 
 class _FakeGuild:
     """Minimal stand-in for ``discord.Guild``.
 
-    Supports ``fetch_member()`` for the ``GET /api/members/{id}`` path.
+    Supports ``fetch_member()`` for the ``GET /api/members/{id}`` path
+    and ``get_role()`` for the ``POST /api/role-sync`` path.
+
     The known member is returned for ``KNOWN_MEMBER_ID``; any other ID
-    raises ``discord.NotFound``.
+    raises ``discord.NotFound``.  The known role is returned for
+    ``KNOWN_ROLE_ID``; any other ID returns ``None``.
     """
 
     def __init__(self) -> None:
@@ -148,6 +200,7 @@ class _FakeGuild:
             KNOWN_MEMBER_USERNAME,
             KNOWN_MEMBER_DISPLAY_NAME,
         )
+        self._known_role = _FakeRole(KNOWN_ROLE_ID, KNOWN_ROLE_NAME)
 
     async def fetch_member(self, user_id: int) -> _FakeMember:
         """Simulate ``Guild.fetch_member()``.
@@ -167,6 +220,20 @@ class _FakeGuild:
         response.status = 404
         response.reason = "Not Found"
         raise discord.NotFound(response, "Unknown Member")
+
+    def get_role(self, role_id: int) -> _FakeRole | None:
+        """Simulate ``Guild.get_role()``.
+
+        Args:
+            role_id: Integer Discord snowflake of the role to look up.
+
+        Returns:
+            The fake ``_FakeRole`` when the ID matches ``KNOWN_ROLE_ID``,
+            ``None`` otherwise (role does not exist in guild).
+        """
+        if role_id == int(KNOWN_ROLE_ID):
+            return self._known_role
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +371,41 @@ class FakeDiscordClient:
         if channel_name != KNOWN_CHANNEL_NAME:
             raise ValueError(f"Channel '{channel_name}' not found in guild")
         return KNOWN_IMAGE_URL
+
+    async def apply_day_role(
+        self,
+        discord_id: str,
+        role_id: str,
+        action: str,
+    ) -> str:
+        """Simulate toggling a day role for a guild member.
+
+        Args:
+            discord_id: Discord snowflake string of the target member.
+                Pass any value other than ``KNOWN_MEMBER_ID`` to trigger
+                ``discord.NotFound`` (member-not-found path).
+            role_id: Discord snowflake string of the role to toggle.
+                Pass ``KNOWN_ROLE_ID`` for the happy path.  Any unknown
+                ID returns ``None`` from ``get_role`` → ``ValueError``.
+            action: ``"assign"`` or ``"unassign"``.
+
+        Returns:
+            ``"applied"`` on success.
+
+        Raises:
+            discord.NotFound: When ``discord_id != KNOWN_MEMBER_ID``.
+            ValueError: When ``role_id`` is not in the fake guild
+                (simulates role-not-found path).
+        """
+        member = await self._fake_guild.fetch_member(int(discord_id))
+        role = self._fake_guild.get_role(int(role_id))
+        if role is None:
+            raise ValueError(f"Role '{role_id}' not found in guild")
+        if action == "assign":
+            await member.add_roles(role)
+        else:
+            await member.remove_roles(role)
+        return "applied"
 
     async def get_members(self) -> list[dict]:
         """Return a one-element member list for the known member.

--- a/bot/app/fake_discord.py
+++ b/bot/app/fake_discord.py
@@ -377,7 +377,7 @@ class FakeDiscordClient:
         discord_id: str,
         role_id: str,
         action: str,
-    ) -> str:
+    ) -> tuple[str, str]:
         """Simulate toggling a day role for a guild member.
 
         Args:
@@ -390,7 +390,7 @@ class FakeDiscordClient:
             action: ``"assign"`` or ``"unassign"``.
 
         Returns:
-            ``"applied"`` on success.
+            A 2-tuple ``("applied", role_name)`` on success.
 
         Raises:
             discord.NotFound: When ``discord_id != KNOWN_MEMBER_ID``.
@@ -405,7 +405,7 @@ class FakeDiscordClient:
             await member.add_roles(role)
         else:
             await member.remove_roles(role)
-        return "applied"
+        return "applied", role.name
 
     async def get_members(self) -> list[dict]:
         """Return a one-element member list for the known member.

--- a/bot/app/http_api.py
+++ b/bot/app/http_api.py
@@ -370,8 +370,7 @@ async def role_sync(
     """
     if body.discord_role_id is None:
         logger.warning(
-            "role-sync skipped — discord_role_id absent "
-            "(discord_id=%s, correlation_id=%s)",
+            "role-sync skipped — discord_role_id absent " "(discord_id=%s, correlation_id=%s)",
             body.discord_id,
             body.correlation_id,
         )
@@ -390,9 +389,7 @@ async def role_sync(
             action=body.action,
         )
     except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
 
     if body.action == "assign":
         added = [role_name]

--- a/bot/app/http_api.py
+++ b/bot/app/http_api.py
@@ -40,6 +40,7 @@ import logging
 import os
 import secrets
 from pathlib import Path
+from typing import Literal
 
 import discord
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, UploadFile, status
@@ -203,13 +204,45 @@ def verify_api_key(
 
 
 class NotifyRequest(BaseModel):
+    """Request body for POST /api/notify."""
+
     username: str
     message: str
 
 
 class PostMessageRequest(BaseModel):
+    """Request body for POST /api/post-message."""
+
     channel_name: str
     message: str
+
+
+class RoleSyncRequest(BaseModel):
+    """Request body for POST /api/role-sync (v1.1 day-role-sync contract).
+
+    All required fields map directly to the payload schema defined in
+    ``docs/webhooks/day-role-sync.md`` §2.  Optional fields are absent in
+    v1.0-conforming producers and MUST be tolerated per the contract.
+
+    Attributes:
+        discord_id: Discord snowflake ID of the member (opaque string).
+        siege_id: Primary key of the siege record; used for correlation.
+        action: ``"assign"`` or ``"unassign"`` — no other values are legal.
+        assigned_at: ISO-8601 UTC timestamp of the assignment change.
+        correlation_id: UUID v4 scoping the fan-out batch (§8).
+        day_number: Attack-day number (optional; absent for unassign-only).
+        discord_role_id: Discord snowflake of the role to toggle (v1.1,
+            optional).  When absent the endpoint returns
+            ``status="skipped"`` per the locked design decision.
+    """
+
+    discord_id: str
+    siege_id: int
+    action: Literal["assign", "unassign"]
+    assigned_at: str
+    correlation_id: str
+    day_number: int | None = None
+    discord_role_id: str | None = None
 
 
 @app.get("/api/version")

--- a/bot/app/http_api.py
+++ b/bot/app/http_api.py
@@ -333,6 +333,81 @@ async def post_image(
     return {"status": "sent", "url": url}
 
 
+@app.post("/api/role-sync")
+async def role_sync(
+    body: RoleSyncRequest,
+    _: None = Depends(verify_api_key),
+) -> dict:
+    """Receive a day-role-sync event and apply or remove the Discord role.
+
+    Implements the receiver side of the v1.1 day-role-sync contract
+    (``docs/webhooks/day-role-sync.md``).  The endpoint is stateless:
+    it executes the role toggle on every call; idempotency is delegated
+    to Discord's ``add_roles``/``remove_roles`` API which are idempotent
+    at the Discord level.
+
+    When ``discord_role_id`` is absent the endpoint returns a
+    ``status="skipped"`` response with a WARNING log and does NOT call
+    the seam.  This is the producer-side v1.0 → v1.1 transition path.
+    The producer's ``_handle_sync_response`` treats ``skipped`` as success
+    (no retry, no producer-side failure).
+
+    Args:
+        body: Validated ``RoleSyncRequest`` from the request body.
+        _: Bearer-token dependency; raises 401 on failure.
+
+    Returns:
+        JSON body conforming to §3 of the contract:
+        ``{"status", "added", "removed"}`` always present;
+        ``"reason"`` present when status is not ``"applied"``.
+
+    Raises:
+        HTTPException: 503 if the bot is not connected.
+        HTTPException: 404 if the member or role is not found (ValueError).
+        discord.NotFound: Propagated to the global 404 handler.
+        discord.Forbidden: Propagated to the global 403 handler.
+        discord.HTTPException: Propagated to the global 502/503 handlers.
+    """
+    if body.discord_role_id is None:
+        logger.warning(
+            "role-sync skipped — discord_role_id absent "
+            "(discord_id=%s, correlation_id=%s)",
+            body.discord_id,
+            body.correlation_id,
+        )
+        return {
+            "status": "skipped",
+            "added": [],
+            "removed": [],
+            "reason": "discord_role_id absent — no local map fallback",
+        }
+
+    bot = _get_bot()
+    try:
+        applied_status, role_name = await bot.apply_day_role(
+            discord_id=body.discord_id,
+            role_id=body.discord_role_id,
+            action=body.action,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        )
+
+    if body.action == "assign":
+        added = [role_name]
+        removed: list[str] = []
+    else:
+        added = []
+        removed = [role_name]
+
+    return {
+        "status": applied_status,
+        "added": added,
+        "removed": removed,
+    }
+
+
 @app.get("/api/members")
 async def get_members(
     _: None = Depends(verify_api_key),

--- a/bot/tests/test_discord_client.py
+++ b/bot/tests/test_discord_client.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
 from app.discord_client import SiegeBot
@@ -155,3 +156,105 @@ async def test_get_members_returns_correct_dict_format():
     bob = next(m for m in result if m["username"] == "bob")
     assert bob["id"] == "200"
     assert bob["display_name"] == "Bobby"
+
+
+# ---------------------------------------------------------------------------
+# apply_day_role
+# ---------------------------------------------------------------------------
+
+
+def _make_role(role_id: int, name: str = "Day 1") -> MagicMock:
+    """Create a minimal mock Discord role."""
+    role = MagicMock()
+    role.id = role_id
+    role.name = name
+    return role
+
+
+def _make_member_with_role_ops(user_id: int = 111000111000111001) -> MagicMock:
+    """Create a member mock that supports add_roles / remove_roles."""
+    member = MagicMock()
+    member.id = user_id
+    member.add_roles = AsyncMock()
+    member.remove_roles = AsyncMock()
+    member.roles = []
+    return member
+
+
+def _make_guild_with_role(role_id: int, role_name: str = "Day 1") -> MagicMock:
+    """Create a guild mock that returns a role from get_role and a member via fetch_member."""
+    guild = MagicMock()
+    role = _make_role(role_id, role_name)
+    guild.get_role.return_value = role
+    member = _make_member_with_role_ops()
+    guild.fetch_member = AsyncMock(return_value=member)
+    return guild, member, role
+
+
+@pytest.mark.asyncio
+async def test_apply_day_role_assign_calls_add_roles_and_returns_applied():
+    """apply_day_role assign path calls add_roles and returns 'applied'."""
+    guild, member, role = _make_guild_with_role(999001, "Day 1")
+    bot = _make_bot(guild=guild)
+
+    result = await bot.apply_day_role(
+        discord_id="111000111000111001",
+        role_id="999001",
+        action="assign",
+    )
+
+    assert result == "applied"
+    member.add_roles.assert_awaited_once_with(role)
+    member.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_day_role_unassign_calls_remove_roles_and_returns_applied():
+    """apply_day_role unassign path calls remove_roles and returns 'applied'."""
+    guild, member, role = _make_guild_with_role(999002, "Day 2")
+    bot = _make_bot(guild=guild)
+
+    result = await bot.apply_day_role(
+        discord_id="111000111000111001",
+        role_id="999002",
+        action="unassign",
+    )
+
+    assert result == "applied"
+    member.remove_roles.assert_awaited_once_with(role)
+    member.add_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_day_role_member_not_found_raises_value_error():
+    """apply_day_role raises ValueError when the Discord member is not found."""
+    guild = MagicMock()
+    response = MagicMock()
+    response.status = 404
+    response.reason = "Not Found"
+    guild.fetch_member = AsyncMock(side_effect=discord.NotFound(response, "Unknown Member"))
+    bot = _make_bot(guild=guild)
+
+    with pytest.raises(discord.NotFound):
+        await bot.apply_day_role(
+            discord_id="000000000000000000",
+            role_id="999001",
+            action="assign",
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_day_role_role_not_found_raises_value_error():
+    """apply_day_role raises ValueError when the role_id is not in the guild."""
+    guild = MagicMock()
+    member = _make_member_with_role_ops()
+    guild.fetch_member = AsyncMock(return_value=member)
+    guild.get_role.return_value = None  # role absent from guild
+    bot = _make_bot(guild=guild)
+
+    with pytest.raises(ValueError, match="999999"):
+        await bot.apply_day_role(
+            discord_id="111000111000111001",
+            role_id="999999",
+            action="assign",
+        )

--- a/bot/tests/test_discord_client.py
+++ b/bot/tests/test_discord_client.py
@@ -193,34 +193,36 @@ def _make_guild_with_role(role_id: int, role_name: str = "Day 1") -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_apply_day_role_assign_calls_add_roles_and_returns_applied():
-    """apply_day_role assign path calls add_roles and returns 'applied'."""
+    """apply_day_role assign path calls add_roles and returns ('applied', role_name)."""
     guild, member, role = _make_guild_with_role(999001, "Day 1")
     bot = _make_bot(guild=guild)
 
-    result = await bot.apply_day_role(
+    status, role_name = await bot.apply_day_role(
         discord_id="111000111000111001",
         role_id="999001",
         action="assign",
     )
 
-    assert result == "applied"
+    assert status == "applied"
+    assert role_name == "Day 1"
     member.add_roles.assert_awaited_once_with(role)
     member.remove_roles.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_apply_day_role_unassign_calls_remove_roles_and_returns_applied():
-    """apply_day_role unassign path calls remove_roles and returns 'applied'."""
+    """apply_day_role unassign path calls remove_roles and returns ('applied', role_name)."""
     guild, member, role = _make_guild_with_role(999002, "Day 2")
     bot = _make_bot(guild=guild)
 
-    result = await bot.apply_day_role(
+    status, role_name = await bot.apply_day_role(
         discord_id="111000111000111001",
         role_id="999002",
         action="unassign",
     )
 
-    assert result == "applied"
+    assert status == "applied"
+    assert role_name == "Day 2"
     member.remove_roles.assert_awaited_once_with(role)
     member.add_roles.assert_not_awaited()
 

--- a/bot/tests/test_http_api.py
+++ b/bot/tests/test_http_api.py
@@ -618,7 +618,7 @@ _ROLE_SYNC_PAYLOAD = {
 
 @pytest.mark.asyncio
 async def test_role_sync_assign_with_role_id_returns_applied(client):
-    """AC-d1: assign with discord_role_id → 200 {"status": "applied", "added": [...], "removed": []}."""
+    """AC-d1: assign with discord_role_id → 200 applied response."""
     bot = _make_mock_bot()
     bot.apply_day_role = AsyncMock(return_value=("applied", "Day 1"))
     http_api_module._bot = bot
@@ -661,14 +661,12 @@ async def test_role_sync_assign_without_role_id_returns_skipped(client, caplog):
     assert data["status"] == "skipped"
     assert "discord_role_id" in data.get("reason", "")
     bot.apply_day_role.assert_not_awaited()
-    assert any(
-        "discord_role_id" in r.message.lower() for r in caplog.records
-    )
+    assert any("discord_role_id" in r.message.lower() for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_role_sync_unassign_with_role_id_returns_applied(client):
-    """AC-d3: unassign with discord_role_id → 200 {"status": "applied", "added": [], "removed": [...]}."""
+    """AC-d3: unassign with discord_role_id → 200 applied, removed populated."""
     bot = _make_mock_bot()
     bot.apply_day_role = AsyncMock(return_value=("applied", "Day 1"))
     http_api_module._bot = bot
@@ -706,9 +704,7 @@ async def test_role_sync_member_not_found_returns_404(client):
     response = MagicMock()
     response.status = 404
     response.reason = "Not Found"
-    bot.apply_day_role = AsyncMock(
-        side_effect=discord.NotFound(response, "Unknown Member")
-    )
+    bot.apply_day_role = AsyncMock(side_effect=discord.NotFound(response, "Unknown Member"))
     http_api_module._bot = bot
     async with client as c:
         response_http = await c.post(

--- a/bot/tests/test_http_api.py
+++ b/bot/tests/test_http_api.py
@@ -7,9 +7,10 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
 
 import app.http_api as http_api_module
-from app.http_api import app
+from app.http_api import RoleSyncRequest, app
 
 API_KEY = "test-key"
 AUTH_HEADER = {"Authorization": f"Bearer {API_KEY}"}
@@ -539,3 +540,61 @@ async def test_notify_discord_forbidden_logs_raw_text(client, caplog):
     assert "secret-channel" not in resp.json()["detail"]
     # Raw text MUST appear in the warning log.
     assert any("secret-channel" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# RoleSyncRequest model
+# ---------------------------------------------------------------------------
+
+
+def test_role_sync_request_full_payload():
+    """RoleSyncRequest parses a complete v1.1 payload with discord_role_id."""
+    req = RoleSyncRequest(
+        discord_id="111000111000111001",
+        siege_id=42,
+        action="assign",
+        assigned_at="2026-05-14T13:52:18.247Z",
+        correlation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        day_number=1,
+        discord_role_id="999000999000999001",
+    )
+    assert req.discord_id == "111000111000111001"
+    assert req.action == "assign"
+    assert req.discord_role_id == "999000999000999001"
+    assert req.day_number == 1
+
+
+def test_role_sync_request_minimal_payload():
+    """RoleSyncRequest accepts payload without optional discord_role_id/day_number."""
+    req = RoleSyncRequest(
+        discord_id="111000111000111001",
+        siege_id=42,
+        action="unassign",
+        assigned_at="2026-05-14T13:52:18.247Z",
+        correlation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    )
+    assert req.discord_role_id is None
+    assert req.day_number is None
+
+
+def test_role_sync_request_invalid_action_raises():
+    """RoleSyncRequest rejects action values outside assign/unassign."""
+    with pytest.raises((ValidationError, ValueError)):
+        RoleSyncRequest(
+            discord_id="111000111000111001",
+            siege_id=42,
+            action="delete",
+            assigned_at="2026-05-14T13:52:18.247Z",
+            correlation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        )
+
+
+def test_role_sync_request_missing_required_field_raises():
+    """RoleSyncRequest raises when discord_id is absent."""
+    with pytest.raises((ValidationError, TypeError)):
+        RoleSyncRequest(
+            siege_id=42,
+            action="assign",
+            assigned_at="2026-05-14T13:52:18.247Z",
+            correlation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        )

--- a/bot/tests/test_http_api.py
+++ b/bot/tests/test_http_api.py
@@ -34,6 +34,7 @@ def _make_mock_bot(ready: bool = True) -> MagicMock:
     bot.post_message = AsyncMock()
     bot.post_image = AsyncMock()
     bot.get_members = AsyncMock(return_value=[])
+    bot.apply_day_role = AsyncMock(return_value=("applied", "Day 1"))
     return bot
 
 
@@ -598,3 +599,156 @@ def test_role_sync_request_missing_required_field_raises():
             assigned_at="2026-05-14T13:52:18.247Z",
             correlation_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/role-sync
+# ---------------------------------------------------------------------------
+
+_ROLE_SYNC_PAYLOAD = {
+    "discord_id": "111000111000111001",
+    "siege_id": 42,
+    "action": "assign",
+    "assigned_at": "2026-05-14T13:52:18.247Z",
+    "correlation_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "day_number": 1,
+    "discord_role_id": "888000888000888001",
+}
+
+
+@pytest.mark.asyncio
+async def test_role_sync_assign_with_role_id_returns_applied(client):
+    """AC-d1: assign with discord_role_id → 200 {"status": "applied", "added": [...], "removed": []}."""
+    bot = _make_mock_bot()
+    bot.apply_day_role = AsyncMock(return_value=("applied", "Day 1"))
+    http_api_module._bot = bot
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=_ROLE_SYNC_PAYLOAD,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "applied"
+    assert data["added"] == ["Day 1"]
+    assert data["removed"] == []
+    bot.apply_day_role.assert_awaited_once_with(
+        discord_id="111000111000111001",
+        role_id="888000888000888001",
+        action="assign",
+    )
+
+
+@pytest.mark.asyncio
+async def test_role_sync_assign_without_role_id_returns_skipped(client, caplog):
+    """AC-d2: assign with discord_role_id absent → 200 skipped + WARNING log."""
+    bot = _make_mock_bot()
+    http_api_module._bot = bot
+    payload = {k: v for k, v in _ROLE_SYNC_PAYLOAD.items() if k != "discord_role_id"}
+
+    caplog.set_level(logging.WARNING, logger="app.http_api")
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=payload,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "skipped"
+    assert "discord_role_id" in data.get("reason", "")
+    bot.apply_day_role.assert_not_awaited()
+    assert any(
+        "discord_role_id" in r.message.lower() for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_role_sync_unassign_with_role_id_returns_applied(client):
+    """AC-d3: unassign with discord_role_id → 200 {"status": "applied", "added": [], "removed": [...]}."""
+    bot = _make_mock_bot()
+    bot.apply_day_role = AsyncMock(return_value=("applied", "Day 1"))
+    http_api_module._bot = bot
+    payload = {**_ROLE_SYNC_PAYLOAD, "action": "unassign"}
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=payload,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "applied"
+    assert data["added"] == []
+    assert data["removed"] == ["Day 1"]
+
+
+@pytest.mark.asyncio
+async def test_role_sync_missing_auth_returns_401(client):
+    """AC-d4: missing/wrong Bearer token → 401."""
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=_ROLE_SYNC_PAYLOAD,
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_role_sync_member_not_found_returns_404(client):
+    """AC-d5: member not in guild → 404."""
+    bot = _make_mock_bot()
+    response = MagicMock()
+    response.status = 404
+    response.reason = "Not Found"
+    bot.apply_day_role = AsyncMock(
+        side_effect=discord.NotFound(response, "Unknown Member")
+    )
+    http_api_module._bot = bot
+    async with client as c:
+        response_http = await c.post(
+            "/api/role-sync",
+            json=_ROLE_SYNC_PAYLOAD,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response_http.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_role_sync_role_not_found_returns_404(client):
+    """AC-d6: role_id not in guild → 404."""
+    bot = _make_mock_bot()
+    bot.apply_day_role = AsyncMock(
+        side_effect=ValueError("Role '888000888000888001' not found in guild")
+    )
+    http_api_module._bot = bot
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=_ROLE_SYNC_PAYLOAD,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_role_sync_malformed_payload_returns_422(client):
+    """AC-d7: missing required field discord_id → 422 (FastAPI validation)."""
+    bot = _make_mock_bot()
+    http_api_module._bot = bot
+    payload = {k: v for k, v in _ROLE_SYNC_PAYLOAD.items() if k != "discord_id"}
+    async with client as c:
+        response = await c.post(
+            "/api/role-sync",
+            json=payload,
+            headers=AUTH_HEADER,
+        )
+    http_api_module._bot = None
+    assert response.status_code == 422

--- a/docs/webhooks/day-role-sync.md
+++ b/docs/webhooks/day-role-sync.md
@@ -276,6 +276,6 @@ Receivers SHOULD persist idempotency state (the last processed `(discord_id, ass
 
 **Canonical producer:** `glitchwerks/rsl-siege-manager` (this repo) — `backend/app/services/bot_client.py` implements the producer side and is the authoritative reference for how to build a contract-conforming sender.
 
-**Second conforming producer:** `glitchwerks/mom-bot` — implements the same contract as a bundled sidecar. Its implementation is a second conforming producer, not the canonical reference.
+**Canonical bundled-bot receiver:** `glitchwerks/rsl-siege-manager` (this repo) — `bot/app/http_api.py` (`POST /api/role-sync`) and `bot/app/discord_client.py` (`apply_day_role`) implement the receiver side as a bundled sidecar, now the canonical reference for contract-conforming receivers. Implemented in #458 item D.
 
 See coord issue `glitchwerks/rsl-mom-apps#9` for the v1.1 contract change that introduced `discord_role_id`.


### PR DESCRIPTION
## Summary

Closes #458 (item D, completes the umbrella). Adds the bundled bot's `POST /api/role-sync` receiver, conforming to day-role-sync contract v1.1. With this PR merged, item #458 closes entirely — items A, B, C all landed in prior PRs (#459, #460, #461).

The bundled siege-bot becomes the **canonical conforming receiver** for the contract — establishing producer/receiver symmetry per the rule shipped in PR #459.

## Locked design decisions

These were resolved upfront to avoid the kind of architectural rework that pivoted item B:

| Decision | Choice | Rationale |
|---|---|---|
| **Idempotency persistence** | Stateless — let Discord absorb dupes | Discord's `add_roles`/`remove_roles` are API-level idempotent. No new sqlite, no schema, no startup seed. |
| **Receiver feature gate** | None — always-on when mounted | Producer-side `DAY_ROLE_SYNC_ENABLED` is the only gate. Symmetric kill-switch on receiver would just duplicate state. |
| **Missing `discord_role_id` in payload** | Return `200 {"status": "skipped"}` + WARNING log | Producer's `_handle_sync_response` already treats `"skipped"` as success — no retry, no producer-side failure. Bundled bot has no local fallback map (would violate stateless decision). |
| **PR shape** | One PR for all of item D | Item is bounded: 1 endpoint + 1 seam method + fake support + tests + doc tweak. |

## Changes

| # | Commit | Scope |
|---|---|---|
| 1 | `b8ff8b8` | `feat(bot)`: add `RoleSyncRequest` Pydantic model |
| 2 | `180d49b` | `feat(bot)`: add `apply_day_role` seam in `discord_client.py` + `_FakeRole`/`_FakeMember.add_roles`/`remove_roles`/`_FakeGuild.get_role`/`FakeDiscordClient.apply_day_role` in `fake_discord.py` |
| 3 | `9ab3f48` | `feat(bot)`: add `POST /api/role-sync` receiver |
| 4 | `47577e0` | `docs(webhooks)`: mark bundled bot as implemented canonical receiver |
| 5 | `13525c9` | `style(bot)`: black + ruff E501 fixup |

## Files modified

- `bot/app/http_api.py` — `RoleSyncRequest` model + `POST /api/role-sync` route
- `bot/app/discord_client.py` — `apply_day_role` seam
- `bot/app/fake_discord.py` — fake role + member-roles + guild role lookup + receiver seam
- `bot/tests/test_http_api.py` — 11 new tests
- `bot/tests/test_discord_client.py` — 4 new seam tests
- `docs/webhooks/day-role-sync.md` — Reference Implementations section update

## Test plan

- [x] 15 new tests — 4 model + 4 seam + 7 route — covering AC-d1..d7:
  - AC-d1 assign with `discord_role_id` → 200 `{"status": "applied", "added": ["<role-name>"], "removed": []}`
  - AC-d2 assign without `discord_role_id` → 200 `{"status": "skipped", "reason": ...}` + WARNING log (seam NOT called)
  - AC-d3 unassign → 200 `{"status": "applied", "added": [], "removed": ["<role-name>"]}`
  - AC-d4 missing/wrong auth → 401
  - AC-d5 member-not-found → 404
  - AC-d6 role-not-found → 404
  - AC-d7 malformed payload (missing required field) → 422
- [x] Bot test suite: 50 → 65 passed; no regressions.
- [x] `ruff check` clean.
- [x] `black --check` clean.
- [x] Response shape `{"status", "added", "removed"}` matches the producer's `_handle_sync_response` parser exactly — no backend-side change needed in this PR.
- [ ] Reviewer confirms `Literal["assign", "unassign"]` validation produces the correct 422 shape vs the existing convention of plain `str` + custom validator.
- [ ] Post-merge: deploy the bundled bot, configure `DAY_ROLE_SYNC_URL` on siege-web to point at it, smoke-test with `DAY_ROLE_SYNC_ENABLED=false`, then flip to `true` and verify a real day-assignment toggles the Discord role end-to-end.

## Coordination

- Coord issue: `glitchwerks/rsl-mom-apps#9` — at-least-one-conforming-receiver-deployed checkbox unblocks once this PR is deployed.
- Contract: `docs/webhooks/day-role-sync.md` (this repo, canonical).

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
