### PR TITLE
feat(bot/http_api): enrich exception handler logs with request context

### DIFF
--- a/bot/app/http_api.py
+++ b/bot/app/http_api.py
@@ -66,7 +66,7 @@ app = FastAPI(title="Siege Bot HTTP API", version="0.1.0")
 
 
 @app.exception_handler(discord.Forbidden)
-async def _handle_discord_forbidden(_request: Request, exc: discord.Forbidden) -> JSONResponse:
+async def _handle_discord_forbidden(request: Request, exc: discord.Forbidden) -> JSONResponse:
     """Translate discord.Forbidden to HTTP 403.
 
     Raised when the bot lacks channel permissions or a user's DMs are
@@ -74,13 +74,20 @@ async def _handle_discord_forbidden(_request: Request, exc: discord.Forbidden) -
     the response body per the module's error envelope policy.
 
     Args:
-        _request: The incoming FastAPI request (intentionally unused).
+        request: The incoming FastAPI request; method and path are
+            included in the WARNING log for operator diagnostics.
         exc: The discord.Forbidden exception instance.
 
     Returns:
         JSONResponse with status 403 and a generic detail message.
     """
-    logger.warning("Discord Forbidden: status=%s text=%r", exc.status, exc.text)
+    logger.warning(
+        "Discord Forbidden on %s %s: status=%s text=%r",
+        request.method,
+        request.url.path,
+        exc.status,
+        exc.text,
+    )
     return JSONResponse(
         status_code=status.HTTP_403_FORBIDDEN,
         content={"detail": "Discord permission denied"},
@@ -88,7 +95,7 @@ async def _handle_discord_forbidden(_request: Request, exc: discord.Forbidden) -
 
 
 @app.exception_handler(discord.NotFound)
-async def _handle_discord_not_found(_request: Request, exc: discord.NotFound) -> JSONResponse:
+async def _handle_discord_not_found(request: Request, exc: discord.NotFound) -> JSONResponse:
     """Translate discord.NotFound to HTTP 404.
 
     Raised when the target channel, message, or user does not exist.
@@ -97,13 +104,20 @@ async def _handle_discord_not_found(_request: Request, exc: discord.NotFound) ->
     response body per the module's error envelope policy.
 
     Args:
-        _request: The incoming FastAPI request (intentionally unused).
+        request: The incoming FastAPI request; method and path are
+            included in the WARNING log for operator diagnostics.
         exc: The discord.NotFound exception instance.
 
     Returns:
         JSONResponse with status 404 and a generic detail message.
     """
-    logger.warning("Discord NotFound: status=%s text=%r", exc.status, exc.text)
+    logger.warning(
+        "Discord NotFound on %s %s: status=%s text=%r",
+        request.method,
+        request.url.path,
+        exc.status,
+        exc.text,
+    )
     return JSONResponse(
         status_code=status.HTTP_404_NOT_FOUND,
         content={"detail": "Discord resource not found"},
@@ -112,7 +126,7 @@ async def _handle_discord_not_found(_request: Request, exc: discord.NotFound) ->
 
 @app.exception_handler(discord.HTTPException)
 async def _handle_discord_http_exception(
-    _request: Request, exc: discord.HTTPException
+    request: Request, exc: discord.HTTPException
 ) -> JSONResponse:
     """Translate discord.HTTPException to 502 or 503.
 
@@ -128,14 +142,17 @@ async def _handle_discord_http_exception(
     excluded from response bodies per the module's error envelope policy.
 
     Args:
-        _request: The incoming FastAPI request (intentionally unused).
+        request: The incoming FastAPI request; method and path are
+            included in the WARNING log for operator diagnostics.
         exc: The discord.HTTPException instance.
 
     Returns:
         JSONResponse with status 502 or 503 and a generic detail message.
     """
     logger.warning(
-        "Discord HTTPException: status=%s text=%r",
+        "Discord HTTPException on %s %s: status=%s text=%r",
+        request.method,
+        request.url.path,
         exc.status,
         exc.text,
     )
@@ -151,7 +168,7 @@ async def _handle_discord_http_exception(
 
 
 @app.exception_handler(asyncio.TimeoutError)
-async def _handle_timeout(_request: Request, exc: asyncio.TimeoutError) -> JSONResponse:
+async def _handle_timeout(request: Request, exc: asyncio.TimeoutError) -> JSONResponse:
     """Translate asyncio.TimeoutError to HTTP 503.
 
     Raised when a Discord API call exceeds its configured timeout.
@@ -159,13 +176,14 @@ async def _handle_timeout(_request: Request, exc: asyncio.TimeoutError) -> JSONR
     for consistency with the module's error envelope policy.
 
     Args:
-        _request: The incoming FastAPI request (intentionally unused).
+        request: The incoming FastAPI request; method and path are
+            included in the WARNING log for operator diagnostics.
         exc: The asyncio.TimeoutError instance.
 
     Returns:
         JSONResponse with status 503 and a generic detail message.
     """
-    logger.warning("Discord timeout: %r", exc)
+    logger.warning("Discord timeout on %s %s: %r", request.method, request.url.path, exc)
     return JSONResponse(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         content={"detail": "Discord temporarily unavailable"},

--- a/bot/tests/test_http_api.py
+++ b/bot/tests/test_http_api.py
@@ -748,3 +748,134 @@ async def test_role_sync_malformed_payload_returns_422(client):
         )
     http_api_module._bot = None
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Request context (endpoint + method) enrichment in exception handler logs
+# (#432)
+#
+# Each test triggers one of the four global Discord exception handlers and
+# asserts that the WARNING log record now contains both the HTTP method and
+# the endpoint path alongside the existing Discord fields.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forbidden_handler_logs_request_method_and_path(client, caplog):
+    """_handle_discord_forbidden logs request method and path (closes #432).
+
+    The WARNING record must contain the HTTP method (POST) and the endpoint
+    path (/api/notify) in addition to the existing Discord status/text
+    fields.  Raw exc.text must appear in logs but never in the response body.
+    """
+    bot = _make_mock_bot()
+    response = MagicMock()
+    response.status = 403
+    response.reason = "Forbidden"
+    bot.send_dm.side_effect = discord.Forbidden(response, "Missing Permissions")
+    http_api_module._bot = bot
+
+    caplog.set_level(logging.WARNING, logger="app.http_api")
+    async with client as c:
+        resp = await c.post(
+            "/api/notify",
+            json={"username": "alice", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+
+    http_api_module._bot = None
+    assert resp.status_code == 403
+    # Response body must NOT contain raw Discord detail.
+    assert "Missing Permissions" not in resp.text
+    # Log record must include both method and path.
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "POST" in msg and "/api/notify" in msg for msg in warning_messages
+    ), f"Expected method+path in log, got: {warning_messages}"
+
+
+@pytest.mark.asyncio
+async def test_not_found_handler_logs_request_method_and_path(client, caplog):
+    """_handle_discord_not_found logs request method and path (closes #432).
+
+    The WARNING record must contain the HTTP method (POST) and the endpoint
+    path (/api/post-message) alongside the existing Discord status/text.
+    """
+    bot = _make_mock_bot()
+    response = MagicMock()
+    response.status = 404
+    response.reason = "Not Found"
+    bot.post_message.side_effect = discord.NotFound(response, "Unknown Channel")
+    http_api_module._bot = bot
+
+    caplog.set_level(logging.WARNING, logger="app.http_api")
+    async with client as c:
+        resp = await c.post(
+            "/api/post-message",
+            json={"channel_name": "no-such-channel", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+
+    http_api_module._bot = None
+    assert resp.status_code == 404
+    assert "Unknown Channel" not in resp.text
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "POST" in msg and "/api/post-message" in msg for msg in warning_messages
+    ), f"Expected method+path in log, got: {warning_messages}"
+
+
+@pytest.mark.asyncio
+async def test_http_exception_handler_logs_request_method_and_path(client, caplog):
+    """_handle_discord_http_exception logs request method and path (closes #432).
+
+    Triggers the generic HTTPException handler (status 429, not Forbidden/
+    NotFound) and asserts the WARNING log contains method and path.
+    """
+    bot = _make_mock_bot()
+    bot.post_image.side_effect = _discord_http_exc(429, "You are being rate limited")
+    http_api_module._bot = bot
+
+    caplog.set_level(logging.WARNING, logger="app.http_api")
+    async with client as c:
+        resp = await c.post(
+            "/api/post-image",
+            data={"channel_name": "siege-images"},
+            files={"file": ("board.png", b"fake-png", "image/png")},
+            headers=AUTH_HEADER,
+        )
+
+    http_api_module._bot = None
+    assert resp.status_code == 502
+    assert "rate limited" not in resp.text
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "POST" in msg and "/api/post-image" in msg for msg in warning_messages
+    ), f"Expected method+path in log, got: {warning_messages}"
+
+
+@pytest.mark.asyncio
+async def test_timeout_handler_logs_request_method_and_path(client, caplog):
+    """_handle_timeout logs request method and path (closes #432).
+
+    Triggers the asyncio.TimeoutError handler via post_message and asserts
+    the WARNING log contains the HTTP method and endpoint path.
+    """
+    bot = _make_mock_bot()
+    bot.post_message.side_effect = asyncio.TimeoutError()  # noqa: UP041
+    http_api_module._bot = bot
+
+    caplog.set_level(logging.WARNING, logger="app.http_api")
+    async with client as c:
+        resp = await c.post(
+            "/api/post-message",
+            json={"channel_name": "general", "message": "hi"},
+            headers=AUTH_HEADER,
+        )
+
+    http_api_module._bot = None
+    assert resp.status_code == 503
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "POST" in msg and "/api/post-message" in msg for msg in warning_messages
+    ), f"Expected method+path in log, got: {warning_messages}"


### PR DESCRIPTION
## Summary

- All four global discord.py exception handlers (`Forbidden`, `NotFound`, `HTTPException`, `TimeoutError`) now include the HTTP method and endpoint path in their `WARNING` log records alongside the existing Discord `status`/`text` fields.
- The `_request` parameter is renamed to `request` in each handler (consistent, lint-clean — no longer unused).
- Security boundary from issue #422 is fully preserved: raw Discord `text` appears in server logs only, never in response bodies.

## Log format after this change

| Handler | Format string |
|---|---|
| `Forbidden` | `"Discord Forbidden on %s %s: status=%s text=%r"` |
| `NotFound` | `"Discord NotFound on %s %s: status=%s text=%r"` |
| `HTTPException` | `"Discord HTTPException on %s %s: status=%s text=%r"` |
| `TimeoutError` | `"Discord timeout on %s %s: %r"` |

## Test plan

- [x] Four new `caplog`-based tests added to `bot/tests/test_http_api.py` covering one handler each; each asserts `POST` + the endpoint path appear in the WARNING log record.
- [x] Tests were written first (RED: 4 failed), then implementation applied (GREEN: 4 pass).
- [x] Existing security-boundary tests (`test_notify_discord_forbidden_logs_raw_text`, `test_notify_discord_forbidden_with_text_none_returns_403`) still pass.
- [x] Full suite: **69 passed, 0 failed** (was 65 before; +4 new tests).
- [x] `black --check`: all files unchanged.
- [x] `ruff check`: all checks passed.

Closes #432

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_