### PR TITLE
fix(validation): allow group_number=10 for level-6 stronghold

### DIFF
--- a/backend/app/services/validation.py
+++ b/backend/app/services/validation.py
@@ -145,15 +145,19 @@ async def validate_siege(session: AsyncSession, siege_id: int) -> ValidationResu
                     )
                 )
 
-    # Rule 4: Group numbers 1–9
+    # Rule 4: Group numbers 1–10
+    # Upper bound matches the DB CHECK constraint on building_group.group_number
+    # (group_number >= 1 AND group_number <= 10) — level-6 strongholds have 10
+    # groups, so 10 is the true global maximum.  See: models/building_group.py.
+    _GROUP_NUMBER_MAX = 10
     for pos, group, building in all_positions:
-        if group.group_number < 1 or group.group_number > 9:
+        if group.group_number < 1 or group.group_number > _GROUP_NUMBER_MAX:
             errors.append(
                 ValidationIssue(
                     rule=4,
                     message=(
                         f"Group id={group.id} has group_number "
-                        f"{group.group_number} outside [1, 9]"
+                        f"{group.group_number} outside [1, {_GROUP_NUMBER_MAX}]"
                     ),
                     context={"group_id": group.id, "building_id": building.id},
                 )

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -418,7 +418,49 @@ async def test_rule3_valid_building_number():
 
 @pytest.mark.asyncio
 async def test_rule4_invalid_group_number():
-    """Rule 4: group_number=10 → error."""
+    """Rule 4: group_number=11 exceeds the maximum of 10 → error.
+
+    Level-6 strongholds have 10 groups; group_number=11 is always invalid.
+    """
+    pos = _make_position(id=1)
+    group = _make_group(id=1, group_number=11)
+    group.positions = [pos]
+    building = _make_building(id=1)
+    building.groups = [group]
+    siege = _make_siege()
+    siege.buildings = [building]
+
+    session = _session_with_siege_and_configs(siege)
+    result = await svc_validate(session, 1)
+    rule4_errors = [e for e in result.errors if e.rule == 4]
+    assert len(rule4_errors) >= 1
+
+
+@pytest.mark.asyncio
+async def test_rule4_group_number_zero_is_invalid():
+    """Rule 4: group_number=0 is below the minimum of 1 → error."""
+    pos = _make_position(id=1)
+    group = _make_group(id=1, group_number=0)
+    group.positions = [pos]
+    building = _make_building(id=1)
+    building.groups = [group]
+    siege = _make_siege()
+    siege.buildings = [building]
+
+    session = _session_with_siege_and_configs(siege)
+    result = await svc_validate(session, 1)
+    rule4_errors = [e for e in result.errors if e.rule == 4]
+    assert len(rule4_errors) >= 1
+
+
+@pytest.mark.asyncio
+async def test_rule4_group_number_10_is_valid():
+    """Rule 4 pass: group_number=10 is valid for a level-6 stronghold.
+
+    The DB CHECK constraint allows group_number in [1, 10].  The validator
+    must align with the DB: group_number=10 must not produce a Rule 4 error.
+    Regression test for GitHub issue #495.
+    """
     pos = _make_position(id=1)
     group = _make_group(id=1, group_number=10)
     group.positions = [pos]
@@ -430,7 +472,10 @@ async def test_rule4_invalid_group_number():
     session = _session_with_siege_and_configs(siege)
     result = await svc_validate(session, 1)
     rule4_errors = [e for e in result.errors if e.rule == 4]
-    assert len(rule4_errors) >= 1
+    assert len(rule4_errors) == 0, (
+        "group_number=10 is valid for a level-6 stronghold (10 groups); "
+        f"Rule 4 must not fire, but got: {rule4_errors}"
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -224,7 +224,7 @@ Phase 8 (Excel Import Script) ── can run any time after Phase 3; defer post-
    1. All assigned members must be active
    2. No member assigned more than `defense_scroll_count` times
    3. Building numbers within type-specific range
-   4. Group numbers 1–9
+   4. Group numbers 1–10 (level-6 strongholds have 10 groups)
    5. Position numbers 1 to `slot_count`
    6. Attack day must be 1 or 2
    7. Post buildings have exactly 1 group

--- a/docs/WEB_DESIGN_DOCUMENT.md
+++ b/docs/WEB_DESIGN_DOCUMENT.md
@@ -193,7 +193,7 @@ Represents an attack group within a building.
 |---|---|---|---|
 | `id` | PK | Auto-generated | |
 | `building_id` | FK → Building | NOT NULL, ON DELETE CASCADE | |
-| `group_number` | INT | 1-9, NOT NULL | Group within the building |
+| `group_number` | INT | 1-10, NOT NULL | Group within the building (level-6 strongholds have 10 groups) |
 | `slot_count` | INT | 1-3, NOT NULL, DEFAULT 3 | Number of position slots in this group |
 
 **Unique constraint:** `(building_id, group_number)`
@@ -1231,7 +1231,7 @@ Seeded into the `PostCondition` table on initial deployment. 36 conditions total
 
 | Constraint | Value | Notes |
 |---|---|---|
-| Group range | 1-9 | Per building |
+| Group range | 1-10 | Per building (level-6 strongholds have 10 groups) |
 | Position range | 1-3 | Per group; last group in a building may have fewer slots (see section 3.3) |
 | Building number range | 1-18 | Building instance on the siege map |
 | Attack days | 1 or 2 | Siege runs over 2 days |
@@ -1261,7 +1261,7 @@ These rules block siege activation and should also be enforced on individual wri
 | 1 | All assigned members active | Every `position.member_id` must reference an active `Member` record | VBA Validate |
 | 2 | No over-assignment | No member may be assigned to more positions than `siege.defense_scroll_count` | VBA Validate |
 | 3 | Building number valid | Building numbers must be within type-specific range (see `BuildingTypeConfig`) | Python `Position.__init__` |
-| 4 | Group number valid | Group numbers must be 1-9 | Python `Position.__init__` |
+| 4 | Group number valid | Group numbers must be 1-10 | Python `Position.__init__` |
 | 5 | Position number valid | Position numbers must be 1 to `building_group.slot_count` | Python `Position.__init__` |
 | 6 | Attack day valid | Attack day must be 1 or 2 (in `SiegeMember` records) | Python `SiegeAssignment.__init__` |
 | 7 | Post group constraint | Post buildings must have exactly 1 group with `slot_count` matching `BuildingTypeConfig` | Domain rule from GAPS.md |


### PR DESCRIPTION
## Problem

Siege validation rejects `group_number=10` as out-of-range, even though a level-6 stronghold has 10 groups. The validator hardcoded the upper bound as `9`, but the DB CHECK constraint on `building_group.group_number` already allows up to `10`.

## Root cause

`backend/app/services/validation.py` line 150:
```python
# Before
if group.group_number < 1 or group.group_number > 9:
```
Error message at lines 155–156 read `outside [1, 9]`.

## Fix

Aligned the validator upper bound with the DB CHECK constraint (10), using a named local constant `_GROUP_NUMBER_MAX = 10` with an inline comment pointing at `models/building_group.py` as the authoritative source.

```python
# After
_GROUP_NUMBER_MAX = 10  # matches DB CHECK: group_number >= 1 AND group_number <= 10
if group.group_number < 1 or group.group_number > _GROUP_NUMBER_MAX:
```
Error message updated to `outside [1, 10]`.

## Tests

Updated `test_rule4_invalid_group_number` to use `group_number=11` (always invalid). Added:
- `test_rule4_group_number_10_is_valid` — regression for #495; confirmed RED before fix, GREEN after
- `test_rule4_group_number_zero_is_invalid` — boundary check at minimum

## Verification

| Check | Before | After |
|---|---|---|
| `black --check app/ tests/` | clean | clean |
| `ruff check app/ tests/` | clean | clean |
| `pytest --ignore=tests/test_schema.py` | 485 passed, 45 errors | 487 passed, 45 errors |

The 45 errors are pre-existing sidecar integration tests that require a live bot process; identical named tests as baseline.

Closes #495

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_