### PR TITLE
fix(notify-discord): remove broken timestamp guard; add workflow_dispatch re-fire

### DIFF
--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -111,25 +111,30 @@ jobs:
             RELEASE_PUBLISHED="$EVT_PUBLISHED"
           fi
 
-          # Write all resolved values to GITHUB_ENV for downstream steps.
-          {
-            echo "RELEASE_TAG=$TAG_NAME"
-            echo "RELEASE_NAME=$RELEASE_NAME"
-            echo "RELEASE_URL=$RELEASE_URL"
-            echo "RELEASE_PRERELEASE=$RELEASE_PRERELEASE"
-            echo "RELEASE_AUTHOR=$RELEASE_AUTHOR"
-            echo "RELEASE_PUBLISHED=$RELEASE_PUBLISHED"
-          } >> "$GITHUB_ENV"
+          # Write all resolved values to GITHUB_ENV using heredoc-style writes
+          # so that ANY value containing a newline (release name, author, etc.)
+          # cannot corrupt the env file or inject unintended env vars.
+          # A single random delimiter is generated once per run and reused for
+          # every field — collision per field is impossible since each heredoc
+          # block is self-contained and the delimiter is 2^128-random.
+          DELIM="GHENV_EOF_$(openssl rand -hex 16)"
 
-          # RELEASE_BODY may be multi-line — write with a per-run unique
-          # delimiter so no release-body line can collide with the sentinel
-          # and end the heredoc early (or inject env vars).
-          DELIM="RELEASE_BODY_EOF_$(openssl rand -hex 16)"
-          {
-            echo "RELEASE_BODY<<$DELIM"
-            printf '%s\n' "$RELEASE_BODY"
-            echo "$DELIM"
-          } >> "$GITHUB_ENV"
+          # Helper: write_env KEY VALUE
+          write_env() {
+            {
+              echo "$1<<$DELIM"
+              printf '%s\n' "$2"
+              echo "$DELIM"
+            } >> "$GITHUB_ENV"
+          }
+
+          write_env RELEASE_TAG       "$TAG_NAME"
+          write_env RELEASE_NAME      "$RELEASE_NAME"
+          write_env RELEASE_URL       "$RELEASE_URL"
+          write_env RELEASE_PRERELEASE "$RELEASE_PRERELEASE"
+          write_env RELEASE_AUTHOR    "$RELEASE_AUTHOR"
+          write_env RELEASE_PUBLISHED "$RELEASE_PUBLISHED"
+          write_env RELEASE_BODY      "$RELEASE_BODY"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -121,12 +121,14 @@ jobs:
             echo "RELEASE_PUBLISHED=$RELEASE_PUBLISHED"
           } >> "$GITHUB_ENV"
 
-          # RELEASE_BODY may be multi-line — write with heredoc delimiter.
+          # RELEASE_BODY may be multi-line — write with a per-run unique
+          # delimiter so no release-body line can collide with the sentinel
+          # and end the heredoc early (or inject env vars).
+          DELIM="RELEASE_BODY_EOF_$(openssl rand -hex 16)"
           {
-            echo "RELEASE_BODY<<__BODY_EOF__"
-            printf '%s' "$RELEASE_BODY"
-            echo ""
-            echo "__BODY_EOF__"
+            echo "RELEASE_BODY<<$DELIM"
+            printf '%s\n' "$RELEASE_BODY"
+            echo "$DELIM"
           } >> "$GITHUB_ENV"
 
       - name: Checkout code

--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -70,11 +70,27 @@ jobs:
       - name: Resolve release metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # All github.event.* and inputs.* values are mapped here so that
+          # bash sees them as environment variables — never as literal text
+          # substituted into the script before the shell parses it.  This
+          # eliminates the script-injection vector (backticks, $(...), quotes,
+          # newlines in release body are shell-data, not shell-syntax).
+          EVENT_NAME:     ${{ github.event_name }}
+          INPUT_TAG:      ${{ inputs.tag }}
+          GH_REPOSITORY:  ${{ github.repository }}
+          EVT_TAG:        ${{ github.event.release.tag_name }}
+          EVT_NAME:       ${{ github.event.release.name }}
+          EVT_BODY:       ${{ github.event.release.body }}
+          EVT_URL:        ${{ github.event.release.html_url }}
+          EVT_PRERELEASE: ${{ github.event.release.prerelease }}
+          EVT_AUTHOR:     ${{ github.event.release.author.login }}
+          EVT_PUBLISHED:  ${{ github.event.release.published_at }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             # Fetch release metadata from the GitHub CLI for the given tag.
-            release_json=$(gh release view "${{ inputs.tag }}" \
-              --repo "${{ github.repository }}" \
+            # INPUT_TAG comes from env — no expression interpolation in the script body.
+            release_json=$(gh release view "$INPUT_TAG" \
+              --repo "$GH_REPOSITORY" \
               --json tagName,name,body,url,isPrerelease,author,publishedAt)
 
             TAG_NAME=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['tagName'])")
@@ -85,13 +101,14 @@ jobs:
             RELEASE_AUTHOR=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('author', {}).get('login', ''))")
             RELEASE_PUBLISHED=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['publishedAt'])")
           else
-            TAG_NAME="${{ github.event.release.tag_name }}"
-            RELEASE_NAME="${{ github.event.release.name }}"
-            RELEASE_BODY="${{ github.event.release.body }}"
-            RELEASE_URL="${{ github.event.release.html_url }}"
-            RELEASE_PRERELEASE="${{ github.event.release.prerelease }}"
-            RELEASE_AUTHOR="${{ github.event.release.author.login }}"
-            RELEASE_PUBLISHED="${{ github.event.release.published_at }}"
+            # release event: values come from env vars, not expression interpolation.
+            TAG_NAME="$EVT_TAG"
+            RELEASE_NAME="$EVT_NAME"
+            RELEASE_BODY="$EVT_BODY"
+            RELEASE_URL="$EVT_URL"
+            RELEASE_PRERELEASE="$EVT_PRERELEASE"
+            RELEASE_AUTHOR="$EVT_AUTHOR"
+            RELEASE_PUBLISHED="$EVT_PUBLISHED"
           fi
 
           # Write all resolved values to GITHUB_ENV for downstream steps.

--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -159,12 +159,15 @@ jobs:
             --url  "$RELEASE_URL")
 
           # Write to GITHUB_OUTPUT using a heredoc so multi-line values are
-          # handled safely by the Actions runner (EOF delimiter is unique).
+          # handled safely by the Actions runner.  Per-run unique delimiter
+          # prevents a highlights line equal to the sentinel from ending the
+          # heredoc early (same collision class as RELEASE_BODY in step above).
+          HL_DELIM="HIGHLIGHTS_EOF_$(openssl rand -hex 16)"
           {
-            echo "description<<__HIGHLIGHTS_EOF__"
+            echo "description<<$HL_DELIM"
             printf '%s' "$description"
             echo ""
-            echo "__HIGHLIGHTS_EOF__"
+            echo "$HL_DELIM"
           } >> "$GITHUB_OUTPUT"
 
       # ── POST to Discord ───────────────────────────────────────────────────

--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -14,9 +14,13 @@
 #
 # ── What triggers a post ─────────────────────────────────────────────────────
 #
-#   Only fires on the initial publication of a release (created_at ==
-#   published_at per coord §R7).  Body-edit re-publications are skipped with
-#   an annotation so the log is clear but no false post is sent.
+#   release: types: [published]
+#     Fires only on the initial publication transition.  Body-edit events
+#     emit type "edited", not "published", so no timestamp guard is needed.
+#
+#   workflow_dispatch (tag input)
+#     Allows re-firing a missed or failed announcement for any existing tag
+#     without needing to re-publish the GitHub Release.
 #
 # ── Embed colour ─────────────────────────────────────────────────────────────
 #
@@ -42,6 +46,12 @@ name: Notify Discord — Release Published
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v1.4.0)"
+        required: true
+        type: string
 
 # No GitHub API writes — read-only is sufficient.
 permissions:
@@ -53,25 +63,62 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # ── Idempotency guard (coord §R7) ─────────────────────────────────────
-      # A re-publication (body edit) sets published_at > created_at.
-      # Log a notice and let the job succeed without posting.
-      # All downstream steps are gated on the inverse condition so they
-      # only execute on the initial publication.
-      - name: Skip re-publications
-        if: github.event.release.created_at != github.event.release.published_at
+      # ── Resolve release metadata ──────────────────────────────────────────
+      # On `release` events, read directly from github.event.release.*.
+      # On `workflow_dispatch`, fetch via `gh release view` for the given tag.
+      # Either way, writes the same set of env vars consumed by later steps.
+      - name: Resolve release metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::notice::Skipping Discord notification — this is a re-publication (body edit), not the initial publish. created_at=${{ github.event.release.created_at }} published_at=${{ github.event.release.published_at }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Fetch release metadata from the GitHub CLI for the given tag.
+            release_json=$(gh release view "${{ inputs.tag }}" \
+              --repo "${{ github.repository }}" \
+              --json tagName,name,body,url,isPrerelease,author,publishedAt)
+
+            TAG_NAME=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['tagName'])")
+            RELEASE_NAME=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['name'])")
+            RELEASE_BODY=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['body'])")
+            RELEASE_URL=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['url'])")
+            RELEASE_PRERELEASE=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d['isPrerelease']).lower())")
+            RELEASE_AUTHOR=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('author', {}).get('login', ''))")
+            RELEASE_PUBLISHED=$(printf '%s' "$release_json" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['publishedAt'])")
+          else
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            RELEASE_NAME="${{ github.event.release.name }}"
+            RELEASE_BODY="${{ github.event.release.body }}"
+            RELEASE_URL="${{ github.event.release.html_url }}"
+            RELEASE_PRERELEASE="${{ github.event.release.prerelease }}"
+            RELEASE_AUTHOR="${{ github.event.release.author.login }}"
+            RELEASE_PUBLISHED="${{ github.event.release.published_at }}"
+          fi
+
+          # Write all resolved values to GITHUB_ENV for downstream steps.
+          {
+            echo "RELEASE_TAG=$TAG_NAME"
+            echo "RELEASE_NAME=$RELEASE_NAME"
+            echo "RELEASE_URL=$RELEASE_URL"
+            echo "RELEASE_PRERELEASE=$RELEASE_PRERELEASE"
+            echo "RELEASE_AUTHOR=$RELEASE_AUTHOR"
+            echo "RELEASE_PUBLISHED=$RELEASE_PUBLISHED"
+          } >> "$GITHUB_ENV"
+
+          # RELEASE_BODY may be multi-line — write with heredoc delimiter.
+          {
+            echo "RELEASE_BODY<<__BODY_EOF__"
+            printf '%s' "$RELEASE_BODY"
+            echo ""
+            echo "__BODY_EOF__"
+          } >> "$GITHUB_ENV"
 
       - name: Checkout code
-        if: github.event.release.created_at == github.event.release.published_at
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       # ── Validate secrets ──────────────────────────────────────────────────
       # Fail fast if the webhook URL is not configured, rather than
       # reaching the POST step and getting an empty-URL curl error.
       - name: Validate webhook secret
-        if: github.event.release.created_at == github.event.release.published_at
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
         run: |
@@ -85,13 +132,7 @@ jobs:
       # ## Highlights section (emoji optional), applies the 1500-char soft cap,
       # and falls back to "<name> published. View notes: <url>" if missing.
       - name: Extract Highlights description
-        if: github.event.release.created_at == github.event.release.published_at
         id: highlights
-        env:
-          RELEASE_BODY: ${{ github.event.release.body }}
-          RELEASE_TAG:  ${{ github.event.release.tag_name }}
-          RELEASE_NAME: ${{ github.event.release.name }}
-          RELEASE_URL:  ${{ github.event.release.html_url }}
         run: |
           description=$(printf '%s' "$RELEASE_BODY" | python3 scripts/extract_highlights.py \
             --tag  "$RELEASE_TAG" \
@@ -109,14 +150,8 @@ jobs:
 
       # ── POST to Discord ───────────────────────────────────────────────────
       - name: Post embed to Discord
-        if: github.event.release.created_at == github.event.release.published_at
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-          RELEASE_TAG:         ${{ github.event.release.tag_name }}
-          RELEASE_URL:         ${{ github.event.release.html_url }}
-          RELEASE_PRERELEASE:  ${{ github.event.release.prerelease }}
-          RELEASE_AUTHOR:      ${{ github.event.release.author.login }}
-          RELEASE_PUBLISHED:   ${{ github.event.release.published_at }}
           DESCRIPTION:         ${{ steps.highlights.outputs.description }}
         run: |
           # ── Title (coord §R3, §R8) ──────────────────────────────────────


### PR DESCRIPTION
## Root cause

The `created_at == published_at` guard (coord §R7) was designed to skip re-publications caused by body edits. The assumption was that an initial publish would have equal timestamps. That assumption is FALSE.

When `gh release create <tag> --target main` is used, GitHub stamps `created_at` from the underlying tag's **commit date** and `published_at` from the **publish API call**. A fresh publish therefore always has `created_at < published_at`, so the guard evaluates false and suppresses the initial announcement — the exact thing it was supposed to allow through.

## Fix

1. **Removed the timestamp guard entirely.** The `release: types: [published]` trigger already provides correct dedup: body-edit events emit type `edited`, not `published`. The equality guard was redundant and broken. Deleted: the "Skip re-publications" step + all four `if: github.event.release.created_at == github.event.release.published_at` conditions on real steps.

2. **Added `workflow_dispatch` trigger** with a required `tag` input (e.g. `v1.4.0`) so a missed or failed announcement can be re-fired manually without re-publishing the GitHub Release.

3. **Added "Resolve release metadata" step** that detects `github.event_name` and populates a uniform set of `$GITHUB_ENV` vars (`RELEASE_TAG`, `RELEASE_NAME`, `RELEASE_BODY`, `RELEASE_URL`, `RELEASE_PRERELEASE`, `RELEASE_AUTHOR`, `RELEASE_PUBLISHED`) from the correct source:
   - `release` event → reads `github.event.release.*` fields directly
   - `workflow_dispatch` → calls `gh release view "${{ inputs.tag }}"` via `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (already within `contents: read`)

   All downstream steps (`Checkout`, `Validate webhook secret`, `Extract Highlights`, `Post embed`) consume only `$GITHUB_ENV` shell vars — no `github.event.release.*` expressions appear outside the resolve step's `else` branch.

## Per-trigger env-var source trace

| Env var | `release` event source | `workflow_dispatch` source |
|---|---|---|
| `RELEASE_TAG` | `github.event.release.tag_name` | `gh release view` → `tagName` |
| `RELEASE_NAME` | `github.event.release.name` | `gh release view` → `name` |
| `RELEASE_BODY` | `github.event.release.body` | `gh release view` → `body` |
| `RELEASE_URL` | `github.event.release.html_url` | `gh release view` → `url` |
| `RELEASE_PRERELEASE` | `github.event.release.prerelease` | `gh release view` → `isPrerelease` (lowercased) |
| `RELEASE_AUTHOR` | `github.event.release.author.login` | `gh release view` → `author.login` |
| `RELEASE_PUBLISHED` | `github.event.release.published_at` | `gh release view` → `publishedAt` |

No `github.event.release.*` reference appears in any step that runs on `workflow_dispatch`. No `created_at` or `published_at` equality comparison exists anywhere in the file.

## Validation

- YAML parser: `python3 -c "import yaml,sys; yaml.safe_load(...)"` → valid
- actionlint: exit 0, zero findings
- Manual grep: no `created_at`/`published_at` guard, no `github.event.release.*` outside resolve step else-branch

Closes #493

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_