### PR TITLE
ci: post Discord release announcement on release publication

### DIFF
--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -1,0 +1,158 @@
+# notify-discord-release.yml
+#
+# Posts a Discord embed to the release-announcement channel whenever a GitHub
+# Release is published on this repo.
+#
+# ── Required secret ──────────────────────────────────────────────────────────
+#
+#   DISCORD_RELEASE_WEBHOOK_URL
+#     The full Discord webhook URL for the target channel.
+#     Add it under: GitHub → Settings → Secrets and variables → Actions →
+#     Repository secrets.
+#     To create a webhook: Discord server → Channel settings →
+#     Integrations → Webhooks → New Webhook → Copy Webhook URL.
+#
+# ── What triggers a post ─────────────────────────────────────────────────────
+#
+#   Only fires on the initial publication of a release (created_at ==
+#   published_at per coord §R7).  Body-edit re-publications are skipped with
+#   an annotation so the log is clear but no false post is sent.
+#
+# ── Embed colour ─────────────────────────────────────────────────────────────
+#
+#   0xC0392B — a muted crimson/siege-red, distinct from Discord blurple
+#   (0x5865F2) used by mom-bot.  Users scrolling the Discord channel can
+#   immediately identify siege-web announcements vs mom-bot announcements at
+#   a glance by the colour stripe on the left of the embed.
+#
+# ── No third-party Actions ───────────────────────────────────────────────────
+#
+#   The POST is made with plain curl + jq.  Both are pre-installed on
+#   ubuntu-latest.  No action pinning needed for runner built-ins.
+#
+# ── Highlights extraction ────────────────────────────────────────────────────
+#
+#   scripts/extract_highlights.py reads the release body from stdin and prints
+#   the Highlights section (or a fallback) to stdout.  Unit tests live at
+#   scripts/tests/test_extract_highlights.py and run in the CI
+#   `validation-script-tests` job on every PR.
+
+name: Notify Discord — Release Published
+
+on:
+  release:
+    types: [published]
+
+# No GitHub API writes — read-only is sufficient.
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Post Discord Release Embed
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Idempotency guard (coord §R7) ─────────────────────────────────────
+      # A re-publication (body edit) sets published_at > created_at.
+      # Skip those runs so we never double-post.
+      - name: Skip re-publications
+        if: github.event.release.created_at != github.event.release.published_at
+        run: |
+          echo "::notice::Skipping Discord notification — this is a re-publication (body edit), not the initial publish. created_at=${{ github.event.release.created_at }} published_at=${{ github.event.release.published_at }}"
+          exit 0
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # ── Build the embed description ───────────────────────────────────────
+      # extract_highlights.py reads the release body from stdin, returns the
+      # ## Highlights section (emoji optional), applies the 1500-char soft cap,
+      # and falls back to "<name> published. View notes: <url>" if missing.
+      - name: Extract Highlights description
+        id: highlights
+        env:
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_TAG:  ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_URL:  ${{ github.event.release.html_url }}
+        run: |
+          description=$(printf '%s' "$RELEASE_BODY" | python3 scripts/extract_highlights.py \
+            --tag  "$RELEASE_TAG" \
+            --name "$RELEASE_NAME" \
+            --url  "$RELEASE_URL")
+
+          # Write to GITHUB_OUTPUT using a heredoc so multi-line values are
+          # handled safely by the Actions runner (EOF delimiter is unique).
+          {
+            echo "description<<__HIGHLIGHTS_EOF__"
+            printf '%s' "$description"
+            echo ""
+            echo "__HIGHLIGHTS_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── POST to Discord ───────────────────────────────────────────────────
+      - name: Post embed to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_TAG:         ${{ github.event.release.tag_name }}
+          RELEASE_URL:         ${{ github.event.release.html_url }}
+          RELEASE_PRERELEASE:  ${{ github.event.release.prerelease }}
+          RELEASE_AUTHOR:      ${{ github.event.release.author.login }}
+          RELEASE_PUBLISHED:   ${{ github.event.release.published_at }}
+          DESCRIPTION:         ${{ steps.highlights.outputs.description }}
+        run: |
+          # ── Title (coord §R3, §R8) ──────────────────────────────────────
+          # Prefix [pre-release] when prerelease == true.
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            title="[pre-release] siege-web ${RELEASE_TAG}"
+          else
+            title="siege-web ${RELEASE_TAG}"
+          fi
+
+          # ── Footer (coord §R3) ──────────────────────────────────────────
+          # Omit footer entirely if author is absent (defensive).
+          if [ -n "$RELEASE_AUTHOR" ]; then
+            footer_json=$(jq -n --arg text "Published by ${RELEASE_AUTHOR}" \
+              '{"text": $text}')
+          else
+            footer_json="null"
+          fi
+
+          # ── Embed colour ────────────────────────────────────────────────
+          # 0xC0392B = 12597547 decimal — siege/crimson red, distinct from
+          # mom-bot's Discord blurple (0x5865F2 = 5793522).
+          COLOR=12597547
+
+          # ── Build payload ───────────────────────────────────────────────
+          payload=$(jq -n \
+            --arg title       "$title" \
+            --arg url         "$RELEASE_URL" \
+            --arg description "$DESCRIPTION" \
+            --argjson color   "$COLOR" \
+            --argjson footer  "$footer_json" \
+            --arg timestamp   "$RELEASE_PUBLISHED" \
+            '{
+              "embeds": [{
+                "title":       $title,
+                "url":         $url,
+                "description": $description,
+                "color":       $color,
+                "footer":      (if $footer == null then empty else $footer end),
+                "timestamp":   $timestamp
+              }]
+            }')
+
+          # ── Send ─────────────────────────────────────────────────────────
+          http_status=$(curl -s -o /tmp/discord_response.txt -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK_URL")
+
+          echo "Discord responded with HTTP ${http_status}"
+          if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+            echo "Discord webhook error response:"
+            cat /tmp/discord_response.txt
+            exit 1
+          fi

--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -55,21 +55,37 @@ jobs:
     steps:
       # ── Idempotency guard (coord §R7) ─────────────────────────────────────
       # A re-publication (body edit) sets published_at > created_at.
-      # Skip those runs so we never double-post.
+      # Log a notice and let the job succeed without posting.
+      # All downstream steps are gated on the inverse condition so they
+      # only execute on the initial publication.
       - name: Skip re-publications
         if: github.event.release.created_at != github.event.release.published_at
         run: |
           echo "::notice::Skipping Discord notification — this is a re-publication (body edit), not the initial publish. created_at=${{ github.event.release.created_at }} published_at=${{ github.event.release.published_at }}"
-          exit 0
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        if: github.event.release.created_at == github.event.release.published_at
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      # ── Validate secrets ──────────────────────────────────────────────────
+      # Fail fast if the webhook URL is not configured, rather than
+      # reaching the POST step and getting an empty-URL curl error.
+      - name: Validate webhook secret
+        if: github.event.release.created_at == github.event.release.published_at
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "::error::DISCORD_RELEASE_WEBHOOK_URL secret is not configured"
+            exit 1
+          fi
 
       # ── Build the embed description ───────────────────────────────────────
       # extract_highlights.py reads the release body from stdin, returns the
       # ## Highlights section (emoji optional), applies the 1500-char soft cap,
       # and falls back to "<name> published. View notes: <url>" if missing.
       - name: Extract Highlights description
+        if: github.event.release.created_at == github.event.release.published_at
         id: highlights
         env:
           RELEASE_BODY: ${{ github.event.release.body }}
@@ -93,6 +109,7 @@ jobs:
 
       # ── POST to Discord ───────────────────────────────────────────────────
       - name: Post embed to Discord
+        if: github.event.release.created_at == github.event.release.published_at
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
           RELEASE_TAG:         ${{ github.event.release.tag_name }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,6 +126,70 @@ After `deploy.yml` finishes (3 jobs: Deploy API / Deploy Bot / Deploy Frontend, 
 - The frontend changelog dropdown shows the new entry as latest (bell icon may need a hard refresh to invalidate the cached bundle)
 - The Container App revision UI for all three apps in `siege-web-prod` shows the new image SHA tag and `Healthy / Running / 100% traffic`
 
+### 8. Check Discord
+
+Publishing the GitHub Release (the `gh release create` command in step 6) fires
+the `notify-discord-release.yml` workflow automatically. Within a minute of
+publication a crimson-red embed should appear in the release-announcement channel.
+
+The embed title is `siege-web v<X.Y.Z>` (prefixed `[pre-release]` for
+pre-releases). Its description is pulled from the `## 📣 Highlights` section of
+the release notes (see [Discord embed content](#discord-embed-content) below).
+
+If the embed does not appear, check the Actions tab for the
+`Notify Discord — Release Published` workflow run.
+
+## Discord embed content
+
+### `## Highlights` convention
+
+The Discord notification pulls its description from a `## Highlights` section in
+the GitHub Release body. This section should contain 1–3 sentences or 3–5 bullets
+describing the **user-visible impact** of the release — what changed, what's new,
+what was fixed. Markdown bullet lists render in Discord.
+
+```markdown
+## 📣 Highlights   ← emoji is optional; plain ## Highlights also works
+
+- New siege-planner calendar view for officers
+- Auto-consult telemetry now captured for performance tuning
+- Login auth match corrected for username-only lookups
+```
+
+`v1.2.0` used `## Highlights` (no emoji); both forms are accepted.
+
+If no `## Highlights` section is present the workflow posts a minimal fallback
+(`v<X.Y.Z> published. View notes: <url>`) — **it never silently drops the post**,
+but the fallback is not very informative. Adding the section is strongly preferred.
+
+### Required repo secret
+
+The workflow reads `DISCORD_RELEASE_WEBHOOK_URL` from repository secrets.
+**Without this secret the workflow will fail** (no post is sent).
+
+To add the secret:
+
+1. In Discord: open the target server → channel settings → **Integrations** →
+   **Webhooks** → **New Webhook** → configure and copy the URL.
+2. In GitHub: **Settings** → **Secrets and variables** → **Actions** →
+   **Repository secrets** → **New repository secret** →
+   name `DISCORD_RELEASE_WEBHOOK_URL`, paste the URL.
+
+### GitHub Releases are still cut manually
+
+Auto-creation of GitHub Releases from tag pushes is **out of scope** for this
+workflow. The `notify-discord-release.yml` workflow reacts to a Release being
+published; it does not create one. Releases continue to be cut with:
+
+```powershell
+gh release create v<X.Y.Z> `
+  --title "v<X.Y.Z> - <headline>" `
+  --notes-file .tmp/release-notes-v<X.Y.Z>.md
+```
+
+A future automation for auto-creating Releases from tag pushes can be tracked
+as a separate issue.
+
 ## What auto-deploy does (and does not) do
 
 `deploy.yml` triggers on `push` to a tag matching `v*`. It:

--- a/scripts/extract_highlights.py
+++ b/scripts/extract_highlights.py
@@ -72,7 +72,7 @@ def apply_length_cap(text: str, url: str) -> str:
 
     Returns:
         The original text (unchanged) if ``len(text) <= 1500``, otherwise the
-        text truncated to 1497 chars + ``…`` followed by a newline and the URL.
+        text truncated to 1499 chars + ``…`` followed by a newline and the URL.
     """
     if len(text) <= _SOFT_CAP:
         return text

--- a/scripts/extract_highlights.py
+++ b/scripts/extract_highlights.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Extract the Highlights section from a GitHub Release body for Discord notifications.
+
+Reads the release body from stdin, extracts the text under a ``## Highlights``
+heading (with or without the ``📣`` emoji), applies a 1500-character soft cap,
+and prints the result to stdout.
+
+If no Highlights section is found (or it is empty after stripping), prints a
+fallback line of the form::
+
+    <release name or tag> published. View notes: <url>
+
+**Always exits 0** — the workflow must post even when the section is absent.
+
+Usage (matches how the workflow invokes it)::
+
+    python scripts/extract_highlights.py \\
+        --tag  "v1.2.0" \\
+        --name "v1.2.0 - Headline" \\
+        --url  "https://github.com/glitchwerks/.../releases/tag/v1.2.0" \\
+        < release_body.txt
+"""
+
+import argparse
+import re
+import sys
+
+# Maximum description length before truncation (coord §R5).
+_SOFT_CAP = 1500
+# Characters reserved for the ellipsis when truncating.
+_ELLIPSIS = "…"  # Unicode HORIZONTAL ELLIPSIS (…)
+# Pattern matching a Highlights heading: ## (optional emoji) Highlights, case-insensitive.
+_HIGHLIGHTS_RE = re.compile(
+    r"^##\s+(?:📣\s+)?highlights\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Pattern matching any ## heading (used as the stop marker).
+_NEXT_HEADING_RE = re.compile(r"^##\s+", re.MULTILINE)
+
+
+def extract_highlights(body: str) -> str | None:
+    """Return the text under the Highlights heading, or None if absent/empty.
+
+    Args:
+        body: The full GitHub Release body text.
+
+    Returns:
+        Stripped text from the Highlights section, or ``None`` if the section
+        does not exist or contains only whitespace.
+    """
+    match = _HIGHLIGHTS_RE.search(body)
+    if not match:
+        return None
+
+    # Text starts immediately after the heading line.
+    after_heading = body[match.end():]
+
+    # Find the next ## heading within that remainder.
+    stop = _NEXT_HEADING_RE.search(after_heading)
+    section = after_heading[: stop.start()] if stop else after_heading
+
+    stripped = section.strip()
+    return stripped if stripped else None
+
+
+def apply_length_cap(text: str, url: str) -> str:
+    """Truncate *text* to 1500 chars if needed, appending an ellipsis and URL line.
+
+    Args:
+        text: The description text to potentially truncate.
+        url: The release HTML URL, appended when truncation occurs.
+
+    Returns:
+        The original text (unchanged) if ``len(text) <= 1500``, otherwise the
+        text truncated to 1497 chars + ``…`` followed by a newline and the URL.
+    """
+    if len(text) <= _SOFT_CAP:
+        return text
+    truncated = text[:_SOFT_CAP - 1] + _ELLIPSIS
+    return f"{truncated}\nView full release notes: {url}"
+
+
+def build_fallback(tag: str, name: str, url: str) -> str:
+    """Build the fallback description when no Highlights section exists.
+
+    Args:
+        tag: The release tag (e.g. ``v1.2.0``).
+        name: The release name (may be empty).
+        url: The release HTML URL.
+
+    Returns:
+        A one-line fallback string per coord §R6.
+    """
+    label = name.strip() if name.strip() else tag
+    return f"{label} published. View notes: {url}"
+
+
+def main() -> None:
+    """Entry point — parse args, read stdin, print result, exit 0."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Release tag (e.g. v1.2.0)")
+    parser.add_argument("--name", default="", help="Release name (may be empty)")
+    parser.add_argument("--url", required=True, help="Release HTML URL")
+    args = parser.parse_args()
+
+    body = sys.stdin.read()
+
+    highlights = extract_highlights(body)
+    if highlights:
+        description = apply_length_cap(highlights, args.url)
+    else:
+        description = build_fallback(args.tag, args.name, args.url)
+
+    print(description, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_extract_highlights.py
+++ b/scripts/tests/test_extract_highlights.py
@@ -8,7 +8,7 @@ Fixture cases exercised:
   1. Highlights present with plain heading (## Highlights)
   2. Highlights present with emoji heading (## 📣 Highlights)
   3. Highlights section is multi-paragraph
-  4. Body oversized — truncated to 1497 chars + ellipsis + URL line
+  4. Body oversized — truncated to 1499 chars + ellipsis + URL line
   5. Body exactly at the 1500-char boundary — NOT truncated
   6. No Highlights section — fallback with release name + URL
   7. No Highlights section, no release name — fallback uses tag
@@ -177,9 +177,13 @@ class TestHighlightsPresent:
 
 class TestLengthCap:
     def test_oversized_is_truncated(self):
+        # Expected: 1499 body chars + "…" (1 char) + "\n" (1 char)
+        # + "View full release notes: " (25 chars) + URL.
+        # Total = 1499 + 1 + 1 + 25 + len(RELEASE_URL) = 1526 + len(RELEASE_URL).
+        expected_len = 1499 + 1 + 1 + len("View full release notes: ") + len(RELEASE_URL)
         result = run_script(OVERSIZED_BODY)
         assert result.returncode == 0
-        assert len(result.stdout.rstrip("\n")) <= 1500 + len(f"\nView full release notes: {RELEASE_URL}") + 50
+        assert len(result.stdout) == expected_len
 
     def test_oversized_ends_with_ellipsis(self):
         result = run_script(OVERSIZED_BODY)

--- a/scripts/tests/test_extract_highlights.py
+++ b/scripts/tests/test_extract_highlights.py
@@ -1,0 +1,240 @@
+"""Tests for scripts/extract_highlights.py.
+
+Covers the Highlights-extraction logic used by the Discord release-notification
+workflow. The script is invoked from the workflow with the GitHub Release body
+piped to stdin; it prints the extracted (or fallback) description to stdout.
+
+Fixture cases exercised:
+  1. Highlights present with plain heading (## Highlights)
+  2. Highlights present with emoji heading (## 📣 Highlights)
+  3. Highlights section is multi-paragraph
+  4. Body oversized — truncated to 1497 chars + ellipsis + URL line
+  5. Body exactly at the 1500-char boundary — NOT truncated
+  6. No Highlights section — fallback with release name + URL
+  7. No Highlights section, no release name — fallback uses tag
+  8. Highlights text is empty (heading with nothing before next ##) — fallback
+  9. Case-insensitive match (## HIGHLIGHTS)
+
+Exit codes:
+  0 — always (the script must not fail even on missing sections)
+
+Usage (matches how the workflow calls it):
+    python scripts/extract_highlights.py \
+        --tag "v1.2.0" \
+        --name "v1.2.0 - Headline" \
+        --url "https://github.com/.../releases/tag/v1.2.0" \
+        < release_body.txt
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "extract_highlights.py"
+
+RELEASE_URL = "https://github.com/glitchwerks/rsl-siege-manager/releases/tag/v1.2.0"
+RELEASE_TAG = "v1.2.0"
+RELEASE_NAME = "v1.2.0 - The Siege Begins"
+
+
+def run_script(body: str, tag: str = RELEASE_TAG, name: str = RELEASE_NAME, url: str = RELEASE_URL) -> subprocess.CompletedProcess:
+    """Run extract_highlights.py with the given release body on stdin."""
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--tag", tag,
+            "--name", name,
+            "--url", url,
+        ],
+        input=body,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+PLAIN_BODY = """\
+## What's Changed
+
+Minor dependency updates.
+
+## Highlights
+
+This release ships the new siege-planner feature.
+Officers can now assign raid windows directly from the calendar view.
+
+## Full Changelog
+
+https://github.com/...
+"""
+
+EMOJI_BODY = """\
+## What's Changed
+
+Some fixes.
+
+## 📣 Highlights
+
+Emoji heading variant — same extraction should apply.
+
+## Notes
+"""
+
+MULTI_PARA_BODY = """\
+## Highlights
+
+First paragraph describing the big feature.
+
+Second paragraph with more detail.
+
+- Bullet one
+- Bullet two
+
+## Full Changelog
+"""
+
+OVERSIZED_BASE = "x" * 2000
+OVERSIZED_BODY = f"## Highlights\n\n{OVERSIZED_BASE}\n\n## Other\n"
+
+# Exactly 1500 chars in the highlights section — must NOT truncate.
+AT_LIMIT_BODY = f"## Highlights\n\n{'y' * 1500}\n\n## Other\n"
+
+NO_HIGHLIGHTS_BODY = """\
+## What's Changed
+
+- Fix login bug (#123)
+- Update dependencies
+
+## Full Changelog
+"""
+
+EMPTY_HIGHLIGHTS_BODY = """\
+## Highlights
+
+## Full Changelog
+
+Nothing here.
+"""
+
+UPPERCASE_BODY = """\
+## HIGHLIGHTS
+
+All-caps heading should still match.
+
+## Notes
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestHighlightsPresent:
+    def test_plain_heading_extracts_content(self):
+        result = run_script(PLAIN_BODY)
+        assert result.returncode == 0
+        assert "siege-planner" in result.stdout
+        assert "calendar view" in result.stdout
+
+    def test_plain_heading_strips_heading_line(self):
+        result = run_script(PLAIN_BODY)
+        assert "## Highlights" not in result.stdout
+
+    def test_emoji_heading_extracts_content(self):
+        result = run_script(EMOJI_BODY)
+        assert result.returncode == 0
+        assert "Emoji heading variant" in result.stdout
+
+    def test_emoji_heading_strips_heading_line(self):
+        result = run_script(EMOJI_BODY)
+        assert "## 📣 Highlights" not in result.stdout
+
+    def test_multi_paragraph_preserved(self):
+        result = run_script(MULTI_PARA_BODY)
+        assert result.returncode == 0
+        assert "First paragraph" in result.stdout
+        assert "Second paragraph" in result.stdout
+        assert "Bullet one" in result.stdout
+
+    def test_stops_at_next_heading(self):
+        result = run_script(PLAIN_BODY)
+        # Content after ## Full Changelog should NOT appear
+        assert "Full Changelog" not in result.stdout
+
+    def test_case_insensitive_match(self):
+        result = run_script(UPPERCASE_BODY)
+        assert result.returncode == 0
+        assert "All-caps" in result.stdout
+
+
+class TestLengthCap:
+    def test_oversized_is_truncated(self):
+        result = run_script(OVERSIZED_BODY)
+        assert result.returncode == 0
+        assert len(result.stdout.rstrip("\n")) <= 1500 + len(f"\nView full release notes: {RELEASE_URL}") + 50
+
+    def test_oversized_ends_with_ellipsis(self):
+        result = run_script(OVERSIZED_BODY)
+        assert "…" in result.stdout
+
+    def test_oversized_appends_url_line(self):
+        result = run_script(OVERSIZED_BODY)
+        assert f"View full release notes: {RELEASE_URL}" in result.stdout
+
+    def test_at_limit_not_truncated(self):
+        result = run_script(AT_LIMIT_BODY)
+        assert result.returncode == 0
+        assert "…" not in result.stdout
+        assert "View full release notes" not in result.stdout
+        # All 1500 'y' chars should be present
+        assert "y" * 100 in result.stdout
+
+
+class TestMissingSummaryFallback:
+    def test_no_highlights_uses_fallback(self):
+        result = run_script(NO_HIGHLIGHTS_BODY)
+        assert result.returncode == 0
+        assert RELEASE_URL in result.stdout
+
+    def test_no_highlights_includes_release_name(self):
+        result = run_script(NO_HIGHLIGHTS_BODY)
+        assert RELEASE_NAME in result.stdout
+
+    def test_no_highlights_no_name_uses_tag(self):
+        result = run_script(NO_HIGHLIGHTS_BODY, name="")
+        assert result.returncode == 0
+        assert RELEASE_TAG in result.stdout
+        assert RELEASE_URL in result.stdout
+
+    def test_empty_highlights_uses_fallback(self):
+        """A ## Highlights heading with no content before next ## counts as missing."""
+        result = run_script(EMPTY_HIGHLIGHTS_BODY)
+        assert result.returncode == 0
+        assert RELEASE_URL in result.stdout
+
+    def test_fallback_does_not_include_changelog_content(self):
+        """The fallback must not accidentally include unrelated body text."""
+        result = run_script(NO_HIGHLIGHTS_BODY)
+        assert "Fix login bug" not in result.stdout
+
+
+class TestAlwaysSucceeds:
+    def test_empty_body(self):
+        result = run_script("")
+        assert result.returncode == 0
+
+    def test_body_is_only_whitespace(self):
+        result = run_script("   \n\n  ")
+        assert result.returncode == 0
+
+    def test_no_stderr_on_normal_input(self):
+        result = run_script(PLAIN_BODY)
+        assert result.stderr == ""


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/notify-discord-release.yml` triggered on `release: published`
- Extracts `## Highlights` (or `## 📣 Highlights`) from the release body via `scripts/extract_highlights.py`; falls back to `<name> published. View notes: <url>` when absent — never silently drops the post
- Posts a crimson-red Discord embed (`0xC0392B`) with title, URL, description, footer (`Published by <author>`), and timestamp; colour is distinct from mom-bot's Discord blurple (`0x5865F2`) so channel readers can tell the two apart at a glance
- Idempotency guard (coord §R7): skips re-publications where `published_at != created_at` (body-edit events) with a `notice::` annotation
- Pre-release flag (coord §R8): prefixes embed title with `[pre-release]` when `release.prerelease == true`
- 1500-char soft cap (coord §R5): truncates to 1497 chars + `…` and appends `View full release notes: <url>` on a new line
- 19-case unit test suite (`scripts/tests/test_extract_highlights.py`) runs in the existing `Validation Script Tests` CI job
- Updates `RELEASING.md` with the `## Highlights` authoring convention, the required secret, and a note that Releases are still cut manually

## Release creation is still manual

This workflow **reacts** to a GitHub Release being published — it does not create one. Releases continue to be cut with `gh release create vX.Y.Z ...` as documented in `RELEASING.md`. Auto-creation of GitHub Releases from tag pushes is out of scope for this PR and can be tracked as a follow-up issue.

## Required repo secret

The workflow reads `DISCORD_RELEASE_WEBHOOK_URL` from repository secrets. Without this secret the workflow fails (no post is sent). Setup instructions are in `RELEASING.md § Required repo secret`.

## Test plan

- [ ] Add `DISCORD_RELEASE_WEBHOOK_URL` to repo secrets (Discord: channel → Integrations → Webhooks → New Webhook → Copy URL)
- [ ] Cut a test pre-release: `gh release create v0.0.1-test-discord --prerelease --title "v0.0.1-test-discord" --notes $'## 📣 Highlights\n\nTest embed from notify-discord-release.yml.'`
- [ ] Verify a `[pre-release] siege-web v0.0.1-test-discord` embed appears in Discord with crimson colour and the Highlights text as description
- [ ] Edit the release body in GitHub UI (triggers re-publication) — confirm the workflow runs but posts nothing (notice annotation in the log, no second Discord message)
- [ ] Delete the test release and tag: `gh release delete v0.0.1-test-discord -y && git push origin :refs/tags/v0.0.1-test-discord`
- [ ] Cut a real release without a `## Highlights` section — confirm fallback `<name> published. View notes: <url>` posts correctly

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/notify-discord-release.yml` | New workflow |
| `scripts/extract_highlights.py` | New extraction script (unit-testable) |
| `scripts/tests/test_extract_highlights.py` | 19 test cases (RED→GREEN verified) |
| `RELEASING.md` | New `## Discord embed content` section + step 8 |

Closes #468
Refs glitchwerks/rsl-mom-apps#17

---
🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_