### PR TITLE
ci: scope notify-discord-release job to prod environment for webhook secret

### DIFF
--- a/.github/workflows/notify-discord-release.yml
+++ b/.github/workflows/notify-discord-release.yml
@@ -61,6 +61,7 @@ jobs:
   notify:
     name: Post Discord Release Embed
     runs-on: ubuntu-latest
+    environment: prod
 
     steps:
       # ── Resolve release metadata ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

`DISCORD_RELEASE_WEBHOOK_URL` is stored as a **prod environment secret** in GitHub Actions. The `notify` job in `.github/workflows/notify-discord-release.yml` had no `environment:` declaration, so `secrets.DISCORD_RELEASE_WEBHOOK_URL` resolved to an empty string on every run. The `Validate webhook secret` step then exited with an error, and no Discord embed was ever posted.

## Fix

Added `environment: prod` to the `notify` job at the job level, alongside `runs-on: ubuntu-latest`:

```yaml
  notify:
    name: Post Discord Release Embed
    runs-on: ubuntu-latest
    environment: prod   # ← added
```

The prod environment has no protection rules, so this won't gate or delay the job.

## Verification

- `actionlint` — exit 0, no issues
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- Parsed structure confirms: 1 job (`notify`), `environment: prod` at job level (not inside `steps:`), `runs-on: ubuntu-latest` co-located correctly

Closes #497

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_