### PR TITLE
feat(ui): show inactive-member indicator icon on siege roster rows

### DIFF
--- a/backend/app/schemas/siege_member.py
+++ b/backend/app/schemas/siege_member.py
@@ -10,6 +10,7 @@ class SiegeMemberResponse(BaseModel):
     member_name: str = ""
     member_role: str = ""
     member_power_level: str | None = None
+    member_is_active: bool = True
     attack_day: int | None
     has_reserve_set: bool | None
     attack_day_override: bool
@@ -21,6 +22,7 @@ class SiegeMemberResponse(BaseModel):
             data.member_name = data.member.name
             data.member_role = data.member.role
             data.member_power_level = data.member.power_level
+            data.member_is_active = data.member.is_active
         return data
 
 

--- a/backend/tests/test_siege_member_is_active_field.py
+++ b/backend/tests/test_siege_member_is_active_field.py
@@ -1,0 +1,101 @@
+"""Tests for the member_is_active field on SiegeMemberResponse (issue #487).
+
+Verifies that the denormalized ``member_is_active`` boolean is correctly
+populated from the related Member's ``is_active`` attribute, both through
+the ORM from-attributes path (the primary read path) and directly via
+schema instantiation with a mock object.
+"""
+
+from types import SimpleNamespace
+
+from app.schemas.siege_member import SiegeMemberResponse
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal SimpleNamespace that quacks like a SiegeMember ORM
+# row with an eagerly loaded .member relation.
+# ---------------------------------------------------------------------------
+
+
+def _make_orm_row(*, is_active: bool) -> SimpleNamespace:
+    """Return a fake ORM SiegeMember row with a nested .member relation.
+
+    Args:
+        is_active: The ``is_active`` flag to assign to the fake member.
+
+    Returns:
+        A ``SimpleNamespace`` that satisfies the ``model_validator`` in
+        ``SiegeMemberResponse`` — specifically the ``hasattr(data, "member")``
+        branch that reads ``data.member.name``, ``data.member.role``,
+        ``data.member.power_level``, and ``data.member.is_active``.
+    """
+    member = SimpleNamespace(
+        id=1,
+        name="Alice",
+        role="advanced",
+        power_level=None,
+        is_active=is_active,
+    )
+    return SimpleNamespace(
+        siege_id=10,
+        member_id=1,
+        member_name="",
+        member_role="",
+        member_power_level=None,
+        attack_day=1,
+        has_reserve_set=False,
+        attack_day_override=False,
+        member=member,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Active member → member_is_active is True
+# ---------------------------------------------------------------------------
+
+
+def test_siege_member_response_member_is_active_true_for_active_member():
+    """SiegeMemberResponse.member_is_active must be True when member.is_active
+    is True (active clan member appearing in the siege roster).
+    """
+    row = _make_orm_row(is_active=True)
+    response = SiegeMemberResponse.model_validate(row)
+
+    assert (
+        response.member_is_active is True
+    ), "member_is_active must be True when the related member is active"
+
+
+# ---------------------------------------------------------------------------
+# 2. Inactive member → member_is_active is False
+# ---------------------------------------------------------------------------
+
+
+def test_siege_member_response_member_is_active_false_for_inactive_member():
+    """SiegeMemberResponse.member_is_active must be False when member.is_active
+    is False (a deactivated member retained in an active/complete siege for
+    historical purposes — the primary scenario for issue #487).
+    """
+    row = _make_orm_row(is_active=False)
+    response = SiegeMemberResponse.model_validate(row)
+
+    assert (
+        response.member_is_active is False
+    ), "member_is_active must be False when the related member is inactive"
+
+
+# ---------------------------------------------------------------------------
+# 3. Field is present in the serialized JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_siege_member_response_member_is_active_present_in_json():
+    """member_is_active must appear in the serialized response payload so the
+    frontend type can rely on it always being present.
+    """
+    row = _make_orm_row(is_active=True)
+    response = SiegeMemberResponse.model_validate(row)
+    data = response.model_dump()
+
+    assert (
+        "member_is_active" in data
+    ), "member_is_active must be present in the serialized response dict"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -114,6 +114,7 @@ export interface SiegeMember {
   member_name: string;
   member_role: string;
   member_power_level: string | null;
+  member_is_active: boolean;
   attack_day: number | null;
   has_reserve_set: boolean | null;
   attack_day_override: boolean;

--- a/frontend/src/pages/SiegeMembersPage.tsx
+++ b/frontend/src/pages/SiegeMembersPage.tsx
@@ -36,7 +36,7 @@ import {
   DialogFooter,
   DialogDescription,
 } from "../components/ui/dialog";
-import { ArrowLeft, Lock, UserPlus, Loader2 } from "lucide-react";
+import { ArrowLeft, Lock, UserPlus, Loader2, UserX } from "lucide-react";
 
 function AttackDaySelect({
   value,
@@ -86,7 +86,17 @@ function SiegeMemberRow({
 
   return (
     <TableRow>
-      <TableCell className="font-medium">{member.member_name}</TableCell>
+      <TableCell className="font-medium">
+        <span className={member.member_is_active === false ? "text-slate-500" : undefined}>
+          {member.member_name}
+        </span>
+        {member.member_is_active === false && (
+          <UserX
+            className="ml-1 inline-block h-3.5 w-3.5 text-slate-500"
+            aria-label="Inactive member"
+          />
+        )}
+      </TableCell>
       <TableCell className="text-sm text-slate-600">
         {{
           heavy_hitter: "Heavy Hitter",

--- a/frontend/src/test/components/PostsTab.test.tsx
+++ b/frontend/src/test/components/PostsTab.test.tsx
@@ -105,6 +105,7 @@ function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
     member_name: "Aethon",
     member_role: "heavy_hitter",
     member_power_level: "gt_25m",
+    member_is_active: true,
     attack_day: 1,
     has_reserve_set: false,
     attack_day_override: false,

--- a/frontend/src/test/pages/BoardPage.test.tsx
+++ b/frontend/src/test/pages/BoardPage.test.tsx
@@ -94,6 +94,7 @@ function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
     member_name: "Aethon",
     member_role: "heavy_hitter",
     member_power_level: "gt_25m",
+    member_is_active: true,
     attack_day: 1,
     has_reserve_set: false,
     attack_day_override: false,

--- a/frontend/src/test/pages/SiegeMembersPage.inactive.test.tsx
+++ b/frontend/src/test/pages/SiegeMembersPage.inactive.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * SiegeMembersPage — inactive-member indicator icon tests (issue #487)
+ *
+ * Verifies that:
+ *  - When member_is_active is false, a UserX icon with the accessible label
+ *    "Inactive member" appears next to the member's name in the row.
+ *  - When member_is_active is true, no such icon is rendered.
+ *  - The member name text is muted (slate-500/600 class) when the member is
+ *    inactive.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeAll, afterAll, afterEach, describe, it, expect } from "vitest";
+import { Routes, Route } from "react-router-dom";
+import { server } from "../server";
+import { renderWithProviders } from "../utils";
+import SiegeMembersPage from "../../pages/SiegeMembersPage";
+import type { Siege, SiegeMember } from "../../api/types";
+
+// ─── Server lifecycle ──────────────────────────────────────────────────────────
+
+beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── Fixture factories ────────────────────────────────────────────────────────
+
+function makeSiege(overrides: Partial<Siege> = {}): Siege {
+  return {
+    id: 42,
+    date: "2026-06-12",
+    status: "active",
+    defense_scroll_count: 0,
+    computed_scroll_count: 0,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSiegeMember(overrides: Partial<SiegeMember> = {}): SiegeMember {
+  return {
+    siege_id: 42,
+    member_id: 1,
+    member_name: "Alice",
+    member_role: "advanced",
+    member_power_level: null,
+    member_is_active: true,
+    attack_day: 1,
+    has_reserve_set: false,
+    attack_day_override: false,
+    ...overrides,
+  };
+}
+
+function registerHandlers(siege: Siege, members: SiegeMember[]) {
+  server.use(
+    http.get(`/api/sieges/${siege.id}`, () => HttpResponse.json(siege)),
+    http.get(`/api/sieges/${siege.id}/members`, () =>
+      HttpResponse.json(members)
+    )
+  );
+}
+
+function renderPage(siegeId = 42) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/sieges/:id/members" element={<SiegeMembersPage />} />
+    </Routes>,
+    { initialEntries: [`/sieges/${siegeId}/members`] }
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SiegeMembersPage — inactive member indicator icon (#487)", () => {
+  it("renders an accessible inactive-member icon when member_is_active is false", async () => {
+    const siege = makeSiege({ status: "active" });
+    const members = [makeSiegeMember({ member_is_active: false })];
+    registerHandlers(siege, members);
+    renderPage();
+
+    // Wait for the member row to appear
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    // The inactive icon must have the accessible label "Inactive member"
+    expect(
+      screen.getByLabelText("Inactive member")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render an inactive-member icon when member_is_active is true", async () => {
+    const siege = makeSiege({ status: "active" });
+    const members = [makeSiegeMember({ member_is_active: true })];
+    registerHandlers(siege, members);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    // No inactive icon expected
+    expect(
+      screen.queryByLabelText("Inactive member")
+    ).not.toBeInTheDocument();
+  });
+
+  it("mutes the name text when the member is inactive", async () => {
+    const siege = makeSiege({ status: "active" });
+    const members = [makeSiegeMember({ member_is_active: false })];
+    registerHandlers(siege, members);
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+    });
+
+    // The name element must carry a muted-text class (slate-500 or slate-600)
+    const nameEl = screen.getByText("Alice");
+    expect(
+      nameEl.className.includes("text-slate-500") ||
+        nameEl.className.includes("text-slate-600")
+    ).toBe(true);
+  });
+});

--- a/frontend/src/test/pages/SiegeMembersPage.test.tsx
+++ b/frontend/src/test/pages/SiegeMembersPage.test.tsx
@@ -51,6 +51,7 @@ function makeSiegeMember(
     member_name: "Alpha",
     member_role: "heavy_hitter",
     member_power_level: "gt_25m",
+    member_is_active: true,
     attack_day: null,
     has_reserve_set: false,
     attack_day_override: false,


### PR DESCRIPTION
## Summary

- Adds `member_is_active: bool` (default `True`) to `SiegeMemberResponse`, populated from `member.is_active` in the existing `resolve_member_fields` model validator alongside `member_name` / `member_role`.
- Adds `member_is_active: boolean` to the `SiegeMember` TypeScript interface in `types.ts`.
- In `SiegeMemberRow`, when `member.member_is_active === false`: renders a `UserX` lucide icon (h-3.5 w-3.5 text-slate-500, aria-label="Inactive member") immediately after the member name, and wraps the name in `text-slate-500` to mute it visually. Follows the exact pattern of the existing `Lock`/pinned icon in the same component.

## Hand-rolled SiegeMemberResponse construction sites

Audited all `SiegeMemberResponse` usages. All three API routes (`list_siege_members`, `add_siege_member`, `update_siege_member`) return ORM objects covered by `from_attributes=True` — no hand-rolled dict-builders exist.

The `get_siege_member_preferences` service does hand-roll a dict, but it constructs `MemberPreferenceSummary` (a different schema), not `SiegeMemberResponse` — so it is unaffected.

## Test plan

- [x] **Backend RED→GREEN**: `test_siege_member_response_member_is_active_true_for_active_member`, `test_siege_member_response_member_is_active_false_for_inactive_member`, `test_siege_member_response_member_is_active_present_in_json` — all watched fail before implementation, then pass.
- [x] **Frontend RED→GREEN**: `renders an accessible inactive-member icon when member_is_active is false`, `does not render an inactive-member icon when member_is_active is true`, `mutes the name text when the member is inactive` — all watched fail before implementation, then pass.
- [x] Backend full suite: 474 passed (up from 471 baseline), 45 errors (identical pre-existing sidecar errors, unchanged).
- [x] Frontend full suite: 244 passed (up from 241 baseline), 0 failures.
- [x] `black` + `ruff check` clean on all changed Python files.
- [x] `eslint` 0 errors on changed frontend files.
- [x] `npm run build` exits 0 (chunk size warning is pre-existing).

Closes #487

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_