### PR TITLE
fix(ci/idempotency-check): emit JSON via --no-pretty-print; debug-echo head before assert

### DIFF
--- a/.github/workflows/idempotency-check.yml
+++ b/.github/workflows/idempotency-check.yml
@@ -95,10 +95,14 @@ jobs:
             --parameters imageTag="${{ env.IMAGE_TAG }}" \
             --result-format FullResourcePayloads \
             --only-show-errors \
+            --no-pretty-print \
             --output json \
             > /tmp/what-if.json
 
       - name: Assert idempotency
         run: |
+          echo "── first 3 lines of /tmp/what-if.json ──"
+          head -3 /tmp/what-if.json
+          echo "────────────────────────────────────────"
           chmod +x scripts/assert-idempotent.sh
           scripts/assert-idempotent.sh /tmp/what-if.json


### PR DESCRIPTION
## Summary

- Adds `--no-pretty-print` to the `az deployment group what-if` call so `--output json` actually takes effect (without it, the CLI emits styled human-readable text regardless of the output flag)
- Adds a 3-line `head -3 /tmp/what-if.json` debug echo in the Assert step so any future parse failure immediately shows what jq sees, eliminating another fix-and-retrigger cycle

Closes #476

## Test plan

- [ ] Trigger `workflow_dispatch` on `main` after merge
- [ ] Confirm head output shows `{` / JSON on the first line (not `The deployment will update...`)
- [ ] Assert step passes on steady-state dev RG

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_