### PR TITLE
fix(scripts/assert-idempotent): read file contents instead of path string

### DIFF
--- a/scripts/assert-idempotent.sh
+++ b/scripts/assert-idempotent.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 WHAT_IF_JSON="${1:-}"
 
 if [[ -n "$WHAT_IF_JSON" ]]; then
-  INPUT="$WHAT_IF_JSON"
+  INPUT="$(cat "$WHAT_IF_JSON")"
 else
   INPUT="$(cat)"
 fi


### PR DESCRIPTION
## Summary

One-line fix: `INPUT="$WHAT_IF_JSON"` → `INPUT="$(cat "$WHAT_IF_JSON")"` on line 28 of `scripts/assert-idempotent.sh`.

The file-argument branch was assigning the literal path string to `INPUT` instead of the file's contents, causing jq to receive a path string and fail with `Invalid numeric literal`. The stdin-pipe path was unaffected.

Closes #478

## Test plan

- Trigger `workflow_dispatch` on `main` after merge; expect green run on steady-state dev RG.

## Smoke test results

Pass path (`{"changes":[]}`):
```
✅  Idempotency check PASSED: what-if returned no changes (empty change set).
exit_code=0
```

Fail path (`{"changes":[{"changeType":"Modify","resourceId":"foo"}]}`):
```
❌  Idempotency check FAILED: 1 resource(s) would be changed on re-deploy:
  [Modify] foo
exit_code=1
```

Both paths behave correctly.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_