### PR TITLE
ci(infra-deploy): automate idempotency verification

### DIFF
--- a/.github/workflows/idempotency-check.yml
+++ b/.github/workflows/idempotency-check.yml
@@ -1,0 +1,103 @@
+name: Infra Idempotency Check
+
+# ── Purpose ─────────────────────────────────────────────────────────────────────
+#
+# Proves that re-deploying the current Bicep templates against the live dev
+# resource group produces zero changes (i.e. the templates are truly idempotent).
+#
+# Strategy: run `az deployment group what-if` (JSON output) against the dev RG
+# and assert that every change entry has changeType == NoChange or Ignore.
+# A non-empty actionable change set fails the job loudly.
+#
+# This is manual-dispatch only — it requires the dev RG to be in a post-deploy
+# steady state. Running it on a fresh RG (before first deploy) will report many
+# "Create" changes that are expected, not regressions.
+#
+# Trigger pattern: run this after any Infra Deploy to dev to confirm idempotency
+# is preserved. Also useful before merging infra PRs that touch resource
+# declarations (run after approving, before squash-merge).
+#
+# Intentional regression test (from issue #233 AC):
+#   Temporarily add `utcNow()` to a resource name in main.bicep, run this
+#   workflow — it should fail. Revert and re-run — it should pass again.
+#
+# ────────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: infra-idempotency-check
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ── Idempotency What-if ──────────────────────────────────────────────────────
+  #
+  # Runs `az deployment group what-if` against the live dev RG with the same
+  # parameter set used by the normal Infra Deploy workflow, then pipes the JSON
+  # output into scripts/assert-idempotent.sh which fails if any resource would
+  # be modified.
+  #
+  # Placeholder secrets are used for sensitive params (same values as infra-ci).
+  # The what-if call validates param shapes but does not apply them to any secret
+  # store, so placeholder values are safe here.
+
+  idempotency-what-if-dev:
+    name: Idempotency Check (dev)
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to Azure
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Get current image tag (dev)
+        run: |
+          # Preserve the currently-running image tag so what-if evaluates
+          # against the same image the RG already has — preventing a spurious
+          # "Modify" diff caused by imageTag defaulting to 'latest'.
+          IMAGE_TAG=$(az containerapp show \
+            --name siege-web-api-dev \
+            --resource-group ${{ vars.DEV_RESOURCE_GROUP }} \
+            --query "properties.template.containers[0].image" \
+            --output tsv 2>/dev/null | awk -F: '{print $NF}') || IMAGE_TAG="latest"
+          if [ -z "$IMAGE_TAG" ]; then
+            echo "⚠️  Could not determine current image tag, defaulting to 'latest'"
+            IMAGE_TAG="latest"
+          fi
+          echo "Using image tag: ${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+      - name: Run what-if (dev) — save JSON
+        run: |
+          az deployment group what-if \
+            --resource-group ${{ vars.DEV_RESOURCE_GROUP }} \
+            --template-file infra/main.bicep \
+            --parameters infra/main.dev.bicepparam \
+            --parameters postgresAdminPassword="ci-placeholder-value" \
+            --parameters discordToken="ci-placeholder-value" \
+            --parameters discordBotApiKey="ci-placeholder-value" \
+            --parameters botApiKey="ci-placeholder-value" \
+            --parameters discordGuildId="000000000000000000" \
+            --parameters sessionSecret="ci-placeholder-value" \
+            --parameters discordClientId="ci-placeholder-value" \
+            --parameters discordClientSecret="ci-placeholder-value" \
+            --parameters discordRedirectUri="https://placeholder.example.com/api/auth/callback" \
+            --parameters imageTag="${{ env.IMAGE_TAG }}" \
+            --result-format FullResourcePayloads \
+            --output json \
+            > /tmp/what-if.json
+
+      - name: Assert idempotency
+        run: |
+          chmod +x scripts/assert-idempotent.sh
+          scripts/assert-idempotent.sh /tmp/what-if.json

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,6 +4,37 @@ Azure Bicep templates for the Siege Assignment System.
 
 > For a complete end-to-end deployment walkthrough (prerequisites, resource-group setup, secret population, GitHub Actions wiring, DNS, and smoke test), see the [Self-Host on Azure wiki page](https://github.com/glitchwerks/rsl-siege-manager/wiki/Self-Host-on-Azure).
 
+## Idempotency guardrail
+
+Bicep templates are designed to be fully idempotent — deploying the same
+template twice against the same resource group should produce zero changes
+on the second run.
+
+The **Infra Idempotency Check** workflow (`.github/workflows/idempotency-check.yml`)
+automates this assertion. It runs `az deployment group what-if` against the live
+dev resource group and fails if any resource would be modified (i.e. if any
+change has a type other than `NoChange` or `Ignore`).
+
+**When to run it:**
+
+- After every `Infra Deploy` to dev, to confirm the just-applied template is
+  still idempotent.
+- Before merging an infra PR that touches resource declarations.
+
+**How to trigger:** GitHub → Actions → "Infra Idempotency Check" → Run workflow.
+
+**Intentional regression test:** temporarily add `utcNow()` to a resource name
+in `main.bicep`, run the workflow — it should fail. Revert and re-run — pass.
+This proves the guardrail catches non-deterministic property regressions.
+
+**Common causes of a failing idempotency check:**
+
+- A non-deterministic function (`utcNow()`, `newGuid()`) in a resource name
+  or tag value
+- A computed value that evaluates differently between ARM evaluation cycles
+- A parameter was changed in the `.bicepparam` file but not yet applied to
+  the live RG (expected — re-deploy first, then re-run the check)
+
 ## Resources provisioned
 
 | Resource | Module |

--- a/scripts/assert-idempotent.sh
+++ b/scripts/assert-idempotent.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# assert-idempotent.sh — parse az deployment group what-if JSON output and
+# assert that every change entry is NoChange or Ignore.
+#
+# Usage:
+#   az deployment group what-if ... --result-format FullResourcePayloads \
+#       --output json | ./scripts/assert-idempotent.sh
+#
+# Exit codes:
+#   0  — all changes are NoChange / Ignore  (idempotent)
+#   1  — one or more resource modifications detected (not idempotent)
+#
+# The script is intentionally lenient about what counts as "idempotent" input:
+# - An empty JSON array [] is fine (nothing would change)
+# - changeType "NoChange" is fine
+# - changeType "Ignore" is fine (unsupported resource types — ARM skips these)
+# - Any other changeType (Create, Modify, Delete, Deploy, Unsupported) is a failure
+#
+# Design note: we parse the raw --output json form, not the human-readable
+# table, because the text output changes wording between az CLI versions and
+# is fragile to parse.  The JSON schema is versioned and stable.
+
+set -euo pipefail
+
+WHAT_IF_JSON="${1:-}"
+
+if [[ -n "$WHAT_IF_JSON" ]]; then
+  INPUT="$WHAT_IF_JSON"
+else
+  INPUT="$(cat)"
+fi
+
+# The what-if JSON is either:
+#   { "changes": [...] }           (wrapped in a result object)
+#   [...]                          (bare array — older az CLI versions)
+# Normalise to an array.
+changes="$(echo "$INPUT" | jq 'if type == "object" then .changes else . end')"
+
+total="$(echo "$changes" | jq 'length')"
+
+if [[ "$total" -eq 0 ]]; then
+  echo "✅  Idempotency check PASSED: what-if returned no changes (empty change set)."
+  exit 0
+fi
+
+# Filter down to actionable changes (anything that isn't NoChange / Ignore).
+actionable="$(echo "$changes" | jq '
+  [.[] | select(.changeType | IN("NoChange","Ignore") | not)]
+')"
+
+actionable_count="$(echo "$actionable" | jq 'length')"
+no_change_count="$(echo "$changes"    | jq '[.[] | select(.changeType == "NoChange")] | length')"
+ignore_count="$(echo "$changes"       | jq '[.[] | select(.changeType == "Ignore")]  | length')"
+
+echo "──────────────────────────────────────────────────────────────"
+echo "  Idempotency what-if summary"
+echo "──────────────────────────────────────────────────────────────"
+echo "  Total resources in change set : $total"
+echo "  NoChange                      : $no_change_count"
+echo "  Ignore (unsupported by ARM)   : $ignore_count"
+echo "  Actionable changes            : $actionable_count"
+echo "──────────────────────────────────────────────────────────────"
+
+if [[ "$actionable_count" -eq 0 ]]; then
+  echo "✅  Idempotency check PASSED: all $total resource(s) are NoChange or Ignore."
+  exit 0
+fi
+
+echo ""
+echo "❌  Idempotency check FAILED: $actionable_count resource(s) would be changed on re-deploy:"
+echo ""
+echo "$actionable" | jq -r '.[] | "  [\(.changeType)] \(.resourceId)"'
+echo ""
+echo "This means a second infra deploy would NOT be a no-op."
+echo "Common causes:"
+echo "  - A non-deterministic property (e.g. utcNow(), newGuid()) in a resource name or tag"
+echo "  - A computed value that differs between evaluation cycles"
+echo "  - A recently-changed parameter that has not yet been applied to the live RG"
+echo ""
+echo "Inspect the actionable resources above and ensure no Bicep expression"
+echo "produces a different value on every deployment."
+exit 1


### PR DESCRIPTION
## DO NOT MERGE — pending live-infra verification

This PR automates the idempotency check required by #233. It adds a
`workflow_dispatch` CI job that runs `az deployment group what-if` against
the dev RG and asserts zero actionable changes. **It cannot be validated
without a real Azure deploy** — see the verification section below.

---

## Changes

**`.github/workflows/idempotency-check.yml`** — new manual-dispatch workflow
- Logs into Azure (dev environment)
- Captures the currently-running image tag from the dev Container App (same
  logic as `infra-deploy.yml`) to avoid spurious "Modify" diffs
- Runs `az deployment group what-if --result-format FullResourcePayloads --output json`
  with placeholder secrets (same values as the existing infra-ci gates)
- Pipes the JSON output to `scripts/assert-idempotent.sh`
- Fails the job if any change entry has a type other than `NoChange` or `Ignore`

**`scripts/assert-idempotent.sh`** — the assertion logic (extracted per
github-actions skill: business logic belongs in scripts, not inline YAML)
- Handles both the `{ "changes": [...] }` and `[...]` JSON shapes across az CLI versions
- Reports a clear summary table (total / NoChange / Ignore / Actionable)
- Exits 1 with a named list of the offending resource IDs and change types
- Exits 0 when all entries are NoChange or Ignore (including an empty set)

**`infra/README.md`** — documents the guardrail, when to run it, and the
intentional regression test procedure (add `utcNow()`, confirm failure, revert)

## Acceptance criteria (from #233)

- [x] CI step exists that verifies idempotency against `dev`
- [x] Green state: 0 resource changes on re-run (asserted by script)
- [ ] Intentional regression test confirmed: **requires manual execution** — add `utcNow()` to a resource name, trigger workflow, confirm failure, revert (cannot be automated)
- [x] README / runbook documents the guardrail (`infra/README.md`)

## Verification required before merge

Per project policy, infra-adjacent CI changes require live-infra verification
before merging. Passing the app CI suite does not prove this workflow is correct.

**Verification steps:**
1. Ensure dev RG is in a stable post-deploy state (run Infra Deploy if needed)
2. GitHub Actions → "Infra Idempotency Check" → Run workflow
3. Confirm the job passes (all NoChange / Ignore)
4. Intentional regression test: temporarily add `|| uniqueString(utcNow())` to
   a resource name tag in `infra/main.bicep`, commit to a test branch, re-run — confirm failure
5. Revert the test change, re-run — confirm pass
6. Promote from draft → ready for merge

## Lint

`actionlint` passes with no findings on `idempotency-check.yml`.

Closes #233

---

> 🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_