### PR TITLE
infra(dev): wire DISCORD_DAY_1/2_ROLE_ID env vars

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -144,6 +144,12 @@ param externalBotApiUrl string = ''
 @description('Custom hostname to bind to the frontend (e.g. rslsiege.com). Leave empty to skip custom domain binding.')
 param customDomainHostname string = ''
 
+@description('Discord role snowflake ID for Day 1 attackers (used by day-role-sync contract v1.1). Leave empty to omit DISCORD_DAY_1_ROLE_ID env var.')
+param discordDay1RoleId string = ''
+
+@description('Discord role snowflake ID for Day 2 attackers (used by day-role-sync contract v1.1). Leave empty to omit DISCORD_DAY_2_ROLE_ID env var.')
+param discordDay2RoleId string = ''
+
 // ── Cloudflare Origin Certificate ────────────────────────────────────────────
 //
 // Two-phase deployment process:
@@ -348,6 +354,8 @@ module containerApps 'modules/container-apps.bicep' = {
     kvCertSecretUrl: kvCertSecretUrl
     useExternalSidecar: useExternalSidecar
     externalBotApiUrl: externalBotApiUrl
+    discordDay1RoleId: discordDay1RoleId
+    discordDay2RoleId: discordDay2RoleId
   }
 }
 

--- a/infra/main.dev.bicepparam
+++ b/infra/main.dev.bicepparam
@@ -127,6 +127,13 @@ param alertEmail = 'cmb_dev@outlook.com'
 param useExternalSidecar = false
 // param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
 
+// ── Day-role sync ─────────────────────────────────────────────────────────────
+// Snowflake IDs for the Day 1 and Day 2 attacker Discord roles.
+// These are injected as DISCORD_DAY_1_ROLE_ID / DISCORD_DAY_2_ROLE_ID into
+// the backend container (day-role-sync contract v1.1). See issue #463.
+param discordDay1RoleId = '1385267221206405171'
+param discordDay2RoleId = '1385267473099653170'
+
 // ── ACR image retention ───────────────────────────────────────────────────────
 // Dev currently has ~364 manifests (127/126/111 across api/bot/frontend).
 // Release tags (v*) are preserved forever. SHA/commit tags beyond the last 10

--- a/infra/main.prod.bicepparam
+++ b/infra/main.prod.bicepparam
@@ -155,6 +155,12 @@ param alertEmail = 'cmb_dev@outlook.com'
 param useExternalSidecar = false
 // param externalBotApiUrl = 'https://your-sidecar.example.com'  // uncomment + set when useExternalSidecar = true
 
+// ── Day-role sync ─────────────────────────────────────────────────────────────
+// Prod day-role IDs deferred until prod rollout of day-role-sync. See siege-web#463.
+// Set these to the production Discord role snowflake IDs and re-deploy infra when ready.
+param discordDay1RoleId = ''
+param discordDay2RoleId = ''
+
 // ── ACR image retention ───────────────────────────────────────────────────────
 // Prod currently has ~155 manifests (51/52/52 across api/bot/frontend).
 // Release tags (v*) are preserved forever. SHA/commit tags beyond the last 10

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -99,6 +99,12 @@ param useExternalSidecar bool = false
 @description('URL of the alternate sidecar HTTP API. Required when useExternalSidecar is true (e.g. https://my-bot.example.com). Ignored when useExternalSidecar is false.')
 param externalBotApiUrl string = ''
 
+@description('Discord role snowflake ID for Day 1 attackers (day-role-sync contract v1.1). When non-empty, injects DISCORD_DAY_1_ROLE_ID into the backend container. Leave empty to omit the env var (required for prod until day-role-sync rollout).')
+param discordDay1RoleId string = ''
+
+@description('Discord role snowflake ID for Day 2 attackers (day-role-sync contract v1.1). When non-empty, injects DISCORD_DAY_2_ROLE_ID into the backend container. Leave empty to omit the env var.')
+param discordDay2RoleId string = ''
+
 var apiAppName = '${appPrefix}-api-${environment}'
 var frontendAppName = '${appPrefix}-frontend-${environment}'
 var botAppName = '${appPrefix}-bot-${environment}'
@@ -230,6 +236,17 @@ resource apiApp 'Microsoft.App/containerApps@2025-07-01' = {
             empty(appInsightsConnectionString) ? [] : [
               { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
               { name: 'OTEL_SERVICE_NAME', value: 'siege-api' }
+            ],
+            // Day-role sync contract v1.1: inject role snowflake IDs only when
+            // non-empty. Omitting the env var entirely (rather than setting it to
+            // "") is required because pydantic-settings parses these as int | None
+            // and an empty string would fail validation. Prod leaves both empty
+            // until the day-role-sync feature is rolled out (see issue #463).
+            empty(discordDay1RoleId) ? [] : [
+              { name: 'DISCORD_DAY_1_ROLE_ID', value: discordDay1RoleId }
+            ],
+            empty(discordDay2RoleId) ? [] : [
+              { name: 'DISCORD_DAY_2_ROLE_ID', value: discordDay2RoleId }
             ]
           )
           probes: [


### PR DESCRIPTION
## Summary

- Adds `discordDay1RoleId` / `discordDay2RoleId` params to `infra/main.bicep` and threads them through to the `siege-api` Container App in `infra/modules/container-apps.bicep`
- Dev bicepparam (`main.dev.bicepparam`) is set with real snowflake values for immediate use
- Prod bicepparam (`main.prod.bicepparam`) explicitly sets both to `''` — documented deferral until the day-role-sync feature rolls out to prod

## Design decisions

**Declarative Bicep over imperative `az containerapp update`:** The issue body suggested an imperative CLI command, but all other env vars on the siege-api Container App are Bicep-managed. An imperative one-off would drift out of sync the next time `infra-deploy.yml` runs (which rewrites the entire container spec). Bicep is the single source of truth.

**Conditional env var injection (empty → omit entirely):** `discord_day_1_role_id` / `discord_day_2_role_id` are typed as `int | None` in pydantic-settings. Setting the env var to `""` would fail validation at startup — the empty string cannot be coerced to `int`. The `!empty(...) ? [...] : []` concat pattern (already used in this file for `appInsightsConnectionString` and `publicUrl`) omits the env var from the container spec entirely when the param is empty string. This makes the prod deferral safe: no env var → pydantic falls back to `None` → v1.0-shape payload (role ID field omitted).

**Prod deferral per issue AC #4:** Both prod values are set to `''` with an explanatory comment. When the prod rollout is ready, set the snowflake IDs in `main.prod.bicepparam` and re-run the infra workflow.

## Operator action required after merge

Run the **Infra Deploy** workflow (`infra-deploy.yml`, manual `workflow_dispatch`) targeting the **dev** environment. This is the step that actually applies the Bicep changes to `siege-web-dev` — the merge alone does not update the Container App.

Closes #463

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_