### PR TITLE
fix(members): remove stale SiegeMember rows on deactivation

### DIFF
--- a/backend/app/services/members.py
+++ b/backend/app/services/members.py
@@ -89,14 +89,14 @@ async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
         .join(Building, BuildingGroup.building_id == Building.id)
         .join(Siege, Building.siege_id == Siege.id)
         .where(Position.member_id == member_id)
-        .where(Siege.status == "planning")
+        .where(Siege.status == SiegeStatus.planning)
     )
     result = await session.execute(stmt)
     positions = result.scalars().all()
     for position in positions:
         position.member_id = None
 
-    # Remove the member from all planning siege rosters.  Active and complete
+    # Remove the member from all planning siege rosters. Active and complete
     # sieges are left untouched so historical records are preserved.
     await session.execute(
         delete(SiegeMember)

--- a/backend/app/services/members.py
+++ b/backend/app/services/members.py
@@ -96,6 +96,16 @@ async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
     for position in positions:
         position.member_id = None
 
+    # Remove the member from all planning siege rosters.  Active and complete
+    # sieges are left untouched so historical records are preserved.
+    await session.execute(
+        delete(SiegeMember)
+        .where(SiegeMember.member_id == member_id)
+        .where(
+            SiegeMember.siege_id.in_(select(Siege.id).where(Siege.status == SiegeStatus.planning))
+        )
+    )
+
     await session.commit()
     await session.refresh(member)
     return member

--- a/backend/app/services/members.py
+++ b/backend/app/services/members.py
@@ -59,30 +59,22 @@ async def create_member(session: AsyncSession, data: MemberCreate) -> Member:
     return member
 
 
-async def update_member(session: AsyncSession, member_id: int, data: MemberUpdate) -> Member:
-    member = await get_member(session, member_id)
-    updates = data.model_dump(exclude_unset=True)
-    if updates.get("is_active") is True and not member.is_active:
-        active_count = await session.scalar(
-            select(func.count()).select_from(Member).where(Member.is_active == True)  # noqa: E712
-        )
-        if active_count >= 30:
-            raise HTTPException(
-                status_code=409,
-                detail="Cannot reactivate member: the 30-active-member limit has been reached",
-            )
-    for field, value in updates.items():
-        setattr(member, field, value)
-    await session.commit()
-    await session.refresh(member)
-    return member
+async def _clear_member_from_planning_sieges(session: AsyncSession, member_id: int) -> None:
+    """Clear a member's position assignments and roster rows from planning sieges.
 
+    Removes all ``Position.member_id`` references for *member_id* that fall
+    within planning sieges, and deletes the corresponding ``SiegeMember`` rows.
+    Active and complete sieges are left untouched so historical records are
+    preserved.
 
-async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
-    member = await get_member(session, member_id)
-    member.is_active = False
+    This helper does **not** commit; the caller is responsible for committing
+    after all mutations are applied.
 
-    # Clear position assignments in planning sieges
+    Args:
+        session: The active async database session.
+        member_id: Primary key of the member to remove from planning sieges.
+    """
+    # Clear position assignments in planning sieges.
     stmt = (
         select(Position)
         .join(BuildingGroup, Position.building_group_id == BuildingGroup.id)
@@ -96,8 +88,7 @@ async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
     for position in positions:
         position.member_id = None
 
-    # Remove the member from all planning siege rosters. Active and complete
-    # sieges are left untouched so historical records are preserved.
+    # Remove the member from all planning siege rosters.
     await session.execute(
         delete(SiegeMember)
         .where(SiegeMember.member_id == member_id)
@@ -105,6 +96,77 @@ async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
             SiegeMember.siege_id.in_(select(Siege.id).where(Siege.status == SiegeStatus.planning))
         )
     )
+
+
+async def update_member(session: AsyncSession, member_id: int, data: MemberUpdate) -> Member:
+    """Update mutable fields on an existing member.
+
+    When the update transitions the member from active to inactive, the
+    planning-siege cleanup is run before committing so that stale
+    ``SiegeMember`` rows and position assignments are never left behind.
+
+    Args:
+        session: The active async database session.
+        member_id: Primary key of the member to update.
+        data: Partial update payload; only fields present in the request are
+            applied.
+
+    Returns:
+        The refreshed ``Member`` instance after the update.
+
+    Raises:
+        HTTPException: 404 if the member does not exist, 409 if reactivating
+            would exceed the 30-active-member limit.
+    """
+    member = await get_member(session, member_id)
+    updates = data.model_dump(exclude_unset=True)
+
+    if updates.get("is_active") is True and not member.is_active:
+        active_count = await session.scalar(
+            select(func.count()).select_from(Member).where(Member.is_active == True)  # noqa: E712
+        )
+        if active_count >= 30:
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot reactivate member: the 30-active-member limit has been reached",
+            )
+
+    # Capture the transition flag BEFORE mutating member.is_active so we can
+    # detect active → inactive reliably regardless of update field order.
+    transitioning_to_inactive = updates.get("is_active") is False and member.is_active is True
+
+    for field, value in updates.items():
+        setattr(member, field, value)
+
+    if transitioning_to_inactive:
+        await _clear_member_from_planning_sieges(session, member_id)
+
+    await session.commit()
+    await session.refresh(member)
+    return member
+
+
+async def deactivate_member(session: AsyncSession, member_id: int) -> Member:
+    """Deactivate a member and clean up their planning-siege presence.
+
+    Sets ``is_active = False``, clears position assignments in planning sieges,
+    and removes ``SiegeMember`` rows from planning sieges. Active and complete
+    sieges are left untouched so historical records are preserved.
+
+    Args:
+        session: The active async database session.
+        member_id: Primary key of the member to deactivate.
+
+    Returns:
+        The refreshed ``Member`` instance after deactivation.
+
+    Raises:
+        HTTPException: 404 if the member does not exist.
+    """
+    member = await get_member(session, member_id)
+    member.is_active = False
+
+    await _clear_member_from_planning_sieges(session, member_id)
 
     await session.commit()
     await session.refresh(member)

--- a/backend/app/services/siege_members.py
+++ b/backend/app/services/siege_members.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from app.models.enums import SiegeStatus
 from app.models.member import Member
+from app.models.siege import Siege
 from app.models.siege_member import SiegeMember
 from app.schemas.siege_member import MemberPreferenceSummary, SiegeMemberUpdate
 from app.services.sieges import get_siege
@@ -15,9 +16,27 @@ from app.services.sieges import get_siege
 async def get_siege_member_preferences(
     session: AsyncSession, siege_id: int
 ) -> list[MemberPreferenceSummary]:
+    """Return member preference summaries for all roster members of *siege_id*.
+
+    Applies the same planning-scoped active-member filter as
+    ``list_siege_members``: inactive members are excluded only when the siege
+    is in ``planning`` status. For ``active`` and ``complete`` sieges all
+    roster rows are returned, preserving the historical record (see Fix 1 in
+    ``deactivate_member`` which removes rows only from planning sieges).
+
+    Args:
+        session: Async SQLAlchemy session.
+        siege_id: Primary key of the siege to query.
+
+    Returns:
+        List of ``MemberPreferenceSummary`` instances ordered by member ID.
+    """
     result = await session.execute(
         select(SiegeMember)
+        .join(Siege, SiegeMember.siege_id == Siege.id)
+        .join(Member, SiegeMember.member_id == Member.id)
         .where(SiegeMember.siege_id == siege_id)
+        .where((Siege.status != SiegeStatus.planning) | (Member.is_active.is_(True)))
         .options(selectinload(SiegeMember.member).selectinload(Member.post_preferences))
         .order_by(SiegeMember.member_id)
     )
@@ -33,24 +52,33 @@ async def get_siege_member_preferences(
 
 
 async def list_siege_members(session: AsyncSession, siege_id: int) -> list[SiegeMember]:
-    """Return all active SiegeMember rows for *siege_id*.
+    """Return SiegeMember rows for *siege_id*, respecting history preservation.
 
-    Members whose ``is_active`` flag is ``False`` are excluded as a
-    defense-in-depth guard against stale roster rows (issue #485).
+    Both fixes for issue #485 work together here:
+
+    - **Fix 1** (``deactivate_member``): removes ``SiegeMember`` rows from
+      planning sieges on deactivation, so stale rows never accumulate there.
+    - **Fix 2** (this function): defense-in-depth read filter that excludes
+      inactive members, but *only* for ``planning`` sieges. For ``active`` and
+      ``complete`` sieges every roster row is returned so that historical
+      records of who participated remain intact even if those members are
+      later deactivated.
 
     Args:
         session: Async SQLAlchemy session.
         siege_id: Primary key of the siege to query.
 
     Returns:
-        List of ``SiegeMember`` instances with ``member`` eagerly loaded,
-        filtered to active members only.
+        List of ``SiegeMember`` instances with ``member`` eagerly loaded.
+        For planning sieges, inactive members are excluded. For active and
+        complete sieges, all roster rows are included.
     """
     result = await session.execute(
         select(SiegeMember)
+        .join(Siege, SiegeMember.siege_id == Siege.id)
         .join(Member, SiegeMember.member_id == Member.id)
         .where(SiegeMember.siege_id == siege_id)
-        .where(Member.is_active.is_(True))
+        .where((Siege.status != SiegeStatus.planning) | (Member.is_active.is_(True)))
         .options(selectinload(SiegeMember.member))
     )
     return list(result.scalars().all())

--- a/backend/app/services/siege_members.py
+++ b/backend/app/services/siege_members.py
@@ -33,9 +33,24 @@ async def get_siege_member_preferences(
 
 
 async def list_siege_members(session: AsyncSession, siege_id: int) -> list[SiegeMember]:
+    """Return all active SiegeMember rows for *siege_id*.
+
+    Members whose ``is_active`` flag is ``False`` are excluded as a
+    defense-in-depth guard against stale roster rows (issue #485).
+
+    Args:
+        session: Async SQLAlchemy session.
+        siege_id: Primary key of the siege to query.
+
+    Returns:
+        List of ``SiegeMember`` instances with ``member`` eagerly loaded,
+        filtered to active members only.
+    """
     result = await session.execute(
         select(SiegeMember)
+        .join(Member, SiegeMember.member_id == Member.id)
         .where(SiegeMember.siege_id == siege_id)
+        .where(Member.is_active.is_(True))
         .options(selectinload(SiegeMember.member))
     )
     return list(result.scalars().all())

--- a/backend/tests/test_deactivate_stale_siege_member.py
+++ b/backend/tests/test_deactivate_stale_siege_member.py
@@ -1,0 +1,272 @@
+"""Regression tests for issue #485 — deactivating a member must remove their
+SiegeMember rows from planning sieges and must not affect active/complete ones.
+
+Uses an in-memory SQLite database (same pattern as
+tests/test_post_suggestions_integration.py) so no live DB is required.
+"""
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import app.models  # noqa: F401 — populate Base.metadata
+from app.db.base import Base
+from app.models.building import Building
+from app.models.building_group import BuildingGroup
+from app.models.enums import BuildingType, MemberRole, SiegeStatus
+from app.models.member import Member
+from app.models.position import Position
+from app.models.siege import Siege
+from app.models.siege_member import SiegeMember
+from app.services.members import deactivate_member
+from app.services.siege_members import list_siege_members
+
+# ---------------------------------------------------------------------------
+# Engine / session fixtures
+# ---------------------------------------------------------------------------
+
+
+def _enable_sqlite_fk(dbapi_conn, _connection_record):
+    """Enable SQLite foreign-key enforcement."""
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys = ON")
+    cursor.close()
+
+
+@pytest.fixture
+async def engine():
+    """Async SQLite in-memory engine with the full schema."""
+    _engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    event.listen(_engine.sync_engine, "connect", _enable_sqlite_fk)
+    async with _engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield _engine
+    await _engine.dispose()
+
+
+@pytest.fixture
+async def session(engine):
+    """Single AsyncSession per test, expire_on_commit=False for easy inspection."""
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as sess:
+        yield sess
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_siege(session: AsyncSession, status: SiegeStatus) -> Siege:
+    """Seed a minimal siege with one building, group and empty position."""
+    siege = Siege(status=status, defense_scroll_count=5)
+    session.add(siege)
+    await session.flush()
+
+    bld = Building(
+        siege_id=siege.id,
+        building_type=BuildingType.stronghold,
+        building_number=1,
+        level=1,
+        is_broken=False,
+    )
+    session.add(bld)
+    await session.flush()
+
+    grp = BuildingGroup(building_id=bld.id, group_number=1, slot_count=3)
+    session.add(grp)
+    await session.flush()
+
+    pos = Position(building_group_id=grp.id, position_number=1)
+    session.add(pos)
+    await session.flush()
+
+    return siege
+
+
+async def _assign_member_to_position(
+    session: AsyncSession, siege: Siege, member: Member
+) -> Position:
+    """Assign *member* to the first position in *siege* and return the position."""
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    result = await session.execute(
+        select(Siege)
+        .where(Siege.id == siege.id)
+        .options(
+            selectinload(Siege.buildings)
+            .selectinload(Building.groups)
+            .selectinload(BuildingGroup.positions)
+        )
+    )
+    full_siege = result.scalar_one()
+    pos = full_siege.buildings[0].groups[0].positions[0]
+    pos.member_id = member.id
+    await session.flush()
+    return pos
+
+
+# ---------------------------------------------------------------------------
+# Issue #485 — regression: deactivating a member removes their SiegeMember
+# rows from planning sieges.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deactivate_removes_siege_member_from_planning_siege(session):
+    """Deactivating a member must remove their SiegeMember row from every
+    planning siege so they no longer appear in the roster.
+
+    This is the primary regression for issue #485.
+    """
+    # Seed: one member + one planning siege
+    member = Member(name="Alice", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.planning)
+
+    # Assign the member to the siege roster
+    siege_member = SiegeMember(siege_id=siege.id, member_id=member.id)
+    session.add(siege_member)
+    await session.commit()
+
+    # Pre-condition: member IS in the roster
+    roster_before = await list_siege_members(session, siege.id)
+    ids_before = [sm.member_id for sm in roster_before]
+    assert member.id in ids_before, "Precondition: member should be in planning roster"
+
+    # Act: deactivate the member
+    await deactivate_member(session, member.id)
+
+    # Assert (a): member is NOT in the roster after deactivation
+    roster_after = await list_siege_members(session, siege.id)
+    ids_after = [sm.member_id for sm in roster_after]
+    assert (
+        member.id not in ids_after
+    ), "Deactivated member must not appear in planning siege roster (issue #485)"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_clears_position_assignments_in_planning_siege(session):
+    """Deactivating a member must clear their position assignments in planning
+    sieges (existing behaviour, confirmed unbroken by this fix).
+    """
+    member = Member(name="Bob", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.planning)
+    siege_member = SiegeMember(siege_id=siege.id, member_id=member.id)
+    session.add(siege_member)
+    await session.flush()
+
+    pos = await _assign_member_to_position(session, siege, member)
+    await session.commit()
+
+    # Confirm position is assigned
+    await session.refresh(pos)
+    assert pos.member_id == member.id
+
+    # Deactivate
+    await deactivate_member(session, member.id)
+
+    # Assert (b): position is cleared
+    await session.refresh(pos)
+    assert pos.member_id is None, "Position must be cleared after member deactivation"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_does_not_remove_siege_member_from_active_siege(session):
+    """Deactivating a member must NOT delete their SiegeMember row from an
+    active siege — the DB row must be preserved for history.
+
+    Note: list_siege_members (Fix 2) intentionally filters out inactive
+    members, so we check the raw SiegeMember row directly to verify Fix 1
+    does not touch non-planning sieges.
+    """
+    from sqlalchemy import select
+
+    member = Member(name="Carol", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.active)
+    siege_member = SiegeMember(siege_id=siege.id, member_id=member.id)
+    session.add(siege_member)
+    await session.commit()
+
+    # Deactivate
+    await deactivate_member(session, member.id)
+
+    # Assert: SiegeMember row still exists in the database
+    result = await session.execute(
+        select(SiegeMember).where(
+            SiegeMember.siege_id == siege.id,
+            SiegeMember.member_id == member.id,
+        )
+    )
+    assert (
+        result.scalar_one_or_none() is not None
+    ), "SiegeMember row must be preserved in active sieges after deactivation"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_does_not_remove_siege_member_from_complete_siege(session):
+    """Deactivating a member must NOT delete their SiegeMember row from a
+    complete siege — historical record must be intact.
+
+    Note: list_siege_members (Fix 2) intentionally filters out inactive
+    members, so we check the raw SiegeMember row directly to verify Fix 1
+    does not touch non-planning sieges.
+    """
+    from sqlalchemy import select
+
+    member = Member(name="Dave", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.complete)
+    siege_member = SiegeMember(siege_id=siege.id, member_id=member.id)
+    session.add(siege_member)
+    await session.commit()
+
+    # Deactivate
+    await deactivate_member(session, member.id)
+
+    # Assert: SiegeMember row still exists in the database
+    result = await session.execute(
+        select(SiegeMember).where(
+            SiegeMember.siege_id == siege.id,
+            SiegeMember.member_id == member.id,
+        )
+    )
+    assert (
+        result.scalar_one_or_none() is not None
+    ), "SiegeMember row must be preserved in complete sieges after deactivation"
+
+
+@pytest.mark.asyncio
+async def test_list_siege_members_excludes_inactive_members(session):
+    """list_siege_members must filter out inactive members even when a stale
+    SiegeMember row exists (defense-in-depth for Fix 2).
+    """
+    active = Member(name="Eve", role=MemberRole.advanced, is_active=True)
+    inactive = Member(name="Frank", role=MemberRole.advanced, is_active=False)
+    session.add_all([active, inactive])
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.planning)
+    session.add(SiegeMember(siege_id=siege.id, member_id=active.id))
+    # Deliberately insert a stale row for the inactive member (simulates bug state)
+    session.add(SiegeMember(siege_id=siege.id, member_id=inactive.id))
+    await session.commit()
+
+    roster = await list_siege_members(session, siege.id)
+    ids = [sm.member_id for sm in roster]
+
+    assert active.id in ids, "Active member must appear in roster"
+    assert (
+        inactive.id not in ids
+    ), "Inactive member must be excluded by list_siege_members (defense-in-depth)"

--- a/backend/tests/test_deactivate_stale_siege_member.py
+++ b/backend/tests/test_deactivate_stale_siege_member.py
@@ -18,7 +18,8 @@ from app.models.member import Member
 from app.models.position import Position
 from app.models.siege import Siege
 from app.models.siege_member import SiegeMember
-from app.services.members import deactivate_member
+from app.schemas.member import MemberUpdate
+from app.services.members import deactivate_member, update_member
 from app.services.siege_members import (
     get_siege_member_preferences,
     list_siege_members,
@@ -393,4 +394,93 @@ async def test_get_siege_member_preferences_shows_deactivated_in_active_siege(
     assert member.id in member_ids, (
         "get_siege_member_preferences must include deactivated members in "
         "active siege rosters (planning-scoped filter, review item 3)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: deactivating via update_member (the PUT/UI path) must also
+# run the planning-siege cleanup — issue #485 gap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_member_deactivate_removes_from_planning_siege_roster(
+    session,
+):
+    """Deactivating a member via update_member (PUT path, used by the UI)
+    must delete their SiegeMember row from every planning siege.
+
+    This is the primary regression for the #485 gap: the original fix only
+    wired cleanup into deactivate_member (DELETE path), leaving update_member
+    (PUT/UI path) without cleanup. We check the raw SiegeMember row to prove
+    the row is deleted, not just filtered by list_siege_members' defense-in-
+    depth inactive-member filter.
+    """
+    from sqlalchemy import select
+
+    member = Member(name="Kate", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.planning)
+    session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.commit()
+
+    # Pre-condition: raw SiegeMember row exists
+    result_before = await session.execute(
+        select(SiegeMember).where(
+            SiegeMember.siege_id == siege.id,
+            SiegeMember.member_id == member.id,
+        )
+    )
+    assert (
+        result_before.scalar_one_or_none() is not None
+    ), "Precondition: SiegeMember row must exist before update"
+
+    # Act: deactivate via update_member — this is the path the UI calls
+    await update_member(session, member.id, MemberUpdate(is_active=False))
+
+    # Assert (a): raw SiegeMember row is deleted from the planning siege
+    result_after = await session.execute(
+        select(SiegeMember).where(
+            SiegeMember.siege_id == siege.id,
+            SiegeMember.member_id == member.id,
+        )
+    )
+    assert result_after.scalar_one_or_none() is None, (
+        "Deactivating via update_member must delete SiegeMember row from "
+        "planning siege (issue #485 gap — PUT path must run cleanup)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_member_deactivate_clears_position_assignments(
+    session,
+):
+    """Deactivating a member via update_member must also clear their position
+    assignments in planning sieges (mirrors deactivate_member behaviour).
+    """
+    member = Member(name="Leo", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.planning)
+    session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.flush()
+
+    pos = await _assign_member_to_position(session, siege, member)
+    await session.commit()
+
+    # Confirm position is assigned before the update
+    await session.refresh(pos)
+    assert pos.member_id == member.id, "Precondition: position must be assigned to member"
+
+    # Act: deactivate via update_member (the PUT path)
+    await update_member(session, member.id, MemberUpdate(is_active=False))
+
+    # Assert (b): position is cleared
+    await session.refresh(pos)
+    assert pos.member_id is None, (
+        "update_member deactivation must clear position assignments in "
+        "planning sieges (issue #485 gap)"
     )

--- a/backend/tests/test_deactivate_stale_siege_member.py
+++ b/backend/tests/test_deactivate_stale_siege_member.py
@@ -19,7 +19,10 @@ from app.models.position import Position
 from app.models.siege import Siege
 from app.models.siege_member import SiegeMember
 from app.services.members import deactivate_member
-from app.services.siege_members import list_siege_members
+from app.services.siege_members import (
+    get_siege_member_preferences,
+    list_siege_members,
+)
 
 # ---------------------------------------------------------------------------
 # Engine / session fixtures
@@ -270,3 +273,124 @@ async def test_list_siege_members_excludes_inactive_members(session):
     assert (
         inactive.id not in ids
     ), "Inactive member must be excluded by list_siege_members (defense-in-depth)"
+
+
+# ---------------------------------------------------------------------------
+# Multi-planning-siege bulk deletion (review item 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deactivate_removes_siege_member_from_all_planning_sieges(session):
+    """Deactivating a member must remove their SiegeMember rows from ALL
+    planning sieges simultaneously (exercises the bulk .in_() delete).
+    """
+    member = Member(name="Grace", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege_a = await _make_siege(session, SiegeStatus.planning)
+    siege_b = await _make_siege(session, SiegeStatus.planning)
+    siege_c = await _make_siege(session, SiegeStatus.planning)
+
+    for siege in (siege_a, siege_b, siege_c):
+        session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.commit()
+
+    # Pre-condition: member appears in all three planning rosters
+    for siege in (siege_a, siege_b, siege_c):
+        roster = await list_siege_members(session, siege.id)
+        assert member.id in [
+            sm.member_id for sm in roster
+        ], f"Precondition: member must be in planning siege {siege.id}"
+
+    # Deactivate
+    await deactivate_member(session, member.id)
+
+    # Assert: member no longer appears in any of the three rosters
+    for siege in (siege_a, siege_b, siege_c):
+        roster = await list_siege_members(session, siege.id)
+        assert member.id not in [sm.member_id for sm in roster], (
+            f"Deactivated member must not appear in planning siege {siege.id} "
+            "(bulk .in_() delete must cover all planning sieges)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Active/complete history preservation visible via list_siege_members
+# (review item 5 — locks the scoping decision for Fix 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_siege_members_shows_deactivated_member_in_active_siege(session):
+    """A member deactivated while a siege is *active* must still appear in
+    that siege's roster via list_siege_members.
+
+    This guards against the over-broad read filter introduced by Fix 2
+    (which must only apply to planning sieges, not active/complete ones).
+    """
+    member = Member(name="Henry", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.active)
+    session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.commit()
+
+    # Deactivate the member (SiegeMember row is preserved per Fix 1)
+    await deactivate_member(session, member.id)
+
+    # list_siege_members must still return the row for an active siege
+    roster = await list_siege_members(session, siege.id)
+    assert member.id in [sm.member_id for sm in roster], (
+        "list_siege_members must include deactivated members in active siege "
+        "rosters (history preservation)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_siege_members_shows_deactivated_member_in_complete_siege(session):
+    """A member deactivated after a siege is *complete* must still appear in
+    that siege's roster via list_siege_members (history preservation).
+    """
+    member = Member(name="Iris", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.complete)
+    session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.commit()
+
+    await deactivate_member(session, member.id)
+
+    roster = await list_siege_members(session, siege.id)
+    assert member.id in [sm.member_id for sm in roster], (
+        "list_siege_members must include deactivated members in complete siege "
+        "rosters (history preservation)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_siege_member_preferences_shows_deactivated_in_active_siege(
+    session,
+):
+    """get_siege_member_preferences must also include deactivated members for
+    active/complete sieges (same planning-scoped filter as list_siege_members).
+    """
+    member = Member(name="Jack", role=MemberRole.advanced, is_active=True)
+    session.add(member)
+    await session.flush()
+
+    siege = await _make_siege(session, SiegeStatus.active)
+    session.add(SiegeMember(siege_id=siege.id, member_id=member.id))
+    await session.commit()
+
+    await deactivate_member(session, member.id)
+
+    prefs = await get_siege_member_preferences(session, siege.id)
+    member_ids = [p.member_id for p in prefs]
+    assert member.id in member_ids, (
+        "get_siege_member_preferences must include deactivated members in "
+        "active siege rosters (planning-scoped filter, review item 3)"
+    )


### PR DESCRIPTION
## Summary

- **Fix 1 (primary):** `deactivate_member` in `backend/app/services/members.py` now deletes `SiegeMember` rows for the deactivated member from all planning sieges after clearing their position assignments. Active and complete sieges are intentionally untouched so historical records are preserved.
- **Fix 2 (defense-in-depth):** `list_siege_members` in `backend/app/services/siege_members.py` now joins `Member` and filters to `is_active = True`, so any residual stale rows are never surfaced even before a cleanup migration runs.
- **Regression test:** `backend/tests/test_deactivate_stale_siege_member.py` — 5 tests covering: planning roster removal (primary regression), position clearing, and preservation of rows in active/complete sieges, plus direct defense-in-depth filter test.

Closes #485

## Test plan

- [ ] `pytest backend/tests/test_deactivate_stale_siege_member.py` — all 5 pass
- [ ] `pytest backend/tests/ --ignore=backend/tests/integration` — 468 pass (up from 463 baseline)
- [ ] `black --check backend/app/ backend/tests/` — clean
- [ ] `ruff check backend/app/ backend/tests/` — clean
- [ ] Deactivate a member in a planning siege via the UI — member no longer appears in the roster

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt