### PR TITLE
fix(ci/idempotency-check): suppress Azure CLI WARNINGs on stdout so jq can parse what-if output

### DIFF
--- a/.github/workflows/idempotency-check.yml
+++ b/.github/workflows/idempotency-check.yml
@@ -94,6 +94,7 @@ jobs:
             --parameters discordRedirectUri="https://placeholder.example.com/api/auth/callback" \
             --parameters imageTag="${{ env.IMAGE_TAG }}" \
             --result-format FullResourcePayloads \
+            --only-show-errors \
             --output json \
             > /tmp/what-if.json
 


### PR DESCRIPTION
## Summary

- Adds `--only-show-errors` to the `az deployment group what-if` call in `idempotency-check.yml`
- Azure CLI was writing Bicep linter WARNINGs to stdout before the JSON payload; `jq` failed with `parse error: Invalid numeric literal at line 2, column 0` (run 26542592635)
- `--only-show-errors` suppresses WARNINGs on stdout, leaving only the JSON payload; warnings still surface in the workflow log via stderr

Closes #474

## Change

One-line addition — `--only-show-errors \` on the `az deployment group what-if` step in `.github/workflows/idempotency-check.yml`, inserted between `--result-format FullResourcePayloads \` and `--output json \`.

## Test plan

- [ ] Trigger `workflow_dispatch` on `main` after merge
- [ ] Expect green run: `Assert idempotency` step parses `/tmp/what-if.json` cleanly, reports zero actionable changes on steady-state dev RG
- [ ] Confirm Bicep linter warnings still appear in the workflow run log (stderr) — only stdout is sanitized

> 🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_